### PR TITLE
refactor: make PySpark imports optional at runtime (Phase 1)

### DIFF
--- a/dataframe_expectations/core/expectation.py
+++ b/dataframe_expectations/core/expectation.py
@@ -1,21 +1,20 @@
 from abc import ABC, abstractmethod
-from typing import List, Optional, cast
+from typing import Any, List, Optional, cast
 
 from pandas import DataFrame as PandasDataFrame
-from pyspark.sql import DataFrame as PySparkDataFrame
 
-# Import the connect DataFrame type for Spark Connect
-try:
-    from pyspark.sql.connect.dataframe import DataFrame as PySparkConnectDataFrame
-except ImportError:
-    # Fallback for older PySpark versions that don't have connect
-    PySparkConnectDataFrame = None  # type: ignore[misc,assignment]
-
+from dataframe_expectations.core.pyspark_utils import is_pyspark_data_frame
 from dataframe_expectations.core.types import DataFrameLike, DataFrameType
 from dataframe_expectations.core.tagging import TagSet
 from dataframe_expectations.result_message import (
     DataFrameExpectationResultMessage,
 )
+
+# Kept as module-level symbol for backward compatibility and test patching.
+try:
+    from pyspark.sql.connect.dataframe import DataFrame as PySparkConnectDataFrame
+except ImportError:
+    PySparkConnectDataFrame = None  # type: ignore[misc,assignment]
 
 
 class DataFrameExpectation(ABC):
@@ -63,17 +62,16 @@ class DataFrameExpectation(ABC):
         """
         Infer the DataFrame type based on the provided DataFrame.
         """
-        match data_frame:
-            case PandasDataFrame():
-                return DataFrameType.PANDAS
-            case PySparkDataFrame():
-                return DataFrameType.PYSPARK
-            case _ if PySparkConnectDataFrame is not None and isinstance(
-                data_frame, PySparkConnectDataFrame
-            ):
-                return DataFrameType.PYSPARK
-            case _:
-                raise ValueError(f"Unsupported DataFrame type: {type(data_frame)}")
+        if isinstance(data_frame, PandasDataFrame):
+            return DataFrameType.PANDAS
+
+        if PySparkConnectDataFrame is not None and isinstance(data_frame, PySparkConnectDataFrame):
+            return DataFrameType.PYSPARK
+
+        if is_pyspark_data_frame(data_frame):
+            return DataFrameType.PYSPARK
+
+        raise ValueError(f"Unsupported DataFrame type: {type(data_frame)}")
 
     def validate(self, data_frame: DataFrameLike, **kwargs):
         """
@@ -121,7 +119,7 @@ class DataFrameExpectation(ABC):
             # Cast to PandasDataFrame since we know it's a Pandas DataFrame at this point
             return len(cast(PandasDataFrame, data_frame))
         elif data_frame_type == DataFrameType.PYSPARK:
-            # Cast to PySparkDataFrame since we know it's a PySpark DataFrame at this point
-            return cast(PySparkDataFrame, data_frame).count()
+            # PySpark DataFrames expose count(), including runtime-provided patched variants.
+            return cast(Any, data_frame).count()
         else:
             raise ValueError(f"Unsupported DataFrame type: {data_frame_type}")

--- a/dataframe_expectations/core/pyspark_utils.py
+++ b/dataframe_expectations/core/pyspark_utils.py
@@ -1,0 +1,76 @@
+"""Utilities for optional PySpark imports and runtime type checks."""
+
+import warnings
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any, Tuple
+
+if TYPE_CHECKING:
+    from pyspark.sql import DataFrame as PySparkDataFrame
+else:
+    PySparkDataFrame = Any
+
+_pyspark_deprecation_warned = False
+
+
+class _MissingPySparkFunctions:
+    def __getattr__(self, name: str) -> Any:
+        raise ImportError(
+            "PySpark is required for PySpark validation paths. "
+            "Install pyspark or use a runtime that provides pyspark."
+        )
+
+
+@lru_cache(maxsize=1)
+def get_pyspark_functions() -> Any:
+    """Return `pyspark.sql.functions` or a proxy raising a clear ImportError on use."""
+    try:
+        from pyspark.sql import functions as F
+
+        return F
+    except ImportError:
+        return _MissingPySparkFunctions()
+
+
+@lru_cache(maxsize=1)
+def _get_pyspark_dataframe_types() -> Tuple[type, ...]:
+    data_frame_types = []
+
+    try:
+        from pyspark.sql import DataFrame as PySparkDataFrameType
+
+        data_frame_types.append(PySparkDataFrameType)
+    except ImportError:
+        pass
+
+    try:
+        from pyspark.sql.connect.dataframe import DataFrame as PySparkConnectDataFrameType
+
+        data_frame_types.append(PySparkConnectDataFrameType)
+    except ImportError:
+        pass
+
+    return tuple(data_frame_types)
+
+
+def is_pyspark_data_frame(data_frame: Any) -> bool:
+    """Return True when the input is a classic or connect PySpark DataFrame."""
+    global _pyspark_deprecation_warned
+
+    data_frame_types = _get_pyspark_dataframe_types()
+    result = (data_frame_types and isinstance(data_frame, data_frame_types)) or (
+        type(data_frame).__module__.startswith("pyspark.sql")
+    )
+
+    if result and not _pyspark_deprecation_warned:
+        _pyspark_deprecation_warned = True
+        warnings.warn(
+            "In a future release, PySpark will be an optional dependency of dataframe-expectations. "
+            "To avoid breakage, either: "
+            "(1) install PySpark separately: pip install pyspark, "
+            "or (2) install dataframe-expectations with PySpark included: "
+            "pip install 'dataframe-expectations[pyspark]'.",
+            FutureWarning,
+            stacklevel=2,
+        )
+
+    return result

--- a/dataframe_expectations/core/types.py
+++ b/dataframe_expectations/core/types.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Union
 
 from pandas import DataFrame as PandasDataFrame
 from pydantic import BaseModel, ConfigDict, Field
-from pyspark.sql import DataFrame as PySparkDataFrame
+from dataframe_expectations.core.pyspark_utils import PySparkDataFrame
 
 # Type aliases
 DataFrameLike = Union[PySparkDataFrame, PandasDataFrame]

--- a/dataframe_expectations/expectations/aggregation/any_value.py
+++ b/dataframe_expectations/expectations/aggregation/any_value.py
@@ -1,8 +1,7 @@
 from typing import List, Optional, cast
 
 from pandas import DataFrame as PandasDataFrame
-from pyspark.sql import DataFrame as PySparkDataFrame
-from pyspark.sql import functions as F
+from dataframe_expectations.core.pyspark_utils import PySparkDataFrame, get_pyspark_functions
 
 from dataframe_expectations.core.aggregation_expectation import (
     DataFrameAggregationExpectation,
@@ -20,6 +19,8 @@ from dataframe_expectations.result_message import (
     DataFrameExpectationResultMessage,
     DataFrameExpectationSuccessMessage,
 )
+
+F = get_pyspark_functions()
 
 
 class ExpectationMinRows(DataFrameAggregationExpectation):

--- a/dataframe_expectations/expectations/aggregation/numerical.py
+++ b/dataframe_expectations/expectations/aggregation/numerical.py
@@ -2,8 +2,7 @@ from typing import List, Optional, Union, cast
 
 import pandas as pd
 from pandas import DataFrame as PandasDataFrame
-from pyspark.sql import DataFrame as PySparkDataFrame
-from pyspark.sql import functions as F
+from dataframe_expectations.core.pyspark_utils import PySparkDataFrame, get_pyspark_functions
 
 from dataframe_expectations.core.aggregation_expectation import (
     DataFrameAggregationExpectation,
@@ -21,6 +20,8 @@ from dataframe_expectations.result_message import (
     DataFrameExpectationResultMessage,
     DataFrameExpectationSuccessMessage,
 )
+
+F = get_pyspark_functions()
 
 
 class ExpectationColumnQuantileBetween(DataFrameAggregationExpectation):

--- a/dataframe_expectations/expectations/aggregation/unique.py
+++ b/dataframe_expectations/expectations/aggregation/unique.py
@@ -2,8 +2,7 @@ from typing import List, Optional, cast
 
 import pandas as pd
 from pandas import DataFrame as PandasDataFrame
-from pyspark.sql import DataFrame as PySparkDataFrame
-from pyspark.sql import functions as F
+from dataframe_expectations.core.pyspark_utils import PySparkDataFrame, get_pyspark_functions
 from dataframe_expectations.core.aggregation_expectation import (
     DataFrameAggregationExpectation,
 )
@@ -20,6 +19,8 @@ from dataframe_expectations.result_message import (
     DataFrameExpectationResultMessage,
     DataFrameExpectationSuccessMessage,
 )
+
+F = get_pyspark_functions()
 
 
 class ExpectationUniqueRows(DataFrameAggregationExpectation):

--- a/dataframe_expectations/expectations/column/any_value.py
+++ b/dataframe_expectations/expectations/column/any_value.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pyspark.sql import functions as F
+from dataframe_expectations.core.pyspark_utils import get_pyspark_functions
 
 from dataframe_expectations.core.column_expectation import (
     DataFrameColumnExpectation,
@@ -11,6 +11,8 @@ from dataframe_expectations.core.types import (
 )
 from dataframe_expectations.registry import register_expectation
 from dataframe_expectations.core.utils import requires_params
+
+F = get_pyspark_functions()
 
 
 @register_expectation(

--- a/dataframe_expectations/expectations/column/numerical.py
+++ b/dataframe_expectations/expectations/column/numerical.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pyspark.sql import functions as F
+from dataframe_expectations.core.pyspark_utils import get_pyspark_functions
 
 from dataframe_expectations.core.column_expectation import (
     DataFrameColumnExpectation,
@@ -11,6 +11,8 @@ from dataframe_expectations.core.types import (
 )
 from dataframe_expectations.registry import register_expectation
 from dataframe_expectations.core.utils import requires_params
+
+F = get_pyspark_functions()
 
 
 @register_expectation(

--- a/dataframe_expectations/expectations/column/string.py
+++ b/dataframe_expectations/expectations/column/string.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
-from pyspark.sql import functions as F
+
+from dataframe_expectations.core.pyspark_utils import get_pyspark_functions
 
 from dataframe_expectations.core.column_expectation import (
     DataFrameColumnExpectation,
@@ -10,6 +11,8 @@ from dataframe_expectations.core.types import (
 )
 from dataframe_expectations.registry import register_expectation
 from dataframe_expectations.core.utils import requires_params
+
+F = get_pyspark_functions()
 
 
 @register_expectation(

--- a/tests/core/test_pyspark_utils.py
+++ b/tests/core/test_pyspark_utils.py
@@ -1,0 +1,114 @@
+import warnings
+
+import pytest
+from unittest.mock import patch
+
+from dataframe_expectations.core import pyspark_utils
+from dataframe_expectations.core.pyspark_utils import (
+    get_pyspark_functions,
+    is_pyspark_data_frame,
+)
+
+
+# ---------------------------------------------------------------------------
+# get_pyspark_functions
+# ---------------------------------------------------------------------------
+
+
+def test_get_pyspark_functions_returns_real_functions_when_pyspark_present():
+    """When pyspark is installed, the real functions module is returned."""
+    # lru_cache may already hold the result from a previous test run, so clear it.
+    get_pyspark_functions.cache_clear()
+
+    F = get_pyspark_functions()
+    # The real pyspark.sql.functions module has `col` as an attribute.
+    assert hasattr(F, "col")
+
+
+def test_get_pyspark_functions_proxy_raises_on_attribute_access_when_pyspark_missing():
+    """When pyspark is not installed, accessing any attribute raises ImportError."""
+    get_pyspark_functions.cache_clear()
+
+    with patch.dict(
+        "sys.modules", {"pyspark": None, "pyspark.sql": None, "pyspark.sql.functions": None}
+    ):
+        get_pyspark_functions.cache_clear()
+        F = get_pyspark_functions()
+        with pytest.raises(ImportError, match="PySpark is required"):
+            _ = F.col
+
+    # Restore cache state for subsequent tests.
+    get_pyspark_functions.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# is_pyspark_data_frame
+# ---------------------------------------------------------------------------
+
+
+def test_is_pyspark_data_frame_returns_false_for_non_spark_objects():
+    import pandas as pd
+
+    assert is_pyspark_data_frame(pd.DataFrame()) is False
+    assert is_pyspark_data_frame("string") is False
+    assert is_pyspark_data_frame(42) is False
+    assert is_pyspark_data_frame(None) is False
+
+
+def test_is_pyspark_data_frame_returns_true_for_pyspark_df(spark):
+    spark_df = spark.createDataFrame([(1,)], ["col1"])
+    assert is_pyspark_data_frame(spark_df) is True
+
+
+def test_is_pyspark_data_frame_returns_true_for_module_name_fallback():
+    """Objects whose __module__ starts with 'pyspark.sql' are treated as Spark DataFrames."""
+
+    class FakeRuntimeSparkDataFrame:
+        pass
+
+    FakeRuntimeSparkDataFrame.__module__ = "pyspark.sql.dataframe"
+
+    obj = FakeRuntimeSparkDataFrame()
+    assert is_pyspark_data_frame(obj) is True
+
+
+# ---------------------------------------------------------------------------
+# FutureWarning
+# ---------------------------------------------------------------------------
+
+
+def test_is_pyspark_data_frame_emits_future_warning_for_pyspark_df(spark):
+    """A FutureWarning is emitted the first time a PySpark DataFrame is detected."""
+    # Reset the module-level flag so the warning fires fresh.
+    pyspark_utils._pyspark_deprecation_warned = False
+
+    spark_df = spark.createDataFrame([(1,)], ["col1"])
+
+    with pytest.warns(FutureWarning, match="optional dependency"):
+        is_pyspark_data_frame(spark_df)
+
+
+def test_is_pyspark_data_frame_warning_fires_only_once(spark):
+    """The FutureWarning fires at most once per process (guarded by the module flag)."""
+    pyspark_utils._pyspark_deprecation_warned = False
+
+    spark_df = spark.createDataFrame([(1,)], ["col1"])
+
+    with pytest.warns(FutureWarning):
+        is_pyspark_data_frame(spark_df)
+
+    # Second call should produce no warning.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning would raise
+        is_pyspark_data_frame(spark_df)  # must not raise
+
+
+def test_is_pyspark_data_frame_no_warning_for_pandas():
+    """No FutureWarning is emitted when the DataFrame is a Pandas DataFrame."""
+    import pandas as pd
+
+    pyspark_utils._pyspark_deprecation_warned = False
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning would raise
+        is_pyspark_data_frame(pd.DataFrame())  # must not raise


### PR DESCRIPTION
### Background

`pyspark>=3.3.0` is currently a hard dependency, which forces installation of the standalone PyPI `pyspark` package even when:

- a user only validates Pandas DataFrames
- a user runs on Databricks Runtime (PySpark is already provided by the cluster)
- a user uses `databricks-connect` (PySpark is provided by the connect client)

This PR is **Phase 1** of a two-phase migration. It makes the codebase safe to run without PySpark installed. **Phase 2** (a separate PR) will move `pyspark` from `[project.dependencies]` to `[project.optional-dependencies]` in `pyproject.toml`.

### What changed

#### New: `dataframe_expectations/core/pyspark_utils.py`

A single shared utility module that replaces 8 duplicate `try/except ImportError` blocks scattered across the codebase. It provides:

- `get_pyspark_functions()` — returns the real `pyspark.sql.functions` module when PySpark is installed, or a `_MissingPySparkFunctions` proxy that raises a clear `ImportError` on attribute access when it is not.
- `is_pyspark_data_frame(obj)` — detects whether an object is a PySpark DataFrame using `isinstance` with a runtime-resolved tuple of types, with a module-name fallback for Databricks Runtime variants. Emits a one-time `FutureWarning` the first time a PySpark DataFrame is actually processed (see below).
- `PySparkDataFrame` type alias — `Any` at runtime, the real type under `TYPE_CHECKING`.

> **Note:** `PySparkConnectDataFrame` is retained as a module-level symbol in `expectation.py` for backward compatibility with existing tests that use `patch("dataframe_expectations.core.expectation.PySparkConnectDataFrame", ...)`.

#### FutureWarning

When a user passes a PySpark DataFrame to a suite, `is_pyspark_data_frame()` emits a `FutureWarning` **once per process**:


## Checklist
<!--
  Please consider the following when submitting code changes.

  Note: You can check the boxes once you submit, or put an x in the [ ] like [x]
-->

-   [ ] Tests have been added in the prescribed format
-   [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
-   [ ] Pre-commit hooks pass locally
