### PR TITLE
fix: manually trigger CI for release-please PRs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:  # Allow manual triggering
 
 permissions:
   contents: write


### PR DESCRIPTION
## Description
In the PRs created by release-please action all the CI steps are not automatically triggered. As a workaround I updated the CI to be triggered manually for these PRs.

## Checklist
<!--
  Please consider the following when submitting code changes.

  Note: You can check the boxes once you submit, or put an x in the [ ] like [x]
-->

-   [x] Tests have been added in the prescribed format
-   [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
-   [x] Pre-commit hooks pass locally
