### PR TITLE
feat!: implement builder pattern for expectation suite runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ runner.run(df)
 **PySpark example:**
 ```python
 from dataframe_expectations.expectations_suite import DataFrameExpectationsSuite
+from pyspark.sql import SparkSession
+
+# Initialize Spark session
+spark = SparkSession.builder.appName("example").getOrCreate()
 
 # Build a validation suite (same API as Pandas!)
 suite = (
@@ -113,7 +117,10 @@ runner.run(df)
 **Decorator pattern for automatic validation:**
 ```python
 from dataframe_expectations.expectations_suite import DataFrameExpectationsSuite
-import pandas as pd
+from pyspark.sql import SparkSession
+
+# Initialize Spark session
+spark = SparkSession.builder.appName("example").getOrCreate()
 
 suite = (
     DataFrameExpectationsSuite()

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ standardized solution for this use case. As a result, any contributions made her
 pip install dataframe-expectations
 ```
 
+### Requirements
+
+* Python 3.10+
+* pandas >= 1.5.0
+* pydantic >= 2.12.4
+* pyspark >= 3.3.0
+* tabulate >= 0.8.9
+
 ### Development setup
 
 To set up the development environment:
@@ -45,67 +53,127 @@ uv run pytest tests/ --cov=dataframe_expectations
 
 ### Using the library
 
-**Pandas example:**
+**Basic usage with Pandas:**
 ```python
-from dataframe_expectations.expectations_suite import DataFameExpectationsSuite
+from dataframe_expectations.expectations_suite import DataFrameExpectationsSuite
+import pandas as pd
 
+# Build a suite with expectations
 suite = (
     DataFrameExpectationsSuite()
-    .expect_value_greater_than("age", 18)
-    .expect_value_less_than("age", 10)
+    .expect_min_rows(min_rows=3)
+    .expect_max_rows(max_rows=10)
+    .expect_value_greater_than(column_name="age", value=18)
+    .expect_value_less_than(column_name="salary", value=100000)
+    .expect_value_not_null(column_name="name")
 )
 
-# Create a Pandas DataFrame
-import pandas as pd
-test_pandas_df = pd.DataFrame({"age": [20, 15, 30], "name": ["Alice", "Bob", "Charlie"]})
+# Create a runner
+runner = suite.build()
 
-suite.run(test_pandas_df)
-
+# Validate a DataFrame
+df = pd.DataFrame({
+    "age": [25, 15, 45, 22],
+    "name": ["Alice", "Bob", "Charlie", "Diana"],
+    "salary": [50000, 60000, 80000, 45000]
+})
+runner.run(df)
 ```
-
 
 **PySpark example:**
 ```python
 from dataframe_expectations.expectations_suite import DataFrameExpectationsSuite
 
+# Build a validation suite (same API as Pandas!)
 suite = (
     DataFrameExpectationsSuite()
-    .expect_value_greater_than("age", 18)
-    .expect_value_less_than("age", 40)
+    .expect_min_rows(min_rows=3)
+    .expect_max_rows(max_rows=10)
+    .expect_value_greater_than(column_name="age", value=18)
+    .expect_value_less_than(column_name="salary", value=100000)
+    .expect_value_not_null(column_name="name")
 )
+
+# Build the runner
+runner = suite.build()
 
 # Create a PySpark DataFrame
-test_spark_df = spark.createDataFrame(
-    [
-        {"name": "Alice", "age": 20},
-        {"name": "Bob", "age": 15},
-        {"name": "Charlie", "age": 30},
-    ]
+data = [
+    {"age": 25, "name": "Alice", "salary": 50000},
+    {"age": 15, "name": "Bob", "salary": 60000},
+    {"age": 45, "name": "Charlie", "salary": 80000},
+    {"age": 22, "name": "Diana", "salary": 45000}
+]
+df = spark.createDataFrame(data)
+
+# Validate
+runner.run(df)
+```
+
+**Decorator pattern for automatic validation:**
+```python
+from dataframe_expectations.expectations_suite import DataFrameExpectationsSuite
+import pandas as pd
+
+suite = (
+    DataFrameExpectationsSuite()
+    .expect_min_rows(min_rows=3)
+    .expect_max_rows(max_rows=10)
+    .expect_value_greater_than(column_name="age", value=18)
+    .expect_value_less_than(column_name="salary", value=100000)
+    .expect_value_not_null(column_name="name")
 )
 
-suite.run(test_spark_df)
+# Build the runner
+runner = suite.build()
 
+# Apply decorator to automatically validate function output
+@runner.validate
+def load_employee_data():
+    """Load and return employee data - automatically validated."""
+    return spark.createDataFrame(
+        [
+            {"age": 25, "name": "Alice", "salary": 50000},
+            {"age": 15, "name": "Bob", "salary": 60000},
+            {"age": 45, "name": "Charlie", "salary": 80000},
+            {"age": 22, "name": "Diana", "salary": 45000}
+        ]
+    )
+
+# Function execution automatically validates the returned DataFrame
+df = load_employee_data()  # Raises DataFrameExpectationsSuiteFailure if validation fails
+
+# Allow functions that may return None
+@runner.validate(allow_none=True)
+def conditional_load(should_load: bool):
+    """Conditionally load data - validation only runs when DataFrame is returned."""
+    if should_load:
+        return spark.createDataFrame([{"age": 25, "name": "Alice", "salary": 50000}])
+    return None  # No validation when None is returned
 ```
 
 **Output:**
 ```python
 ========================== Running expectations suite ==========================
-ExpectationValueGreaterThan ('age' greater than 18) ... FAIL
-ExpectationValueLessThan ('age' less than 40) ... OK
-============================ 1 success, 1 failures =============================
+ExpectationMinRows (DataFrame contains at least 3 rows) ... OK
+ExpectationMaxRows (DataFrame contains at most 10 rows) ... OK
+ExpectationValueGreaterThan ('age' is greater than 18) ... FAIL
+ExpectationValueLessThan ('salary' is less than 100000) ... OK
+ExpectationValueNotNull ('name' is not null) ... OK
+============================ 4 success, 1 failures =============================
 
-ExpectationSuiteFailure: (1/2) expectations failed.
+ExpectationSuiteFailure: (1/5) expectations failed.
 
 ================================================================================
 List of violations:
 --------------------------------------------------------------------------------
-[Failed 1/1] ExpectationValueGreaterThan ('age' greater than 18): Found 1 row(s) where 'age' is not greater than 18.
+[Failed 1/1] ExpectationValueGreaterThan ('age' is greater than 18): Found 1 row(s) where 'age' is not greater than 18.
 Some examples of violations:
-+-----+------+
-| age | name |
-+-----+------+
-| 15  | Bob  |
-+-----+------+
++-----+------+--------+
+| age | name | salary |
++-----+------+--------+
+| 15  | Bob  | 60000  |
++-----+------+--------+
 ================================================================================
 
 ```

--- a/dataframe_expectations/expectations_suite.py
+++ b/dataframe_expectations/expectations_suite.py
@@ -61,6 +61,20 @@ class DataFrameExpectationsSuiteRunner:
         """
         self.__expectations = tuple(expectations)  # Immutable tuple
 
+    @property
+    def expectation_count(self) -> int:
+        """Return the number of expectations in this runner."""
+        return len(self.__expectations)
+
+    def list_expectations(self) -> List[str]:
+        """
+        Return a list of expectation descriptions in this runner.
+
+        :return: List of expectation descriptions as strings in the format:
+                 "ExpectationName (description)"
+        """
+        return [f"{exp}" for exp in self.__expectations]
+
     def run(
         self,
         data_frame: DataFrameLike,

--- a/dataframe_expectations/expectations_suite.py
+++ b/dataframe_expectations/expectations_suite.py
@@ -1,4 +1,5 @@
-from typing import List, cast
+from functools import wraps
+from typing import Callable, List, Optional, cast
 
 from dataframe_expectations.expectations import DataFrameLike
 from dataframe_expectations.expectations.expectation_registry import (
@@ -44,66 +45,21 @@ class DataFrameExpectationsSuiteFailure(Exception):
         return "\n".join(lines)
 
 
-class DataFrameExpectationsSuite:
+class DataFrameExpectationsSuiteRunner:
     """
-    A suite of expectations for validating DataFrames.
+    Immutable runner for executing a fixed set of expectations.
+
+    This class is created by DataFrameExpectationsSuite.build() and contains
+    a snapshot of expectations that won't change during execution.
     """
 
-    def __init__(self):
+    def __init__(self, expectations: List):
         """
-        Initialize the expectation suite.
+        Initialize the runner with a list of expectations.
+
+        :param expectations: List of expectation instances to run.
         """
-        self.__expectations = []
-
-    def __getattr__(self, name: str):
-        """
-        Dynamically create expectation methods.
-
-        This is called when Python can't find an attribute through normal lookup.
-        We use it to generate expect_* methods on-the-fly from the registry.
-        """
-        # Only handle expect_* methods
-        if not name.startswith("expect_"):
-            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
-
-        mapping = DataFrameExpectationRegistry.get_suite_method_mapping()
-
-        # Check if this method exists in the registry
-        if name not in mapping:
-            available = list(mapping.keys())
-            raise AttributeError(
-                f"Unknown expectation method '{name}'. "
-                f"Available methods: {', '.join(available[:5])}..."
-            )
-
-        expectation_name = mapping[name]
-
-        # Create and return the dynamic method
-        return self._create_expectation_method(expectation_name, name)
-
-    def _create_expectation_method(self, expectation_name: str, method_name: str):
-        """
-        Create a dynamic expectation method.
-
-        Returns a closure that captures the expectation_name and self.
-        """
-
-        def dynamic_method(**kwargs):
-            """Dynamically generated expectation method."""
-            expectation = DataFrameExpectationRegistry.get_expectation(
-                expectation_name=expectation_name, **kwargs
-            )
-
-            logger.info(f"Adding expectation: {expectation}")
-
-            # Add to internal list
-            self.__expectations.append(expectation)
-            return self
-
-        # Set helpful name for debugging
-        dynamic_method.__name__ = method_name
-
-        return dynamic_method
+        self.__expectations = tuple(expectations)  # Immutable tuple
 
     def run(
         self,
@@ -183,25 +139,211 @@ class DataFrameExpectationsSuite:
                 total_expectations=len(self.__expectations), failures=failures
             )
 
+    def validate(self, func: Optional[Callable] = None, *, allow_none: bool = False) -> Callable:
+        """
+        Decorator to validate the DataFrame returned by a function.
+
+        This decorator runs the expectations suite on the DataFrame returned
+        by the decorated function. If validation fails, it raises
+        DataFrameExpectationsSuiteFailure.
+
+        Example:
+            runner = suite.build()
+
+            @runner.validate
+            def load_data():
+                return pd.read_csv("data.csv")
+
+            df = load_data()  # Automatically validated
+
+            # Allow None returns
+            @runner.validate(allow_none=True)
+            def maybe_load_data():
+                if condition:
+                    return pd.read_csv("data.csv")
+                return None
+
+        :param func: Function that returns a DataFrame.
+        :param allow_none: If True, allows the function to return None without validation.
+                          If False (default), None will raise a ValueError.
+        :return: Wrapped function that validates the returned DataFrame.
+        """
+
+        def decorator(f: Callable) -> Callable:
+            @wraps(f)
+            def wrapper(*args, **kwargs):
+                # Call the original function
+                result = f(*args, **kwargs)
+
+                # Handle None case
+                if result is None:
+                    if allow_none:
+                        logger.info(
+                            f"Function '{f.__name__}' returned None, skipping validation (allow_none=True)"
+                        )
+                        return None
+                    else:
+                        raise ValueError(
+                            f"Function '{f.__name__}' returned None. "
+                            f"Use @runner.validate(allow_none=True) if this is intentional."
+                        )
+
+                # Validate the returned DataFrame
+                logger.info(f"Validating DataFrame returned from '{f.__name__}'")
+                self.run(data_frame=result)
+
+                # Return the original DataFrame if validation passes
+                return result
+
+            return wrapper
+
+        # Support both @validate and @validate(allow_none=True) syntax
+        if func is None:
+            # Called with arguments: @validate(allow_none=True)
+            return decorator
+        else:
+            # Called without arguments: @validate
+            return decorator(func)
+
+
+class DataFrameExpectationsSuite:
+    """
+    A builder for creating expectation suites for validating DataFrames.
+
+    Use this class to add expectations, then call build() to create an
+    immutable runner that can execute the expectations on DataFrames.
+
+    Example:
+        suite = DataFrameExpectationsSuite()
+        suite.expect_value_greater_than(column_name="age", value=18)
+        suite.expect_value_less_than(column_name="salary", value=100000)
+
+        runner = suite.build()
+        runner.run(df1)
+        runner.run(df2)  # Same expectations, different DataFrame
+    """
+
+    def __init__(self):
+        """
+        Initialize the expectation suite builder.
+        """
+        self.__expectations = []
+
+    def __getattr__(self, name: str):
+        """
+        Dynamically create expectation methods.
+
+        This is called when Python can't find an attribute through normal lookup.
+        We use it to generate expect_* methods on-the-fly from the registry.
+        """
+        # Only handle expect_* methods
+        if not name.startswith("expect_"):
+            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+
+        mapping = DataFrameExpectationRegistry.get_suite_method_mapping()
+
+        # Check if this method exists in the registry
+        if name not in mapping:
+            available = list(mapping.keys())
+            raise AttributeError(
+                f"Unknown expectation method '{name}'. "
+                f"Available methods: {', '.join(available[:5])}..."
+            )
+
+        expectation_name = mapping[name]
+
+        # Create and return the dynamic method
+        return self._create_expectation_method(expectation_name, name)
+
+    def _create_expectation_method(self, expectation_name: str, method_name: str):
+        """
+        Create a dynamic expectation method.
+
+        Returns a closure that captures the expectation_name and self.
+        """
+
+        def dynamic_method(**kwargs):
+            """Dynamically generated expectation method."""
+            expectation = DataFrameExpectationRegistry.get_expectation(
+                expectation_name=expectation_name, **kwargs
+            )
+
+            logger.info(f"Adding expectation: {expectation}")
+
+            # Add to internal list
+            self.__expectations.append(expectation)
+            return self
+
+        # Set helpful name for debugging
+        dynamic_method.__name__ = method_name
+
+        return dynamic_method
+
+    def build(self) -> DataFrameExpectationsSuiteRunner:
+        """
+        Build an immutable runner from the current expectations.
+
+        The runner contains a snapshot of expectations at the time of building.
+        You can continue to add more expectations to this suite and build
+        new runners without affecting previously built runners.
+
+        :return: An immutable DataFrameExpectationsSuiteRunner instance.
+        :raises ValueError: If no expectations have been added.
+        """
+        if not self.__expectations:
+            raise ValueError(
+                "Cannot build suite runner: no expectations added. "
+                "Add at least one expectation using expect_* methods."
+            )
+
+        # Create a copy of expectations for the runner
+        return DataFrameExpectationsSuiteRunner(list(self.__expectations))
+
 
 if __name__ == "__main__":
-    # Example usage
+    import pandas as pd
+
+    # Example 1: Direct usage
+    print("=== Example 1: Direct Usage ===")
     suite = DataFrameExpectationsSuite()
     suite.expect_value_greater_than(column_name="age", value=18)
-    suite.expect_value_less_than(column_name="salary", value=100000)
+    suite.expect_value_less_than(column_name="salary", value=1000)
     suite.expect_unique_rows(column_names=["id"])
     suite.expect_column_mean_between(column_name="age", min_value=20, max_value=40)
-    suite.expect_column_max_between(column_name="salary", min_value=80000, max_value=150000)
-
-    import pandas as pd
+    suite.expect_column_max_between(column_name="salary", min_value=80000, max_value=85000)
 
     # Create a sample DataFrame
     df = pd.DataFrame(
         {
             "id": [1, 2, 3, 4],
             "age": [20, 25, 30, 35],
-            "salary": [50000, 120000, 80000, 90000],
+            "salary": [50000, 90000, 80000, 85000],
         }
     )
 
-    suite.run(data_frame=df)
+    # Build the runner and execute
+    runner = suite.build()
+    runner.run(data_frame=df)
+
+    # Example 2: Decorator usage
+    print("\n=== Example 2: Decorator Usage ===")
+    suite = DataFrameExpectationsSuite()
+    suite.expect_value_greater_than(column_name="age", value=20)
+    suite.expect_unique_rows(column_names=["id"])
+
+    runner = suite.build()
+
+    @runner.validate
+    def load_employee_data():
+        """Load employee data with automatic validation."""
+        return pd.DataFrame(
+            {
+                "id": [1, 2, 3],
+                "age": [18, 30, 35],
+                "name": ["Alice", "Bob", "Charlie"],
+            }
+        )
+
+    # Function is automatically validated when called
+    validated_df = load_employee_data()
+    print(f"Successfully loaded and validated DataFrame with {len(validated_df)} rows")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,8 +17,8 @@ with open(os.path.abspath('../../pyproject.toml'), 'rb') as f:
 
 # Project information
 project = 'DataFrame Expectations'
-copyright = '2025, Data Products GYG'
-author = 'Data Products GYG'
+copyright = '2025, GetYourGuide'
+author = 'Data Products GetYourGuide'
 
 # Extensions
 extensions = [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,15 +1,24 @@
 import os
 import sys
 
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
 # Add the project root and extension directories to the path
 sys.path.insert(0, os.path.abspath('../../'))
 sys.path.insert(0, os.path.abspath('_ext'))
 
+# Read version from pyproject.toml
+with open(os.path.abspath('../../pyproject.toml'), 'rb') as f:
+    pyproject = tomllib.load(f)
+    release = pyproject['project']['version']
+
 # Project information
 project = 'DataFrame Expectations'
-copyright = '2024, Your Name'
-author = 'Your Name'
-release = '0.1.0'
+copyright = '2025, Data Products GYG'
+author = 'Data Products GYG'
 
 # Extensions
 extensions = [

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -17,6 +17,7 @@ Requirements
 
 * Python 3.10+
 * pandas >= 1.5.0
+* pydantic >= 2.12.4
 * pyspark >= 3.3.0
 * tabulate >= 0.8.9
 
@@ -25,33 +26,34 @@ Basic Usage
 
 DataFrame Expectations provides a fluent API for building validation suites. Here's how to get started:
 
-Pandas Example
-~~~~~~~~~~~~~~
+Basic Usage with Pandas
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
 
     import pandas as pd
     from dataframe_expectations.expectations_suite import DataFrameExpectationsSuite
 
-    # Create a sample DataFrame
+    # Build a suite with expectations
+    suite = (
+         DataFrameExpectationsSuite()
+         .expect_min_rows(min_rows=3)
+         .expect_max_rows(max_rows=10)
+         .expect_value_greater_than(column_name="age", value=18)
+         .expect_value_less_than(column_name="salary", value=100000)
+         .expect_value_not_null(column_name="name")
+    )
+
+    # Create a runner
+    runner = suite.build()
+
+    # Validate a DataFrame
     df = pd.DataFrame({
          "age": [25, 15, 45, 22],
          "name": ["Alice", "Bob", "Charlie", "Diana"],
          "salary": [50000, 60000, 80000, 45000]
     })
-
-    # Build a validation suite
-    suite = (
-         DataFrameExpectationsSuite()
-         .expect_min_rows(3)  # At least 3 rows
-         .expect_max_rows(10)  # At most 10 rows
-         .expect_value_greater_than("age", 18)  # All ages > 18
-         .expect_value_less_than("salary", 100000)  # All salaries < 100k
-         .expect_value_not_null("name")  # No null names
-    )
-
-    # Run validation
-     suite.run(df)
+    runner.run(df)
 
 
 PySpark Example
@@ -59,13 +61,22 @@ PySpark Example
 
 .. code-block:: python
 
-    from pyspark.sql import SparkSession
     from dataframe_expectations.expectations_suite import DataFrameExpectationsSuite
 
-    # Initialize Spark
-    spark = SparkSession.builder.appName("DataFrameExpectations").getOrCreate()
+    # Build a validation suite (same API as Pandas!)
+    suite = (
+         DataFrameExpectationsSuite()
+         .expect_min_rows(min_rows=3)
+         .expect_max_rows(max_rows=10)
+         .expect_value_greater_than(column_name="age", value=18)
+         .expect_value_less_than(column_name="salary", value=100000)
+         .expect_value_not_null(column_name="name")
+    )
 
-    # Create a sample DataFrame
+    # Build the runner
+    runner = suite.build()
+
+    # Create a PySpark DataFrame
     data = [
          {"age": 25, "name": "Alice", "salary": 50000},
          {"age": 15, "name": "Bob", "salary": 60000},
@@ -74,18 +85,52 @@ PySpark Example
     ]
     df = spark.createDataFrame(data)
 
-    # Build a validation suite (same API as Pandas!)
+    # Validate
+    runner.run(df)
+
+Decorator Pattern for Automatic Validation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    import pandas as pd
+    from dataframe_expectations.expectations_suite import DataFrameExpectationsSuite
+
     suite = (
          DataFrameExpectationsSuite()
-         .expect_min_rows(3)
-         .expect_max_rows(10)
-         .expect_value_greater_than("age", 18)
-         .expect_value_less_than("salary", 100000)
-         .expect_value_not_null("name")
+         .expect_min_rows(min_rows=3)
+         .expect_max_rows(max_rows=10)
+         .expect_value_greater_than(column_name="age", value=18)
+         .expect_value_less_than(column_name="salary", value=100000)
+         .expect_value_not_null(column_name="name")
     )
 
-    # Run validation
-    suite.run(df)
+    # Build the runner
+    runner = suite.build()
+
+    # Apply decorator to automatically validate function output
+    @runner.validate
+    def load_employee_data():
+         """Load and return employee data - automatically validated."""
+         return spark.createDataFrame(
+              [
+                   {"age": 25, "name": "Alice", "salary": 50000},
+                   {"age": 15, "name": "Bob", "salary": 60000},
+                   {"age": 45, "name": "Charlie", "salary": 80000},
+                   {"age": 22, "name": "Diana", "salary": 45000}
+              ]
+         )
+
+    # Function execution automatically validates the returned DataFrame
+    df = load_employee_data()  # Raises DataFrameExpectationsSuiteFailure if validation fails
+
+    # Allow functions that may return None
+    @runner.validate(allow_none=True)
+    def conditional_load(should_load: bool):
+         """Conditionally load data - validation only runs when DataFrame is returned."""
+         if should_load:
+              return spark.createDataFrame([{"age": 25, "name": "Alice", "salary": 50000}])
+         return None  # No validation when None is returned
 
 Example Output
 ~~~~~~~~~~~~~~

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -62,6 +62,10 @@ PySpark Example
 .. code-block:: python
 
     from dataframe_expectations.expectations_suite import DataFrameExpectationsSuite
+    from pyspark.sql import SparkSession
+
+    # Initialize Spark session
+    spark = SparkSession.builder.appName("example").getOrCreate()
 
     # Build a validation suite (same API as Pandas!)
     suite = (
@@ -93,8 +97,11 @@ Decorator Pattern for Automatic Validation
 
 .. code-block:: python
 
-    import pandas as pd
     from dataframe_expectations.expectations_suite import DataFrameExpectationsSuite
+    from pyspark.sql import SparkSession
+
+    # Initialize Spark session
+    spark = SparkSession.builder.appName("example").getOrCreate()
 
     suite = (
          DataFrameExpectationsSuite()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,10 @@ version = "0.2.0"
 description = "Python library designed to validate Pandas and PySpark DataFrames using customizable, reusable expectations"
 readme = "README.md"
 requires-python = ">=3.10"
+authors = [
+    {name = "Data Products GYG", email = "engineering.data-products@getyourguide.com"}
+]
+
 dependencies = [
     "pandas>=1.5.0",
     "pydantic>=2.12.4",
@@ -26,6 +30,7 @@ docs = [
     "pyspark>=3.3.0",
     "pandas>=1.5.0",
     "tabulate>=0.8.9",
+    "tomli>=2.0.0; python_version < '3.11'",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Python library designed to validate Pandas and PySpark DataFrames
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [
-    {name = "Data Products GYG", email = "engineering.data-products@getyourguide.com"}
+    {name = "Data Products GetYourGuide", email = "engineering.data-products@getyourguide.com"}
 ]
 
 dependencies = [

--- a/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_distinct_column_values_between.py
+++ b/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_distinct_column_values_between.py
@@ -404,7 +404,7 @@ def test_suite_pandas_success():
         column_name="col1", min_value=2, max_value=5
     )
     data_frame = pd.DataFrame({"col1": [1, 2, 3, 2, 1]})  # 3 distinct values
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -417,7 +417,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": [1, 2, 1, 2, 1]})  # 2 distinct values, expected 4-6
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -430,7 +430,7 @@ def test_suite_pyspark_success(spark):
     data_frame = spark.createDataFrame(
         [(1,), (2,), (3,), (2,), (1,)], ["col1"]
     )  # 3 distinct values
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -445,7 +445,7 @@ def test_suite_pyspark_violations(spark):
         [(1,), (2,), (1,), (2,), (1,)], ["col1"]
     )  # 2 distinct values, expected 4-6
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -457,7 +457,7 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([(1,), (2,), (3,), (4,), (5,)], ["col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_string_column_with_mixed_values():

--- a/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_distinct_column_values_equals.py
+++ b/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_distinct_column_values_equals.py
@@ -493,7 +493,7 @@ def test_suite_pandas_success():
         column_name="col1", expected_value=3
     )
     data_frame = pd.DataFrame({"col1": [1, 2, 3, 2, 1]})  # exactly 3 distinct values
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -506,7 +506,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": [1, 2, 1, 2, 1]})  # 2 distinct values, expected 5
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -519,7 +519,7 @@ def test_suite_pyspark_success(spark):
     data_frame = spark.createDataFrame(
         [(1,), (2,), (3,), (2,), (1,)], ["col1"]
     )  # exactly 3 distinct values
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -534,7 +534,7 @@ def test_suite_pyspark_violations(spark):
         [(1,), (2,), (1,), (2,), (1,)], ["col1"]
     )  # 2 distinct values, expected 5
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -546,7 +546,7 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([(1,), (2,), (3,), (4,), (5,)], ["col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_categorical_data():

--- a/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_distinct_column_values_greater_than.py
+++ b/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_distinct_column_values_greater_than.py
@@ -499,7 +499,7 @@ def test_suite_pandas_success():
         column_name="col1", threshold=2
     )
     data_frame = pd.DataFrame({"col1": [1, 2, 3, 2, 1]})  # 3 distinct values > 2
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -512,7 +512,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": [1, 2, 1, 2, 1]})  # 2 distinct values, need > 5
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -525,7 +525,7 @@ def test_suite_pyspark_success(spark):
     data_frame = spark.createDataFrame(
         [(1,), (2,), (3,), (2,), (1,)], ["col1"]
     )  # 3 distinct values > 2
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -540,7 +540,7 @@ def test_suite_pyspark_violations(spark):
         [(1,), (2,), (1,), (2,), (1,)], ["col1"]
     )  # 2 distinct values, need > 5
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -552,7 +552,7 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([(1,), (2,), (3,), (4,), (5,)], ["col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_categorical_data():

--- a/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_distinct_column_values_less_than.py
+++ b/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_distinct_column_values_less_than.py
@@ -529,7 +529,7 @@ def test_suite_pandas_success():
         column_name="col1", threshold=5
     )
     data_frame = pd.DataFrame({"col1": [1, 2, 3, 2, 1]})  # 3 distinct values < 5
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -542,7 +542,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": [1, 2, 3, 2, 1]})  # 3 distinct values, need < 2
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -555,7 +555,7 @@ def test_suite_pyspark_success(spark):
     data_frame = spark.createDataFrame(
         [(1,), (2,), (3,), (2,), (1,)], ["col1"]
     )  # 3 distinct values < 5
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -570,7 +570,7 @@ def test_suite_pyspark_violations(spark):
         [(1,), (2,), (3,), (2,), (1,)], ["col1"]
     )  # 3 distinct values, need < 2
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -582,7 +582,7 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([(1,), (2,), (3,), (4,), (5,)], ["col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_categorical_data():

--- a/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_max_null_count.py
+++ b/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_max_null_count.py
@@ -437,7 +437,7 @@ def test_suite_pandas_success():
     data_frame = pd.DataFrame(
         {"col1": [1, None, 3], "col2": ["a", "b", "c"]}
     )  # 1 null value, which is less than max_count of 2
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -450,7 +450,7 @@ def test_suite_pandas_violations():
         {"col1": [1, None, None], "col2": ["a", "b", "c"]}
     )  # 2 null values, which exceeds max_count of 1
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -461,7 +461,7 @@ def test_suite_pyspark_success(spark):
     data_frame = spark.createDataFrame(
         [(1, "a"), (None, "b"), (3, "c")], ["col1", "col2"]
     )  # 1 null value, which is less than max_count of 2
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -474,7 +474,7 @@ def test_suite_pyspark_violations(spark):
         [(1, "a"), (None, "b"), (None, "c")], ["col1", "col2"]
     )  # 2 null values, which exceeds max_count of 1
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -484,7 +484,7 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([(1, "a"), (2, "b"), (3, "c")], ["col2", "col3"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_expectation_parameter_validation():

--- a/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_max_null_percentage.py
+++ b/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_max_null_percentage.py
@@ -434,7 +434,7 @@ def test_suite_pandas_success():
     )
     # 4 values in col1, 1 nulls = 25% null (should pass)
     data_frame = pd.DataFrame({"col1": [1, 2, None, 4], "col2": ["a", "b", "c", "d"]})
-    expectations_suite.run(data_frame=data_frame)
+    expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pandas_violations():
@@ -445,7 +445,7 @@ def test_suite_pandas_violations():
     # 2 values in col1, 1 null = 50% null (exceeds 10%)
     data_frame = pd.DataFrame({"col1": [1, None], "col2": ["a", "b"]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -455,7 +455,7 @@ def test_suite_pyspark_success(spark):
     )
     # 2 values in col1, 1 null = 50% null (equals 50%)
     data_frame = spark.createDataFrame([(1, "a"), (None, "b")], ["col1", "col2"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -467,7 +467,7 @@ def test_suite_pyspark_violations(spark):
     # 2 values in col1, 1 null = 50% null (exceeds 20%)
     data_frame = spark.createDataFrame([(None, "a"), (2, None)], ["col1", "col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_expectation_parameter_validation():

--- a/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_max_rows.py
+++ b/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_max_rows.py
@@ -312,7 +312,7 @@ def test_suite_pandas_success():
     """Test integration with expectations suite for pandas success case."""
     expectations_suite = DataFrameExpectationsSuite().expect_max_rows(max_rows=5)
     data_frame = pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -321,14 +321,14 @@ def test_suite_pandas_violations():
     expectations_suite = DataFrameExpectationsSuite().expect_max_rows(max_rows=2)
     data_frame = pd.DataFrame({"col1": [1, 2, 3, 4], "col2": ["a", "b", "c", "d"]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
     """Test integration with expectations suite for PySpark success case."""
     expectations_suite = DataFrameExpectationsSuite().expect_max_rows(max_rows=5)
     data_frame = spark.createDataFrame([(1, "a"), (2, "b"), (3, "c")], ["col1", "col2"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -337,7 +337,7 @@ def test_suite_pyspark_violations(spark):
     expectations_suite = DataFrameExpectationsSuite().expect_max_rows(max_rows=2)
     data_frame = spark.createDataFrame([(1, "a"), (2, "b"), (3, "c"), (4, "d")], ["col1", "col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_expectation_parameter_validation():

--- a/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_min_rows.py
+++ b/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_min_rows.py
@@ -365,7 +365,7 @@ def test_suite_pandas_success():
     """Test integration with expectations suite for pandas success case."""
     expectations_suite = DataFrameExpectationsSuite().expect_min_rows(min_rows=2)
     data_frame = pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -374,14 +374,14 @@ def test_suite_pandas_violations():
     expectations_suite = DataFrameExpectationsSuite().expect_min_rows(min_rows=5)
     data_frame = pd.DataFrame({"col1": [1, 2], "col2": ["a", "b"]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
     """Test integration with expectations suite for PySpark success case."""
     expectations_suite = DataFrameExpectationsSuite().expect_min_rows(min_rows=2)
     data_frame = spark.createDataFrame([(1, "a"), (2, "b"), (3, "c")], ["col1", "col2"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -390,7 +390,7 @@ def test_suite_pyspark_violations(spark):
     expectations_suite = DataFrameExpectationsSuite().expect_min_rows(min_rows=5)
     data_frame = spark.createDataFrame([(1, "a"), (2, "b")], ["col1", "col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_expectation_parameter_validation():

--- a/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_unique_rows.py
+++ b/tests/expectations_implemented/aggregation_expectations/any_value_expectations/test_expect_unique_rows.py
@@ -479,7 +479,7 @@ def test_suite_pandas_success_specific_columns():
     """
     expectations_suite = DataFrameExpectationsSuite().expect_unique_rows(column_names=["col1"])
     data_frame = pd.DataFrame({"col1": [1, 2, 3], "col2": [10, 10, 10]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -490,7 +490,7 @@ def test_suite_pandas_violations_specific_columns():
     expectations_suite = DataFrameExpectationsSuite().expect_unique_rows(column_names=["col1"])
     data_frame = pd.DataFrame({"col1": [1, 1, 3], "col2": [10, 20, 30]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pandas_success_all_columns():
@@ -499,7 +499,7 @@ def test_suite_pandas_success_all_columns():
     """
     expectations_suite = DataFrameExpectationsSuite().expect_unique_rows(column_names=[])
     data_frame = pd.DataFrame({"col1": [1, 2, 3], "col2": [10, 20, 30]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -510,7 +510,7 @@ def test_suite_pandas_violations_all_columns():
     expectations_suite = DataFrameExpectationsSuite().expect_unique_rows(column_names=[])
     data_frame = pd.DataFrame({"col1": [1, 1, 3], "col2": [10, 10, 30]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success_specific_columns(spark):
@@ -519,7 +519,7 @@ def test_suite_pyspark_success_specific_columns(spark):
     """
     expectations_suite = DataFrameExpectationsSuite().expect_unique_rows(column_names=["col1"])
     data_frame = spark.createDataFrame([(1, 10), (2, 10), (3, 10)], ["col1", "col2"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -530,7 +530,7 @@ def test_suite_pyspark_violations_specific_columns(spark):
     expectations_suite = DataFrameExpectationsSuite().expect_unique_rows(column_names=["col1"])
     data_frame = spark.createDataFrame([(1, 10), (1, 20), (3, 30)], ["col1", "col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success_all_columns(spark):
@@ -539,7 +539,7 @@ def test_suite_pyspark_success_all_columns(spark):
     """
     expectations_suite = DataFrameExpectationsSuite().expect_unique_rows(column_names=[])
     data_frame = spark.createDataFrame([(1, 10), (2, 20), (3, 30)], ["col1", "col2"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -550,7 +550,7 @@ def test_suite_pyspark_violations_all_columns(spark):
     expectations_suite = DataFrameExpectationsSuite().expect_unique_rows(column_names=[])
     data_frame = spark.createDataFrame([(1, 10), (1, 10), (3, 30)], ["col1", "col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pandas_column_missing_error():
@@ -562,7 +562,7 @@ def test_suite_pandas_column_missing_error():
     )
     data_frame = pd.DataFrame({"col1": [1, 2, 3]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -574,4 +574,4 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([(1,), (2,), (3,)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/expectations_implemented/aggregation_expectations/numerical_expectations/test_expect_column_max_between.py
+++ b/tests/expectations_implemented/aggregation_expectations/numerical_expectations/test_expect_column_max_between.py
@@ -71,7 +71,7 @@ def test_pandas_success_registry_and_suite():
         suite = DataFrameExpectationsSuite().expect_column_max_between(
             column_name="col1", min_value=min_val, max_value=max_val
         )
-        suite_result = suite.run(data_frame=data_frame)
+        suite_result = suite.build().run(data_frame=data_frame)
         assert suite_result is None, (
             f"Suite test failed for {description}: expected None but got {suite_result}"
         )
@@ -117,7 +117,7 @@ def test_pandas_failure_registry_and_suite():
             column_name="col1", min_value=min_val, max_value=max_val
         )
         with pytest.raises(DataFrameExpectationsSuiteFailure):
-            suite.run(data_frame=data_frame)
+            suite.build().run(data_frame=data_frame)
 
 
 def test_pandas_missing_column_registry_and_suite():
@@ -145,7 +145,7 @@ def test_pandas_missing_column_registry_and_suite():
         column_name="nonexistent_col", min_value=30, max_value=40
     )
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        suite.run(data_frame=data_frame)
+        suite.build().run(data_frame=data_frame)
 
 
 def test_pyspark_success_registry_and_suite(spark):
@@ -178,7 +178,7 @@ def test_pyspark_success_registry_and_suite(spark):
         suite = DataFrameExpectationsSuite().expect_column_max_between(
             column_name="col1", min_value=min_val, max_value=max_val
         )
-        suite_result = suite.run(data_frame=data_frame)
+        suite_result = suite.build().run(data_frame=data_frame)
         assert suite_result is None, (
             f"Suite test failed for {description}: expected None but got {suite_result}"
         )
@@ -220,7 +220,7 @@ def test_pyspark_failure_registry_and_suite(spark):
             column_name="col1", min_value=min_val, max_value=max_val
         )
         with pytest.raises(DataFrameExpectationsSuiteFailure):
-            suite.run(data_frame=data_frame)
+            suite.build().run(data_frame=data_frame)
 
 
 def test_pyspark_null_scenarios_registry_and_suite(spark):
@@ -272,7 +272,7 @@ def test_pyspark_null_scenarios_registry_and_suite(spark):
             column_name="col1", min_value=30, max_value=40
         )
         with pytest.raises(DataFrameExpectationsSuiteFailure):
-            suite.run(data_frame=data_frame)
+            suite.build().run(data_frame=data_frame)
 
 
 def test_pyspark_missing_column_registry_and_suite(spark):
@@ -300,7 +300,7 @@ def test_pyspark_missing_column_registry_and_suite(spark):
         column_name="nonexistent_col", min_value=30, max_value=40
     )
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        suite.run(data_frame=data_frame)
+        suite.build().run(data_frame=data_frame)
 
 
 def test_boundary_values_both_dataframes(spark):

--- a/tests/expectations_implemented/aggregation_expectations/numerical_expectations/test_expect_column_mean_between.py
+++ b/tests/expectations_implemented/aggregation_expectations/numerical_expectations/test_expect_column_mean_between.py
@@ -76,7 +76,7 @@ def test_pandas_success_registry_and_suite():
         suite = DataFrameExpectationsSuite().expect_column_mean_between(
             column_name="col1", min_value=min_val, max_value=max_val
         )
-        suite_result = suite.run(data_frame=data_frame)
+        suite_result = suite.build().run(data_frame=data_frame)
         assert suite_result is None, (
             f"Suite test failed for {description}: expected None but got {suite_result}"
         )
@@ -126,7 +126,7 @@ def test_pandas_failure_registry_and_suite():
             column_name="col1", min_value=min_val, max_value=max_val
         )
         with pytest.raises(DataFrameExpectationsSuiteFailure):
-            suite.run(data_frame=data_frame)
+            suite.build().run(data_frame=data_frame)
 
 
 def test_pandas_missing_column_registry_and_suite():
@@ -154,7 +154,7 @@ def test_pandas_missing_column_registry_and_suite():
         column_name="nonexistent_col", min_value=25, max_value=30
     )
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        suite.run(data_frame=data_frame)
+        suite.build().run(data_frame=data_frame)
 
 
 def test_pyspark_success_registry_and_suite(spark):
@@ -187,7 +187,7 @@ def test_pyspark_success_registry_and_suite(spark):
         suite = DataFrameExpectationsSuite().expect_column_mean_between(
             column_name="col1", min_value=min_val, max_value=max_val
         )
-        suite_result = suite.run(data_frame=data_frame)
+        suite_result = suite.build().run(data_frame=data_frame)
         assert suite_result is None, (
             f"Suite test failed for {description}: expected None but got {suite_result}"
         )
@@ -228,7 +228,7 @@ def test_pyspark_failure_registry_and_suite(spark):
             column_name="col1", min_value=min_val, max_value=max_val
         )
         with pytest.raises(DataFrameExpectationsSuiteFailure):
-            suite.run(data_frame=data_frame)
+            suite.build().run(data_frame=data_frame)
 
 
 def test_pyspark_null_scenarios_registry_and_suite(spark):
@@ -280,7 +280,7 @@ def test_pyspark_null_scenarios_registry_and_suite(spark):
             column_name="col1", min_value=25, max_value=30
         )
         with pytest.raises(DataFrameExpectationsSuiteFailure):
-            suite.run(data_frame=data_frame)
+            suite.build().run(data_frame=data_frame)
 
 
 def test_pyspark_missing_column_registry_and_suite(spark):
@@ -308,7 +308,7 @@ def test_pyspark_missing_column_registry_and_suite(spark):
         column_name="nonexistent_col", min_value=25, max_value=30
     )
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        suite.run(data_frame=data_frame)
+        suite.build().run(data_frame=data_frame)
 
 
 def test_boundary_values_both_dataframes(spark):

--- a/tests/expectations_implemented/aggregation_expectations/numerical_expectations/test_expect_column_median_between.py
+++ b/tests/expectations_implemented/aggregation_expectations/numerical_expectations/test_expect_column_median_between.py
@@ -86,7 +86,7 @@ def test_pandas_success_registry_and_suite():
         suite = DataFrameExpectationsSuite().expect_column_median_between(
             column_name="col1", min_value=min_val, max_value=max_val
         )
-        suite_result = suite.run(data_frame=data_frame)
+        suite_result = suite.build().run(data_frame=data_frame)
         assert suite_result is None, (
             f"Suite test failed for {description}: expected None but got {suite_result}"
         )
@@ -135,7 +135,7 @@ def test_pandas_failure_registry_and_suite():
             column_name="col1", min_value=min_val, max_value=max_val
         )
         with pytest.raises(DataFrameExpectationsSuiteFailure):
-            suite.run(data_frame=data_frame)
+            suite.build().run(data_frame=data_frame)
 
 
 def test_pandas_missing_column_registry_and_suite():
@@ -163,7 +163,7 @@ def test_pandas_missing_column_registry_and_suite():
         column_name="nonexistent_col", min_value=25, max_value=30
     )
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        suite.run(data_frame=data_frame)
+        suite.build().run(data_frame=data_frame)
 
 
 def test_pyspark_success_registry_and_suite(spark):
@@ -198,7 +198,7 @@ def test_pyspark_success_registry_and_suite(spark):
         suite = DataFrameExpectationsSuite().expect_column_median_between(
             column_name="col1", min_value=min_val, max_value=max_val
         )
-        suite_result = suite.run(data_frame=data_frame)
+        suite_result = suite.build().run(data_frame=data_frame)
         assert suite_result is None, (
             f"Suite test failed for {description}: expected None but got {suite_result}"
         )
@@ -245,7 +245,7 @@ def test_pyspark_failure_registry_and_suite(spark):
             column_name="col1", min_value=min_val, max_value=max_val
         )
         with pytest.raises(DataFrameExpectationsSuiteFailure):
-            suite.run(data_frame=data_frame)
+            suite.build().run(data_frame=data_frame)
 
 
 def test_pyspark_null_scenarios_registry_and_suite(spark):
@@ -297,7 +297,7 @@ def test_pyspark_null_scenarios_registry_and_suite(spark):
             column_name="col1", min_value=25, max_value=30
         )
         with pytest.raises(DataFrameExpectationsSuiteFailure):
-            suite.run(data_frame=data_frame)
+            suite.build().run(data_frame=data_frame)
 
 
 def test_pyspark_missing_column_registry_and_suite(spark):
@@ -325,7 +325,7 @@ def test_pyspark_missing_column_registry_and_suite(spark):
         column_name="nonexistent_col", min_value=25, max_value=30
     )
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        suite.run(data_frame=data_frame)
+        suite.build().run(data_frame=data_frame)
 
 
 def test_boundary_values_both_dataframes(spark):

--- a/tests/expectations_implemented/aggregation_expectations/numerical_expectations/test_expect_column_min_between.py
+++ b/tests/expectations_implemented/aggregation_expectations/numerical_expectations/test_expect_column_min_between.py
@@ -84,7 +84,7 @@ def test_pandas_success_registry_and_suite():
         suite = DataFrameExpectationsSuite().expect_column_min_between(
             column_name="col1", min_value=min_val, max_value=max_val
         )
-        suite_result = suite.run(data_frame=data_frame)
+        suite_result = suite.build().run(data_frame=data_frame)
         assert suite_result is None, (
             f"Suite test failed for {description}: expected None but got {suite_result}"
         )
@@ -132,7 +132,7 @@ def test_pandas_failure_registry_and_suite():
             column_name="col1", min_value=min_val, max_value=max_val
         )
         with pytest.raises(DataFrameExpectationsSuiteFailure):
-            suite.run(data_frame=data_frame)
+            suite.build().run(data_frame=data_frame)
 
 
 def test_pandas_missing_column_registry_and_suite():
@@ -160,7 +160,7 @@ def test_pandas_missing_column_registry_and_suite():
         column_name="nonexistent_col", min_value=15, max_value=25
     )
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        suite.run(data_frame=data_frame)
+        suite.build().run(data_frame=data_frame)
 
 
 def test_pyspark_success_registry_and_suite(spark):
@@ -193,7 +193,7 @@ def test_pyspark_success_registry_and_suite(spark):
         suite = DataFrameExpectationsSuite().expect_column_min_between(
             column_name="col1", min_value=min_val, max_value=max_val
         )
-        suite_result = suite.run(data_frame=data_frame)
+        suite_result = suite.build().run(data_frame=data_frame)
         assert suite_result is None, (
             f"Suite test failed for {description}: expected None but got {suite_result}"
         )
@@ -234,7 +234,7 @@ def test_pyspark_failure_registry_and_suite(spark):
             column_name="col1", min_value=min_val, max_value=max_val
         )
         with pytest.raises(DataFrameExpectationsSuiteFailure):
-            suite.run(data_frame=data_frame)
+            suite.build().run(data_frame=data_frame)
 
 
 def test_pyspark_null_scenarios_registry_and_suite(spark):
@@ -286,7 +286,7 @@ def test_pyspark_null_scenarios_registry_and_suite(spark):
             column_name="col1", min_value=15, max_value=25
         )
         with pytest.raises(DataFrameExpectationsSuiteFailure):
-            suite.run(data_frame=data_frame)
+            suite.build().run(data_frame=data_frame)
 
 
 def test_pyspark_missing_column_registry_and_suite(spark):
@@ -314,7 +314,7 @@ def test_pyspark_missing_column_registry_and_suite(spark):
         column_name="nonexistent_col", min_value=15, max_value=25
     )
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        suite.run(data_frame=data_frame)
+        suite.build().run(data_frame=data_frame)
 
 
 def test_boundary_values_both_dataframes(spark):

--- a/tests/expectations_implemented/aggregation_expectations/numerical_expectations/test_expect_column_quantile_between.py
+++ b/tests/expectations_implemented/aggregation_expectations/numerical_expectations/test_expect_column_quantile_between.py
@@ -94,7 +94,7 @@ def test_pandas_success_registry_and_suite():
             min_value=min_val,
             max_value=max_val,
         )
-        suite_result = suite.run(data_frame=data_frame)
+        suite_result = suite.build().run(data_frame=data_frame)
         assert suite_result is None, (
             f"Suite test failed for {description}: expected None but got {suite_result}"
         )
@@ -172,7 +172,7 @@ def test_pandas_failure_registry_and_suite():
             max_value=max_val,
         )
         with pytest.raises(DataFrameExpectationsSuiteFailure):
-            suite.run(data_frame=data_frame)
+            suite.build().run(data_frame=data_frame)
 
 
 def test_pyspark_success_registry_and_suite(spark):
@@ -211,7 +211,7 @@ def test_pyspark_success_registry_and_suite(spark):
             min_value=min_val,
             max_value=max_val,
         )
-        suite_result = suite.run(data_frame=data_frame)
+        suite_result = suite.build().run(data_frame=data_frame)
         assert suite_result is None, (
             f"Suite test failed for {description}: expected None but got {suite_result}"
         )
@@ -272,7 +272,7 @@ def test_pyspark_failure_registry_and_suite(spark):
             max_value=max_val,
         )
         with pytest.raises(DataFrameExpectationsSuiteFailure):
-            suite.run(data_frame=data_frame)
+            suite.build().run(data_frame=data_frame)
 
 
 def test_pyspark_null_scenarios_registry_and_suite(spark):
@@ -325,7 +325,7 @@ def test_pyspark_null_scenarios_registry_and_suite(spark):
             column_name="col1", quantile=0.5, min_value=20, max_value=30
         )
         with pytest.raises(DataFrameExpectationsSuiteFailure):
-            suite.run(data_frame=data_frame)
+            suite.build().run(data_frame=data_frame)
 
 
 def test_invalid_quantile_range():

--- a/tests/expectations_implemented/column_expectations/any_value_expectations/test_expect_value_equals.py
+++ b/tests/expectations_implemented/column_expectations/any_value_expectations/test_expect_value_equals.py
@@ -141,7 +141,7 @@ def test_suite_pandas_success():
         column_name="col1", value=5
     )
     data_frame = pd.DataFrame({"col1": [5, 5, 5]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -154,7 +154,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": [3, 4, 5]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -165,7 +165,7 @@ def test_suite_pyspark_success(spark):
         column_name="col1", value=5
     )
     data_frame = spark.createDataFrame([(5,), (5,), (5,)], ["col1"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -178,7 +178,7 @@ def test_suite_pyspark_violations(spark):
     )
     data_frame = spark.createDataFrame([(3,), (4,), (5,)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -190,4 +190,4 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([(5,), (5,), (5,)], ["col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/expectations_implemented/column_expectations/any_value_expectations/test_expect_value_in.py
+++ b/tests/expectations_implemented/column_expectations/any_value_expectations/test_expect_value_in.py
@@ -117,7 +117,7 @@ def test_suite_pandas_success():
         column_name="col1", values=[1, 2, 3]
     )
     data_frame = pd.DataFrame({"col1": [1, 2, 3, 2, 1]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -127,7 +127,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": [1, 4, 5, 2, 3]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -135,7 +135,7 @@ def test_suite_pyspark_success(spark):
         column_name="col1", values=[1, 2, 3]
     )
     data_frame = spark.createDataFrame([(1,), (2,), (3,), (2,), (1,)], ["col1"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -145,7 +145,7 @@ def test_suite_pyspark_violations(spark):
     )
     data_frame = spark.createDataFrame([(1,), (4,), (5,), (2,), (3,)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -154,4 +154,4 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([(1,), (2,), (3,)], ["col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/expectations_implemented/column_expectations/any_value_expectations/test_expect_value_not_equals.py
+++ b/tests/expectations_implemented/column_expectations/any_value_expectations/test_expect_value_not_equals.py
@@ -117,7 +117,7 @@ def test_suite_pandas_success():
         column_name="col1", value=5
     )
     data_frame = pd.DataFrame({"col1": [3, 4, 6]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -127,7 +127,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": [3, 5, 5]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -135,7 +135,7 @@ def test_suite_pyspark_success(spark):
         column_name="col1", value=5
     )
     data_frame = spark.createDataFrame([(3,), (4,), (6,)], ["col1"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -145,7 +145,7 @@ def test_suite_pyspark_violations(spark):
     )
     data_frame = spark.createDataFrame([(3,), (5,), (5,)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -154,4 +154,4 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([(3,), (4,), (5,)], ["col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/expectations_implemented/column_expectations/any_value_expectations/test_expect_value_not_in.py
+++ b/tests/expectations_implemented/column_expectations/any_value_expectations/test_expect_value_not_in.py
@@ -117,7 +117,7 @@ def test_suite_pandas_success():
         column_name="col1", values=[1, 2, 3]
     )
     data_frame = pd.DataFrame({"col1": [4, 5, 6, 7]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -127,7 +127,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": [1, 2, 4, 5]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -135,7 +135,7 @@ def test_suite_pyspark_success(spark):
         column_name="col1", values=[1, 2, 3]
     )
     data_frame = spark.createDataFrame([(4,), (5,), (6,), (7,)], ["col1"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -145,7 +145,7 @@ def test_suite_pyspark_violations(spark):
     )
     data_frame = spark.createDataFrame([(1,), (2,), (4,), (5,)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -154,4 +154,4 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([(4,), (5,), (6,)], ["col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/expectations_implemented/column_expectations/any_value_expectations/test_expect_value_not_null.py
+++ b/tests/expectations_implemented/column_expectations/any_value_expectations/test_expect_value_not_null.py
@@ -110,7 +110,7 @@ def test_column_missing_error():
 def test_suite_pandas_success():
     expectations_suite = DataFrameExpectationsSuite().expect_value_not_null(column_name="col1")
     data_frame = pd.DataFrame({"col1": [1, 2, 3]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -118,13 +118,13 @@ def test_suite_pandas_violations():
     expectations_suite = DataFrameExpectationsSuite().expect_value_not_null(column_name="col1")
     data_frame = pd.DataFrame({"col1": [1, None, np.nan]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
     expectations_suite = DataFrameExpectationsSuite().expect_value_not_null(column_name="col1")
     data_frame = spark.createDataFrame([(1,), (2,), (3,)], ["col1"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -132,11 +132,11 @@ def test_suite_pyspark_violations(spark):
     expectations_suite = DataFrameExpectationsSuite().expect_value_not_null(column_name="col1")
     data_frame = spark.createDataFrame([(1,), (None,), (None,)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
     expectations_suite = DataFrameExpectationsSuite().expect_value_not_null(column_name="col1")
     data_frame = spark.createDataFrame([(1,), (2,), (3,)], ["col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/expectations_implemented/column_expectations/any_value_expectations/test_expect_value_null.py
+++ b/tests/expectations_implemented/column_expectations/any_value_expectations/test_expect_value_null.py
@@ -110,7 +110,7 @@ def test_column_missing_error():
 def test_suite_pandas_success():
     expectations_suite = DataFrameExpectationsSuite().expect_value_null(column_name="col1")
     data_frame = pd.DataFrame({"col1": [None, None, None]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -118,13 +118,13 @@ def test_suite_pandas_violations():
     expectations_suite = DataFrameExpectationsSuite().expect_value_null(column_name="col1")
     data_frame = pd.DataFrame({"col1": [None, 1, 2]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
     expectations_suite = DataFrameExpectationsSuite().expect_value_null(column_name="col1")
     data_frame = spark.createDataFrame([(None,), (None,), (None,)], "col1: int")
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -132,11 +132,11 @@ def test_suite_pyspark_violations(spark):
     expectations_suite = DataFrameExpectationsSuite().expect_value_null(column_name="col1")
     data_frame = spark.createDataFrame([(None,), (1,), (2,)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
     expectations_suite = DataFrameExpectationsSuite().expect_value_null(column_name="col1")
     data_frame = spark.createDataFrame([(None,), (None,), (None,)], "col2: int")
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/expectations_implemented/column_expectations/numerical_expectations/test_expect_value_between.py
+++ b/tests/expectations_implemented/column_expectations/numerical_expectations/test_expect_value_between.py
@@ -123,7 +123,7 @@ def test_suite_pandas_success():
         column_name="col1", min_value=2, max_value=5
     )
     data_frame = pd.DataFrame({"col1": [2, 3, 4, 5]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -133,7 +133,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": [1, 2, 3, 6]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -141,7 +141,7 @@ def test_suite_pyspark_success(spark):
         column_name="col1", min_value=2, max_value=5
     )
     data_frame = spark.createDataFrame([(2,), (3,), (4,), (5,)], ["col1"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -151,7 +151,7 @@ def test_suite_pyspark_violations(spark):
     )
     data_frame = spark.createDataFrame([(1,), (2,), (3,), (6,)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_column_missing_error():
@@ -160,4 +160,4 @@ def test_suite_column_missing_error():
     )
     data_frame = pd.DataFrame({"col2": [2, 3, 4]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/expectations_implemented/column_expectations/numerical_expectations/test_expect_value_greater_than.py
+++ b/tests/expectations_implemented/column_expectations/numerical_expectations/test_expect_value_greater_than.py
@@ -144,7 +144,7 @@ def test_suite_pandas_success():
         column_name="col1", value=2
     )
     data_frame = pd.DataFrame({"col1": [3, 4, 5]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -157,7 +157,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": [3, 4, 5]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -168,7 +168,7 @@ def test_suite_pyspark_success(spark):
         column_name="col1", value=2
     )
     data_frame = spark.createDataFrame([(3,), (4,), (5,)], ["col1"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -181,7 +181,7 @@ def test_suite_pyspark_violations(spark):
     )
     data_frame = spark.createDataFrame([(3,), (4,), (5,)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_column_missing_error():
@@ -193,4 +193,4 @@ def test_suite_column_missing_error():
     )
     data_frame = pd.DataFrame({"col2": [3, 4, 5]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/expectations_implemented/column_expectations/numerical_expectations/test_expect_value_less_than.py
+++ b/tests/expectations_implemented/column_expectations/numerical_expectations/test_expect_value_less_than.py
@@ -145,7 +145,7 @@ def test_suite_pandas_success():
     )
 
     data_frame = pd.DataFrame({"col1": [3, 4, 5]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -159,7 +159,7 @@ def test_suite_pandas_violations():
     data_frame = pd.DataFrame({"col1": [3, 4, 5]})
 
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -170,7 +170,7 @@ def test_suite_pyspark_success(spark):
         column_name="col1", value=6
     )
     data_frame = spark.createDataFrame([(3,), (4,), (5,)], ["col1"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -183,7 +183,7 @@ def test_suite_pyspark_violations(spark):
     )
     data_frame = spark.createDataFrame([(3,), (4,), (5,)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_column_missing_error():
@@ -195,4 +195,4 @@ def test_suite_column_missing_error():
     )
     data_frame = pd.DataFrame({"col2": [3, 4, 5]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/expectations_implemented/column_expectations/string_expectations/test_expect_string_contains.py
+++ b/tests/expectations_implemented/column_expectations/string_expectations/test_expect_string_contains.py
@@ -117,7 +117,7 @@ def test_suite_pandas_success():
         column_name="col1", substring="foo"
     )
     data_frame = pd.DataFrame({"col1": ["foobar", "foo123", "barfoo"]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -127,7 +127,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": ["foobar", "bar", "baz"]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -135,7 +135,7 @@ def test_suite_pyspark_success(spark):
         column_name="col1", substring="foo"
     )
     data_frame = spark.createDataFrame([("foobar",), ("foo123",), ("barfoo",)], ["col1"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -145,7 +145,7 @@ def test_suite_pyspark_violations(spark):
     )
     data_frame = spark.createDataFrame([("foobar",), ("bar",), ("baz",)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -154,4 +154,4 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([("foobar",), ("foo123",), ("barfoo",)], ["col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/expectations_implemented/column_expectations/string_expectations/test_expect_string_ends_with.py
+++ b/tests/expectations_implemented/column_expectations/string_expectations/test_expect_string_ends_with.py
@@ -117,7 +117,7 @@ def test_suite_pandas_success():
         column_name="col1", suffix="bar"
     )
     data_frame = pd.DataFrame({"col1": ["foobar", "bar", "bazbar"]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -127,7 +127,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": ["foobar", "bar", "baz"]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -135,7 +135,7 @@ def test_suite_pyspark_success(spark):
         column_name="col1", suffix="bar"
     )
     data_frame = spark.createDataFrame([("foobar",), ("bar",), ("bazbar",)], ["col1"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -145,7 +145,7 @@ def test_suite_pyspark_violations(spark):
     )
     data_frame = spark.createDataFrame([("foobar",), ("bar",), ("baz",)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -154,4 +154,4 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([("foobar",), ("bar",), ("bazbar",)], ["col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/expectations_implemented/column_expectations/string_expectations/test_expect_string_length_between.py
+++ b/tests/expectations_implemented/column_expectations/string_expectations/test_expect_string_length_between.py
@@ -123,7 +123,7 @@ def test_suite_pandas_success():
         column_name="col1", min_length=3, max_length=6
     )
     data_frame = pd.DataFrame({"col1": ["foo", "bazz", "hello", "foobar"]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -133,7 +133,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": ["fo", "bazz", "hellothere", "foobar"]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -141,7 +141,7 @@ def test_suite_pyspark_success(spark):
         column_name="col1", min_length=3, max_length=6
     )
     data_frame = spark.createDataFrame([("foo",), ("bazz",), ("hello",), ("foobar",)], ["col1"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -151,7 +151,7 @@ def test_suite_pyspark_violations(spark):
     )
     data_frame = spark.createDataFrame([("fo",), ("bazz",), ("hellothere",), ("foobar",)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -160,4 +160,4 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([("foo",), ("bazz",), ("hello",)], ["col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/expectations_implemented/column_expectations/string_expectations/test_expect_string_length_equals.py
+++ b/tests/expectations_implemented/column_expectations/string_expectations/test_expect_string_length_equals.py
@@ -117,7 +117,7 @@ def test_suite_pandas_success():
         column_name="col1", length=3
     )
     data_frame = pd.DataFrame({"col1": ["foo", "bar", "baz"]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -127,7 +127,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": ["foo", "bar", "bazz", "foobar"]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -135,7 +135,7 @@ def test_suite_pyspark_success(spark):
         column_name="col1", length=3
     )
     data_frame = spark.createDataFrame([("foo",), ("bar",), ("baz",)], ["col1"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -145,7 +145,7 @@ def test_suite_pyspark_violations(spark):
     )
     data_frame = spark.createDataFrame([("foo",), ("bar",), ("bazz",), ("foobar",)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -154,4 +154,4 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([("foo",), ("bar",), ("baz",)], ["col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/expectations_implemented/column_expectations/string_expectations/test_expect_string_length_greater_than.py
+++ b/tests/expectations_implemented/column_expectations/string_expectations/test_expect_string_length_greater_than.py
@@ -117,7 +117,7 @@ def test_suite_pandas_success():
         column_name="col1", length=3
     )
     data_frame = pd.DataFrame({"col1": ["foobar", "bazz", "hello"]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -127,7 +127,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": ["foo", "bar", "bazzz"]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -135,7 +135,7 @@ def test_suite_pyspark_success(spark):
         column_name="col1", length=3
     )
     data_frame = spark.createDataFrame([("foobar",), ("bazz",), ("hello",)], ["col1"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -145,7 +145,7 @@ def test_suite_pyspark_violations(spark):
     )
     data_frame = spark.createDataFrame([("foo",), ("bar",), ("bazzz",)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -154,4 +154,4 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([("foobar",), ("bazz",), ("hello",)], ["col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/expectations_implemented/column_expectations/string_expectations/test_expect_string_length_less_than.py
+++ b/tests/expectations_implemented/column_expectations/string_expectations/test_expect_string_length_less_than.py
@@ -117,7 +117,7 @@ def test_suite_pandas_success():
         column_name="col1", length=5
     )
     data_frame = pd.DataFrame({"col1": ["foo", "bar", "baz"]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -127,7 +127,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": ["foobar", "bar", "bazbaz"]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -135,7 +135,7 @@ def test_suite_pyspark_success(spark):
         column_name="col1", length=5
     )
     data_frame = spark.createDataFrame([("foo",), ("bar",), ("baz",)], ["col1"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -145,7 +145,7 @@ def test_suite_pyspark_violations(spark):
     )
     data_frame = spark.createDataFrame([("foobar",), ("bar",), ("bazbaz",)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -154,4 +154,4 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([("foo",), ("bar",), ("baz",)], ["col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/expectations_implemented/column_expectations/string_expectations/test_expect_string_not_contains.py
+++ b/tests/expectations_implemented/column_expectations/string_expectations/test_expect_string_not_contains.py
@@ -117,7 +117,7 @@ def test_suite_pandas_success():
         column_name="col1", substring="foo"
     )
     data_frame = pd.DataFrame({"col1": ["bar", "baz", "qux"]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -127,7 +127,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": ["foobar", "bar", "foo"]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -135,7 +135,7 @@ def test_suite_pyspark_success(spark):
         column_name="col1", substring="foo"
     )
     data_frame = spark.createDataFrame([("bar",), ("baz",), ("qux",)], ["col1"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -145,7 +145,7 @@ def test_suite_pyspark_violations(spark):
     )
     data_frame = spark.createDataFrame([("foobar",), ("bar",), ("foo",)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -154,4 +154,4 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([("bar",), ("baz",), ("qux",)], ["col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/expectations_implemented/column_expectations/string_expectations/test_expect_string_starts_with.py
+++ b/tests/expectations_implemented/column_expectations/string_expectations/test_expect_string_starts_with.py
@@ -117,7 +117,7 @@ def test_suite_pandas_success():
         column_name="col1", prefix="foo"
     )
     data_frame = pd.DataFrame({"col1": ["foobar", "foo123", "foobaz"]})
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -127,7 +127,7 @@ def test_suite_pandas_violations():
     )
     data_frame = pd.DataFrame({"col1": ["foobar", "barfoo", "baz"]})
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_success(spark):
@@ -135,7 +135,7 @@ def test_suite_pyspark_success(spark):
         column_name="col1", prefix="foo"
     )
     data_frame = spark.createDataFrame([("foobar",), ("foo123",), ("foobaz",)], ["col1"])
-    result = expectations_suite.run(data_frame=data_frame)
+    result = expectations_suite.build().run(data_frame=data_frame)
     assert result is None, "Expected no exceptions to be raised"
 
 
@@ -145,7 +145,7 @@ def test_suite_pyspark_violations(spark):
     )
     data_frame = spark.createDataFrame([("foobar",), ("barfoo",), ("baz",)], ["col1"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)
 
 
 def test_suite_pyspark_column_missing_error(spark):
@@ -154,4 +154,4 @@ def test_suite_pyspark_column_missing_error(spark):
     )
     data_frame = spark.createDataFrame([("foobar",), ("foo123",), ("foobaz",)], ["col2"])
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        expectations_suite.run(data_frame=data_frame)
+        expectations_suite.build().run(data_frame=data_frame)

--- a/tests/test_expectations_suite.py
+++ b/tests/test_expectations_suite.py
@@ -207,11 +207,25 @@ def test_builder_pattern_immutability():
     # Build first runner
     runner1 = suite.build()
 
+    # Verify runner1 has exactly 1 expectation
+    assert runner1.expectation_count == 1, "Runner1 should have 1 expectation"
+    expectations_list = runner1.list_expectations()
+    assert len(expectations_list) == 1
+    assert expectations_list[0] == "ExpectationValueGreaterThan ('col1' is greater than 5)"
+
     # Add more expectations to suite
     suite.expect_value_less_than(column_name="col1", value=20)
 
     # Build second runner
     runner2 = suite.build()
+
+    # Verify runner2 has 2 expectations but runner1 is unchanged
+    assert runner1.expectation_count == 1, "Runner1 should still have 1 expectation (immutable)"
+    assert runner2.expectation_count == 2, "Runner2 should have 2 expectations"
+    expectations_list2 = runner2.list_expectations()
+    assert len(expectations_list2) == 2
+    assert expectations_list2[0] == "ExpectationValueGreaterThan ('col1' is greater than 5)"
+    assert expectations_list2[1] == "ExpectationValueLessThan ('col1' is less than 20)"
 
     # Test data
     df = pd.DataFrame({"col1": [10, 15]})

--- a/tests/test_expectations_suite.py
+++ b/tests/test_expectations_suite.py
@@ -16,11 +16,6 @@ def test_suite_success():
     Test the ExpectationsSuite with a successful expectation.
     """
 
-    # No expectations
-    suite = DataFrameExpectationsSuite()
-    result = suite.run(data_frame=pd.DataFrame())
-    assert result is None, "Expected no result for empty suite"
-
     # All succeeding expectations
     suite = (
         DataFrameExpectationsSuite()
@@ -28,7 +23,8 @@ def test_suite_success():
         .expect_value_less_than(column_name="col1", value=10)
     )
     data_Frame = pd.DataFrame({"col1": [3, 4, 5]})
-    result = suite.run(data_frame=data_Frame)
+    runner = suite.build()
+    result = runner.run(data_frame=data_Frame)
     assert result is None, "Expected no result for successful suite"
 
 
@@ -44,9 +40,10 @@ def test_suite_failure():
         .expect_value_less_than(column_name="col1", value=3)
     )
     data_Frame = pd.DataFrame({"col1": [3, 4, 5]})
+    runner = suite.build()
 
     with pytest.raises(DataFrameExpectationsSuiteFailure):
-        suite.run(data_frame=data_Frame)
+        runner.run(data_frame=data_Frame)
 
 
 def test_invalid_data_frame_type():
@@ -59,10 +56,11 @@ def test_invalid_data_frame_type():
         .expect_value_greater_than(column_name="col1", value=2)
         .expect_value_less_than(column_name="col1", value=10)
     )
+    runner = suite.build()
     data_Frame = None
 
     with pytest.raises(ValueError):
-        suite.run(data_frame=data_Frame)
+        runner.run(data_frame=data_Frame)
 
 
 def test_suite_with_supported_dataframe_types(spark):
@@ -71,15 +69,16 @@ def test_suite_with_supported_dataframe_types(spark):
     """
 
     suite = DataFrameExpectationsSuite().expect_min_rows(min_rows=1)
+    runner = suite.build()
 
     # Test with pandas DataFrame
     pandas_df = pd.DataFrame({"col1": [1, 2, 3]})
-    result = suite.run(data_frame=pandas_df)
+    result = runner.run(data_frame=pandas_df)
     assert result is None, "Expected success for pandas DataFrame"
 
     # Test with PySpark DataFrame
     spark_df = spark.createDataFrame([(1,), (2,), (3,)], ["col1"])
-    result = suite.run(data_frame=spark_df)
+    result = runner.run(data_frame=spark_df)
     assert result is None, "Expected success for PySpark DataFrame"
 
 
@@ -88,6 +87,7 @@ def test_suite_with_unsupported_dataframe_types():
     Test the ExpectationsSuite with unsupported DataFrame types.
     """
     suite = DataFrameExpectationsSuite().expect_min_rows(min_rows=1)
+    runner = suite.build()
 
     # Test various unsupported types
     unsupported_types = [
@@ -101,7 +101,7 @@ def test_suite_with_unsupported_dataframe_types():
 
     for unsupported_data in unsupported_types:
         with pytest.raises(ValueError) as context:
-            suite.run(data_frame=unsupported_data)
+            runner.run(data_frame=unsupported_data)
         assert "Unsupported DataFrame type" in str(context.value), (
             f"Expected unsupported type error for {type(unsupported_data)}"
         )
@@ -127,6 +127,7 @@ def test_suite_with_pyspark_connect_dataframe():
             return self
 
     suite = DataFrameExpectationsSuite().expect_min_rows(min_rows=0)
+    runner = suite.build()
 
     with patch(
         "dataframe_expectations.expectations.PySparkConnectDataFrame",
@@ -134,7 +135,7 @@ def test_suite_with_pyspark_connect_dataframe():
     ):
         # Create mock expectation that can handle Connect DataFrame
         with patch.object(
-            suite._DataFrameExpectationsSuite__expectations[0], "validate"
+            runner._DataFrameExpectationsSuiteRunner__expectations[0], "validate"
         ) as mock_validate:
             from dataframe_expectations.result_message import (
                 DataFrameExpectationSuccessMessage,
@@ -145,7 +146,7 @@ def test_suite_with_pyspark_connect_dataframe():
             )
 
             mock_connect_df = MockConnectDataFrame()
-            result = suite.run(data_frame=mock_connect_df)
+            result = runner.run(data_frame=mock_connect_df)
             assert result is None, "Expected success for mock Connect DataFrame"
 
 
@@ -182,3 +183,195 @@ def test_expectation_suite_failure_message():
     assert str(suite_failure) == expected_str, (
         f"Expected suite failure message but got: {str(suite_failure)}"
     )
+
+
+def test_build_empty_suite():
+    """
+    Test that building a suite with no expectations raises an error.
+    """
+    suite = DataFrameExpectationsSuite()
+
+    with pytest.raises(ValueError) as context:
+        suite.build()
+
+    assert "no expectations added" in str(context.value)
+
+
+def test_builder_pattern_immutability():
+    """
+    Test that runners are immutable and independent.
+    """
+    suite = DataFrameExpectationsSuite()
+    suite.expect_value_greater_than(column_name="col1", value=5)
+
+    # Build first runner
+    runner1 = suite.build()
+
+    # Add more expectations to suite
+    suite.expect_value_less_than(column_name="col1", value=20)
+
+    # Build second runner
+    runner2 = suite.build()
+
+    # Test data
+    df = pd.DataFrame({"col1": [10, 15]})
+
+    # Runner1 should only have 1 expectation (passes)
+    result1 = runner1.run(data_frame=df)
+    assert result1 is None, "Runner1 should pass with only 1 expectation"
+
+    # Runner2 should have 2 expectations (passes)
+    result2 = runner2.run(data_frame=df)
+    assert result2 is None, "Runner2 should pass with 2 expectations"
+
+
+def test_decorator_success():
+    """
+    Test the validate decorator with successful validation.
+    """
+    suite = DataFrameExpectationsSuite()
+    suite.expect_min_rows(min_rows=1)
+    suite.expect_value_greater_than(column_name="col1", value=0)
+
+    runner = suite.build()
+
+    @runner.validate
+    def load_data():
+        return pd.DataFrame({"col1": [1, 2, 3]})
+
+    # Should not raise exception
+    df = load_data()
+    assert len(df) == 3, "Should return the original DataFrame"
+    assert list(df["col1"]) == [1, 2, 3]
+
+
+def test_decorator_failure():
+    """
+    Test the validate decorator with failing validation.
+    """
+    suite = DataFrameExpectationsSuite()
+    suite.expect_value_greater_than(column_name="col1", value=10)
+
+    runner = suite.build()
+
+    @runner.validate
+    def load_bad_data():
+        return pd.DataFrame({"col1": [1, 2, 3]})
+
+    # Should raise DataFrameExpectationsSuiteFailure
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        load_bad_data()
+
+
+def test_decorator_with_arguments():
+    """
+    Test the validate decorator with functions that take arguments.
+    """
+    suite = DataFrameExpectationsSuite()
+    suite.expect_min_rows(min_rows=1)
+
+    runner = suite.build()
+
+    @runner.validate
+    def load_filtered_data(min_value: int, max_value: int):
+        data = [i for i in range(min_value, max_value + 1)]
+        return pd.DataFrame({"col1": data})
+
+    df = load_filtered_data(5, 10)
+    assert len(df) == 6, "Should return filtered DataFrame"
+    assert list(df["col1"]) == [5, 6, 7, 8, 9, 10]
+
+
+def test_decorator_preserves_function_metadata():
+    """
+    Test that the validate decorator preserves function metadata.
+    """
+    suite = DataFrameExpectationsSuite()
+    suite.expect_min_rows(min_rows=0)
+
+    runner = suite.build()
+
+    @runner.validate
+    def my_function():
+        """This is my docstring."""
+        return pd.DataFrame({"col1": []})
+
+    assert my_function.__name__ == "my_function"
+    assert my_function.__doc__ == "This is my docstring."
+
+
+def test_decorator_with_none_not_allowed():
+    """
+    Test that the decorator raises ValueError when function returns None by default.
+    """
+    suite = DataFrameExpectationsSuite()
+    suite.expect_min_rows(min_rows=1)
+
+    runner = suite.build()
+
+    @runner.validate
+    def returns_none():
+        return None
+
+    with pytest.raises(ValueError, match="returned None"):
+        returns_none()
+
+
+def test_decorator_with_none_allowed():
+    """
+    Test that the decorator allows None when allow_none=True.
+    """
+    suite = DataFrameExpectationsSuite()
+    suite.expect_min_rows(min_rows=1)
+
+    runner = suite.build()
+
+    @runner.validate(allow_none=True)
+    def returns_none():
+        return None
+
+    result = returns_none()
+    assert result is None
+
+
+def test_decorator_with_none_allowed_validates_dataframe():
+    """
+    Test that when allow_none=True, the decorator still validates DataFrames.
+    """
+    suite = DataFrameExpectationsSuite()
+    suite.expect_min_rows(min_rows=2)
+
+    runner = suite.build()
+
+    @runner.validate(allow_none=True)
+    def returns_dataframe():
+        return pd.DataFrame({"col1": [1]})
+
+    # Should fail validation because min_rows=2 but only 1 row
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        returns_dataframe()
+
+
+def test_decorator_with_none_allowed_conditional():
+    """
+    Test that allow_none=True works for conditional DataFrame returns.
+    """
+    suite = DataFrameExpectationsSuite()
+    suite.expect_min_rows(min_rows=1)
+
+    runner = suite.build()
+
+    @runner.validate(allow_none=True)
+    def conditional_load(load: bool):
+        if load:
+            return pd.DataFrame({"col1": [1, 2, 3]})
+        return None
+
+    # Should validate DataFrame
+    result_with_data = conditional_load(True)
+    assert isinstance(result_with_data, pd.DataFrame)
+    assert len(result_with_data) == 3
+
+    # Should allow None
+    result_none = conditional_load(False)
+    assert result_none is None

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ toml = [
 
 [[package]]
 name = "dataframe-expectations"
-version = "0.1.1"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "pandas" },
@@ -332,6 +332,7 @@ docs = [
     { name = "sphinx" },
     { name = "sphinx-autobuild" },
     { name = "tabulate" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.metadata]
@@ -357,6 +358,7 @@ docs = [
     { name = "sphinx", specifier = ">=4.0.0" },
     { name = "sphinx-autobuild", specifier = ">=2021.3.14" },
     { name = "tabulate", specifier = ">=0.8.9" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

‼️ BREAKING CHANGE: The `DataFrameExpectationsSuite` API has changed. Users must now call `.build()` before `.run()`.

- Add DataFrameExpectationsSuiteRunner class for immutable expectation execution
- Separate mutable suite builder from immutable runner to prevent side effects
- Add validate() decorator method to runner for automatic DataFrame validation
- Support allow_none parameter in decorator for optional DataFrame returns
- Update all tests to use new builder pattern (suite.build().run())
- Update README.md and getting_started.rst with new examples
- Add comprehensive test coverage for builder pattern and decorator functionality

**Migration guide:**
```python
# Before
suite.run(df) 

# After  
runner = suite.build()
runner.run(df)
```

**New decorator feature:**
 ```python
@runner.validate 
def load_data(): 
    return pd.read_csv(\"data.csv\")

@runner.validate(allow_none=True) 
def optional_load():
    return None  # Skip validation when None
```

  



## Commit Message Format
<!--
  This project uses Conventional Commits for automated versioning and changelog generation.
  Ensure your commit messages follow this format:

  - feat: A new feature (triggers MINOR version bump)
  - fix: A bug fix (triggers PATCH version bump)
  - feat!: A breaking change (triggers MAJOR version bump)
  - docs: Documentation changes
  - chore: Maintenance tasks
  - test: Adding or updating tests

  Examples:
  - feat: add expectation for null value validation
  - fix: correct type hint in expect_value_greater_than
  - feat!: remove deprecated validation methods
-->

## Checklist
<!--
  Please consider the following when submitting code changes.

  Note: You can check the boxes once you submit, or put an x in the [ ] like [x]
-->

-   [x] Tests have been added in the prescribed format
-   [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
-   [x] Pre-commit hooks pass locally
