### PR TITLE
Phase 2 make pyspark optional

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,13 +12,13 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
 jobs:
-  test:
+  tests-without-pyspark:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
       fail-fast: false  # Don't cancel other jobs if one fails
-    name: Test (Python ${{ matrix.python-version }})
+    name: Tests Without PySpark (Python ${{ matrix.python-version }})
     steps:
       - uses: actions/checkout@v4
       - name: Install Python and UV
@@ -31,7 +31,56 @@ jobs:
       - name: Run sanity check
         run: |
           uv run python scripts/sanity_checks.py
-      - name: Run tests
+      - name: Run tests without pyspark marker
+        run: |
+          uv run pytest tests/ -m "not pyspark" -n auto --tb=line --cov=dataframe_expectations
+
+  tests-with-pyspark-extra:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+      fail-fast: false  # Don't cancel other jobs if one fails
+    name: Tests With PySpark Extra (Python ${{ matrix.python-version }})
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Python and UV
+        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies with pyspark extra
+        run: |
+          uv sync --group dev --extra pyspark
+      - name: Run sanity check
+        run: |
+          uv run python scripts/sanity_checks.py
+      - name: Run tests with pyspark marker
+        run: |
+          uv run pytest tests/ -n auto --tb=line --cov=dataframe_expectations
+
+  tests-with-external-pyspark:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+      fail-fast: false  # Don't cancel other jobs if one fails
+    name: Tests With External PySpark (Python ${{ matrix.python-version }})
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Python and UV
+        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies without pyspark extra
+        run: |
+          uv sync --group dev
+      - name: Install pyspark as external dependency
+        run: |
+          uv pip install "pyspark>=3.3.0"
+      - name: Run sanity check
+        run: |
+          uv run python scripts/sanity_checks.py
+      - name: Run tests with pyspark marker
         run: |
           uv run pytest tests/ -n auto --tb=line --cov=dataframe_expectations
 
@@ -56,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PYTHON_VERSION: "3.11"  # Use a single version for docs
-    needs: [test, lint]
+    needs: [tests-without-pyspark, tests-with-pyspark-extra, tests-with-external-pyspark, lint]
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -14,4 +14,4 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c # v4.3.0
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0

--- a/dataframe_expectations/core/pyspark_utils.py
+++ b/dataframe_expectations/core/pyspark_utils.py
@@ -1,6 +1,5 @@
 """Utilities for optional PySpark imports and runtime type checks."""
 
-import warnings
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Tuple
 
@@ -8,8 +7,6 @@ if TYPE_CHECKING:
     from pyspark.sql import DataFrame as PySparkDataFrame
 else:
     PySparkDataFrame = Any
-
-_pyspark_deprecation_warned = False
 
 
 class _MissingPySparkFunctions:
@@ -54,23 +51,7 @@ def _get_pyspark_dataframe_types() -> Tuple[type, ...]:
 
 def is_pyspark_data_frame(data_frame: Any) -> bool:
     """Return True when the input is a classic or connect PySpark DataFrame."""
-    global _pyspark_deprecation_warned
-
     data_frame_types = _get_pyspark_dataframe_types()
-    result = (data_frame_types and isinstance(data_frame, data_frame_types)) or (
+    return (data_frame_types and isinstance(data_frame, data_frame_types)) or (
         type(data_frame).__module__.startswith("pyspark.sql")
     )
-
-    if result and not _pyspark_deprecation_warned:
-        _pyspark_deprecation_warned = True
-        warnings.warn(
-            "In a future release, PySpark will be an optional dependency of dataframe-expectations. "
-            "To avoid breakage, either: "
-            "(1) install PySpark separately: pip install pyspark, "
-            "or (2) install dataframe-expectations with PySpark included: "
-            "pip install 'dataframe-expectations[pyspark]'.",
-            FutureWarning,
-            stacklevel=2,
-        )
-
-    return result

--- a/dataframe_expectations/expectations/aggregation/any_value.py
+++ b/dataframe_expectations/expectations/aggregation/any_value.py
@@ -20,6 +20,9 @@ from dataframe_expectations.result_message import (
     DataFrameExpectationSuccessMessage,
 )
 
+# F is a module-level proxy: returns real pyspark.sql.functions when pyspark is installed,
+# or _MissingPySparkFunctions otherwise. Lambdas capture F lazily, so no pyspark import
+# occurs at module load / test collection time.
 F = get_pyspark_functions()
 
 

--- a/dataframe_expectations/expectations/aggregation/numerical.py
+++ b/dataframe_expectations/expectations/aggregation/numerical.py
@@ -21,6 +21,9 @@ from dataframe_expectations.result_message import (
     DataFrameExpectationSuccessMessage,
 )
 
+# F is a module-level proxy: returns real pyspark.sql.functions when pyspark is installed,
+# or _MissingPySparkFunctions otherwise. Lambdas capture F lazily, so no pyspark import
+# occurs at module load / test collection time.
 F = get_pyspark_functions()
 
 

--- a/dataframe_expectations/expectations/aggregation/unique.py
+++ b/dataframe_expectations/expectations/aggregation/unique.py
@@ -20,6 +20,9 @@ from dataframe_expectations.result_message import (
     DataFrameExpectationSuccessMessage,
 )
 
+# F is a module-level proxy: returns real pyspark.sql.functions when pyspark is installed,
+# or _MissingPySparkFunctions otherwise. Lambdas capture F lazily, so no pyspark import
+# occurs at module load / test collection time.
 F = get_pyspark_functions()
 
 

--- a/dataframe_expectations/expectations/column/any_value.py
+++ b/dataframe_expectations/expectations/column/any_value.py
@@ -12,6 +12,9 @@ from dataframe_expectations.core.types import (
 from dataframe_expectations.registry import register_expectation
 from dataframe_expectations.core.utils import requires_params
 
+# F is a module-level proxy: returns real pyspark.sql.functions when pyspark is installed,
+# or _MissingPySparkFunctions otherwise. Lambdas capture F lazily, so no pyspark import
+# occurs at module load / test collection time.
 F = get_pyspark_functions()
 
 

--- a/dataframe_expectations/expectations/column/numerical.py
+++ b/dataframe_expectations/expectations/column/numerical.py
@@ -12,6 +12,9 @@ from dataframe_expectations.core.types import (
 from dataframe_expectations.registry import register_expectation
 from dataframe_expectations.core.utils import requires_params
 
+# F is a module-level proxy: returns real pyspark.sql.functions when pyspark is installed,
+# or _MissingPySparkFunctions otherwise. Lambdas capture F lazily, so no pyspark import
+# occurs at module load / test collection time.
 F = get_pyspark_functions()
 
 

--- a/dataframe_expectations/expectations/column/string.py
+++ b/dataframe_expectations/expectations/column/string.py
@@ -12,6 +12,9 @@ from dataframe_expectations.core.types import (
 from dataframe_expectations.registry import register_expectation
 from dataframe_expectations.core.utils import requires_params
 
+# F is a module-level proxy: returns real pyspark.sql.functions when pyspark is installed,
+# or _MissingPySparkFunctions otherwise. Lambdas capture F lazily, so no pyspark import
+# occurs at module load / test collection time.
 F = get_pyspark_functions()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,18 @@ authors = [
 dependencies = [
     "pandas>=1.5.0",
     "pydantic>=2.12.4",
-    "pyspark>=3.3.0",
     "tabulate>=0.8.9",
+]
+
+[project.optional-dependencies]
+pyspark = [
+    "pyspark>=3.3.0",
+]
+
+[tool.pytest.ini_options]
+markers = [
+    "pyspark: marks tests as requiring PySpark (deselect with '-m \"not pyspark\"')",
+    "pandas: marks tests as standard pandas logic"
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ pyspark = [
 ]
 
 [tool.pytest.ini_options]
+addopts = "--strict-markers"
 markers = [
     "pyspark: marks tests as requiring PySpark (deselect with '-m \"not pyspark\"')",
     "pandas: marks tests as standard pandas logic"

--- a/tests/base/test_result_message.py
+++ b/tests/base/test_result_message.py
@@ -43,6 +43,7 @@ def test_data_frame_to_str_pandas():
     )
 
 
+@pytest.mark.pyspark
 def test_dataframe_to_str_pyspark(spark):
     """
     Test the dataframe_to_str method with a mock PySpark DataFrame.

--- a/tests/base/test_suite.py
+++ b/tests/base/test_suite.py
@@ -68,7 +68,7 @@ def test_invalid_data_frame_type():
         runner.run(data_frame=data_Frame)
 
 
-def test_suite_with_supported_dataframe_types(spark):
+def test_suite_with_supported_dataframe_pandas():
     """
     Test the ExpectationsSuite with all supported DataFrame types.
     """
@@ -83,6 +83,16 @@ def test_suite_with_supported_dataframe_types(spark):
     assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
     assert result.success, "Expected success for pandas DataFrame"
     assert result.dataframe_type == DataFrameType.PANDAS
+
+
+@pytest.mark.pyspark
+def test_suite_with_supported_dataframe_pyspark(spark):
+    """
+    Test the ExpectationsSuite with all supported DataFrame types.
+    """
+
+    suite = DataFrameExpectationsSuite().expect_min_rows(min_rows=1)
+    runner = suite.build()
 
     # Test with PySpark DataFrame
     spark_df = spark.createDataFrame([(1,), (2,), (3,)], ["col1"])
@@ -118,6 +128,7 @@ def test_suite_with_unsupported_dataframe_types():
         )
 
 
+@pytest.mark.pyspark
 def test_suite_with_pyspark_connect_dataframe():
     """
     Test the ExpectationsSuite with PySpark Connect DataFrame (if available).

--- a/tests/base/test_suite_result.py
+++ b/tests/base/test_suite_result.py
@@ -297,6 +297,7 @@ def test_serialize_pandas_violations():
     assert sample[0] == {"col1": 1}
 
 
+@pytest.mark.pyspark
 def test_serialize_pyspark_violations(spark):
     """Test serializing PySpark DataFrame violations."""
     violations_df = spark.createDataFrame([(i,) for i in range(1, 11)], ["col1"])

--- a/tests/base/test_suite_with_tagging.py
+++ b/tests/base/test_suite_with_tagging.py
@@ -266,6 +266,7 @@ def test_result_applied_filters():
     assert result.tag_match_mode == "any"
 
 
+@pytest.mark.pyspark
 def test_pyspark_caching_enabled(spark):
     """Test that PySpark DataFrame is cached during execution."""
     suite = DataFrameExpectationsSuite()
@@ -288,6 +289,7 @@ def test_pyspark_caching_enabled(spark):
     assert not df.is_cached
 
 
+@pytest.mark.pyspark
 def test_pyspark_already_cached(spark):
     """Test behavior when PySpark DataFrame is already cached."""
     suite = DataFrameExpectationsSuite()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,12 @@
 import pytest
-from pyspark.sql import SparkSession
 import pandas as pd
 import pandas.testing as pdt
 
 
 @pytest.fixture(scope="module")
-def spark() -> SparkSession:
-    """create a spark session we can reuse for every test"""
+def spark():
+    """Create a Spark session reused for every test in the module."""
+    from pyspark.sql import SparkSession
 
     return SparkSession.builder.master("local").appName("Test").getOrCreate()
 

--- a/tests/core/test_column_expectations.py
+++ b/tests/core/test_column_expectations.py
@@ -50,6 +50,7 @@ def test_validate_for_pandas_df(expectation):
     )
 
 
+@pytest.mark.pyspark
 def test_validate_for_pyspark_df(expectation, spark):
     """
     Test whether row_validation() and get_filter_fn() methods are called with the right parameters for PySpark.

--- a/tests/core/test_expectations.py
+++ b/tests/core/test_expectations.py
@@ -82,6 +82,14 @@ class MockConnectDataFrame:
         pass
 
 
+class FakeDataFrame:
+    def count(self):
+        return 5
+
+    def collect(self):
+        return []
+
+
 def test_data_frame_type_enum():
     """
     Test that the DataFrameType enum has the correct values.
@@ -137,6 +145,7 @@ def test_validate_pandas_called():
         expectation.validate(None)
 
 
+@pytest.mark.pyspark
 def test_validate_pyspark_called(spark):
     """
     Test that validate_pyspark method is called with right parameters.
@@ -155,7 +164,7 @@ def test_validate_pyspark_called(spark):
         expectation.validate(None)
 
 
-def test_num_data_frame_rows(spark):
+def test_num_data_frame_rows_pandas():
     """
     Test that the number of rows in a DataFrame are counted correctly.
     """
@@ -167,11 +176,6 @@ def test_num_data_frame_rows(spark):
     num_rows = expectation.num_data_frame_rows(pandas_df)
     assert num_rows == 3, f"Expected 3 rows for pandas DataFrame but got: {num_rows}"
 
-    # Mock a PySpark DataFrame
-    spark_df = spark.createDataFrame([(1, "a"), (2, "b"), (3, "c")], ["col1", "col2"])
-    num_rows = expectation.num_data_frame_rows(spark_df)
-    assert num_rows == 3, f"Expected 3 rows for PySpark DataFrame but got: {num_rows}"
-
     # Test unsupported DataFrame type
     with pytest.raises(ValueError):
         expectation.num_data_frame_rows(None)
@@ -182,6 +186,29 @@ def test_num_data_frame_rows(spark):
     num_rows = expectation.num_data_frame_rows(empty_pandas_df)
     assert num_rows == 0, f"Expected 0 rows for empty pandas DataFrame but got: {num_rows}"
 
+    # Test unsupported DataFrame type
+    with pytest.raises(ValueError):
+        expectation.num_data_frame_rows(None)
+
+
+@pytest.mark.pyspark
+def test_num_data_frame_rows_pyspark(spark):
+    """
+    Test that the number of rows in a DataFrame are counted correctly.
+    """
+    expectation = MyTestExpectation()
+
+    # 1. Non empty DataFrames
+    # Mock a PySpark DataFrame
+    spark_df = spark.createDataFrame([(1, "a"), (2, "b"), (3, "c")], ["col1", "col2"])
+    num_rows = expectation.num_data_frame_rows(spark_df)
+    assert num_rows == 3, f"Expected 3 rows for PySpark DataFrame but got: {num_rows}"
+
+    # Test unsupported DataFrame type
+    with pytest.raises(ValueError):
+        expectation.num_data_frame_rows(None)
+
+    # 2. Empty DataFrames
     # Mock an empty PySpark DataFrame
     empty_spark_df = spark.createDataFrame([], "col1 INT, col2 STRING")
     num_rows = expectation.num_data_frame_rows(empty_spark_df)
@@ -192,7 +219,7 @@ def test_num_data_frame_rows(spark):
         expectation.num_data_frame_rows(None)
 
 
-def test_infer_data_frame_type(spark):
+def test_infer_data_frame_type_pandas():
     """
     Test that the DataFrame type is inferred correctly for all supported DataFrame types.
     """
@@ -205,18 +232,26 @@ def test_infer_data_frame_type(spark):
         f"Expected PANDAS type but got: {data_frame_type}"
     )
 
-    # Test PySpark DataFrame
-    spark_df = spark.createDataFrame([(1, "a"), (2, "b"), (3, "c")], ["col1", "col2"])
-    data_frame_type = expectation.infer_data_frame_type(spark_df)
-    assert data_frame_type == DataFrameType.PYSPARK, (
-        f"Expected PYSPARK type but got: {data_frame_type}"
-    )
-
     # Test empty pandas DataFrame
     empty_pandas_df = pd.DataFrame(columns=["col1", "col2"])
     data_frame_type = expectation.infer_data_frame_type(empty_pandas_df)
     assert data_frame_type == DataFrameType.PANDAS, (
         f"Expected PANDAS type for empty DataFrame but got: {data_frame_type}"
+    )
+
+
+@pytest.mark.pyspark
+def test_infer_data_frame_type_pyspark(spark):
+    """
+    Test that the DataFrame type is inferred correctly for all supported DataFrame types.
+    """
+    expectation = MyTestExpectation()
+
+    # Test PySpark DataFrame
+    spark_df = spark.createDataFrame([(1, "a"), (2, "b"), (3, "c")], ["col1", "col2"])
+    data_frame_type = expectation.infer_data_frame_type(spark_df)
+    assert data_frame_type == DataFrameType.PYSPARK, (
+        f"Expected PYSPARK type but got: {data_frame_type}"
     )
 
     # Test empty PySpark DataFrame
@@ -226,52 +261,29 @@ def test_infer_data_frame_type(spark):
         f"Expected PYSPARK type for empty DataFrame but got: {data_frame_type}"
     )
 
-    # Test unsupported DataFrame types
-    with pytest.raises(ValueError) as context:
-        expectation.infer_data_frame_type(None)
-    assert "Unsupported DataFrame type" in str(context.value), (
-        f"Expected 'Unsupported DataFrame type' in error message but got: {str(context.value)}"
-    )
 
-    with pytest.raises(ValueError) as context:
-        expectation.infer_data_frame_type("not_a_dataframe")
-    assert "Unsupported DataFrame type" in str(context.value), (
-        f"Expected 'Unsupported DataFrame type' in error message but got: {str(context.value)}"
-    )
-
-    with pytest.raises(ValueError) as context:
-        expectation.infer_data_frame_type([1, 2, 3])
-    assert "Unsupported DataFrame type" in str(context.value), (
-        f"Expected 'Unsupported DataFrame type' in error message but got: {str(context.value)}"
-    )
-
-    with pytest.raises(ValueError) as context:
-        expectation.infer_data_frame_type({"col1": [1, 2, 3]})
-    assert "Unsupported DataFrame type" in str(context.value), (
-        f"Expected 'Unsupported DataFrame type' in error message but got: {str(context.value)}"
-    )
-
-    # Test with objects that might have similar attributes but aren't DataFrames
-    class FakeDataFrame:
-        def count(self):
-            return 5
-
-        def collect(self):
-            return []
-
-    fake_df = FakeDataFrame()
-    with pytest.raises(ValueError):
-        expectation.infer_data_frame_type(fake_df)
-
-    # Test with numeric types
-    with pytest.raises(ValueError):
-        expectation.infer_data_frame_type(42)
-
-    # Test with boolean
-    with pytest.raises(ValueError):
-        expectation.infer_data_frame_type(True)
+@pytest.mark.parametrize(
+    "invalid_input",
+    [
+        None,
+        "not_a_dataframe",
+        [1, 2, 3],
+        {"col1": [1, 2, 3]},
+        FakeDataFrame(),
+        42,
+        True,
+    ],
+)
+def test_infer_data_frame_type_invalid(invalid_input):
+    """
+    Test that the DataFrame type is inferred correctly for all supported DataFrame types.
+    """
+    expectation = MyTestExpectation()
+    with pytest.raises(ValueError, match="Unsupported DataFrame type"):
+        expectation.infer_data_frame_type(invalid_input)
 
 
+@pytest.mark.pyspark
 def test_infer_data_frame_type_with_connect_dataframe_available():
     """
     Test that PySpark Connect DataFrame is correctly identified when available.
@@ -294,7 +306,7 @@ def test_infer_data_frame_type_with_connect_dataframe_available():
 
 
 @patch("dataframe_expectations.core.expectation.PySparkConnectDataFrame", None)
-def test_infer_data_frame_type_without_connect_support(spark):
+def test_infer_data_frame_type_without_connect_support_pandas():
     """
     Test that the method works correctly when PySpark Connect is not available.
     """
@@ -307,6 +319,16 @@ def test_infer_data_frame_type_without_connect_support(spark):
         f"Expected PANDAS type but got: {data_frame_type}"
     )
 
+
+@pytest.mark.pyspark
+@patch("dataframe_expectations.core.expectation.PySparkConnectDataFrame", None)
+def test_infer_data_frame_type_without_connect_support_pyspark(spark):
+    """
+    Test that the method works correctly when PySpark Connect is not available.
+    """
+    expectation = MyTestExpectation()
+
+    # Test that regular DataFrames still work when Connect is not available
     spark_df = spark.createDataFrame([(1,), (2,), (3,)], ["col1"])
     data_frame_type = expectation.infer_data_frame_type(spark_df)
     assert data_frame_type == DataFrameType.PYSPARK, (
@@ -314,7 +336,7 @@ def test_infer_data_frame_type_without_connect_support(spark):
     )
 
 
-def test_infer_data_frame_type_connect_import_behavior(spark):
+def test_infer_data_frame_type_connect_import_behavior_pandas():
     """
     Test that the Connect DataFrame import behavior works as expected.
     """
@@ -327,10 +349,6 @@ def test_infer_data_frame_type_connect_import_behavior(spark):
         result_type = expectation.infer_data_frame_type(pandas_df)
         assert result_type == DataFrameType.PANDAS, f"Expected PANDAS type but got: {result_type}"
 
-        spark_df = spark.createDataFrame([(1,), (2,), (3,)], ["col1"])
-        result_type = expectation.infer_data_frame_type(spark_df)
-        assert result_type == DataFrameType.PYSPARK, f"Expected PYSPARK type but got: {result_type}"
-
     # Test case 2: When PySparkConnectDataFrame is available (mocked)
     with patch(
         "dataframe_expectations.core.expectation.PySparkConnectDataFrame",
@@ -341,6 +359,34 @@ def test_infer_data_frame_type_connect_import_behavior(spark):
         result_type = expectation.infer_data_frame_type(pandas_df)
         assert result_type == DataFrameType.PANDAS, f"Expected PANDAS type but got: {result_type}"
 
+        # Mock Connect DataFrame should be identified as PYSPARK
+        mock_connect_df = MockConnectDataFrame()
+        result_type = expectation.infer_data_frame_type(mock_connect_df)
+        assert result_type == DataFrameType.PYSPARK, (
+            f"Expected PYSPARK type for Connect DataFrame but got: {result_type}"
+        )
+
+
+@pytest.mark.pyspark
+def test_infer_data_frame_type_connect_import_behavior_pyspark(spark):
+    """
+    Test that the Connect DataFrame import behavior works as expected.
+    """
+    expectation = MyTestExpectation()
+
+    # Test case 1: When PySparkConnectDataFrame is None (import failed)
+    with patch("dataframe_expectations.core.expectation.PySparkConnectDataFrame", None):
+        # Should still work with regular DataFrames
+        spark_df = spark.createDataFrame([(1,), (2,), (3,)], ["col1"])
+        result_type = expectation.infer_data_frame_type(spark_df)
+        assert result_type == DataFrameType.PYSPARK, f"Expected PYSPARK type but got: {result_type}"
+
+    # Test case 2: When PySparkConnectDataFrame is available (mocked)
+    with patch(
+        "dataframe_expectations.core.expectation.PySparkConnectDataFrame",
+        MockConnectDataFrame,
+    ):
+        # Regular DataFrames should still work
         spark_df = spark.createDataFrame([(1,), (2,), (3,)], ["col1"])
         result_type = expectation.infer_data_frame_type(spark_df)
         assert result_type == DataFrameType.PYSPARK, f"Expected PYSPARK type but got: {result_type}"

--- a/tests/core/test_pyspark_utils.py
+++ b/tests/core/test_pyspark_utils.py
@@ -1,9 +1,6 @@
-import warnings
-
 import pytest
 from unittest.mock import patch
 
-from dataframe_expectations.core import pyspark_utils
 from dataframe_expectations.core.pyspark_utils import (
     get_pyspark_functions,
     is_pyspark_data_frame,
@@ -15,6 +12,7 @@ from dataframe_expectations.core.pyspark_utils import (
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.pyspark
 def test_get_pyspark_functions_returns_real_functions_when_pyspark_present():
     """When pyspark is installed, the real functions module is returned."""
     # lru_cache may already hold the result from a previous test run, so clear it.
@@ -55,6 +53,7 @@ def test_is_pyspark_data_frame_returns_false_for_non_spark_objects():
     assert is_pyspark_data_frame(None) is False
 
 
+@pytest.mark.pyspark
 def test_is_pyspark_data_frame_returns_true_for_pyspark_df(spark):
     spark_df = spark.createDataFrame([(1,)], ["col1"])
     assert is_pyspark_data_frame(spark_df) is True
@@ -70,45 +69,3 @@ def test_is_pyspark_data_frame_returns_true_for_module_name_fallback():
 
     obj = FakeRuntimeSparkDataFrame()
     assert is_pyspark_data_frame(obj) is True
-
-
-# ---------------------------------------------------------------------------
-# FutureWarning
-# ---------------------------------------------------------------------------
-
-
-def test_is_pyspark_data_frame_emits_future_warning_for_pyspark_df(spark):
-    """A FutureWarning is emitted the first time a PySpark DataFrame is detected."""
-    # Reset the module-level flag so the warning fires fresh.
-    pyspark_utils._pyspark_deprecation_warned = False
-
-    spark_df = spark.createDataFrame([(1,)], ["col1"])
-
-    with pytest.warns(FutureWarning, match="optional dependency"):
-        is_pyspark_data_frame(spark_df)
-
-
-def test_is_pyspark_data_frame_warning_fires_only_once(spark):
-    """The FutureWarning fires at most once per process (guarded by the module flag)."""
-    pyspark_utils._pyspark_deprecation_warned = False
-
-    spark_df = spark.createDataFrame([(1,)], ["col1"])
-
-    with pytest.warns(FutureWarning):
-        is_pyspark_data_frame(spark_df)
-
-    # Second call should produce no warning.
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # any warning would raise
-        is_pyspark_data_frame(spark_df)  # must not raise
-
-
-def test_is_pyspark_data_frame_no_warning_for_pandas():
-    """No FutureWarning is emitted when the DataFrame is a Pandas DataFrame."""
-    import pandas as pd
-
-    pyspark_utils._pyspark_deprecation_warned = False
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # any warning would raise
-        is_pyspark_data_frame(pd.DataFrame())  # must not raise

--- a/tests/expectations/aggregation/any_value_expectations/test_expect_distinct_column_values_between.py
+++ b/tests/expectations/aggregation/any_value_expectations/test_expect_distinct_column_values_between.py
@@ -17,10 +17,9 @@ from dataframe_expectations.result_message import (
 
 
 def create_pyspark_dataframe(data, column_name, spark, data_type="long"):
-    """Helper function to create pandas or pyspark DataFrame.
+    """Helper function to create a PySpark DataFrame.
 
     Args:
-        df_type: "pandas" or "pyspark"
         data: List of values for the column
         column_name: Name of the column
         spark: Spark session (required for pyspark)

--- a/tests/expectations/aggregation/any_value_expectations/test_expect_distinct_column_values_between.py
+++ b/tests/expectations/aggregation/any_value_expectations/test_expect_distinct_column_values_between.py
@@ -8,15 +8,15 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark, data_type="long"):
+def create_pyspark_dataframe(data, column_name, spark, data_type="long"):
     """Helper function to create pandas or pyspark DataFrame.
 
     Args:
@@ -26,30 +26,27 @@ def create_dataframe(df_type, data, column_name, spark, data_type="long"):
         spark: Spark session (required for pyspark)
         data_type: Data type for the column - "long", "string", "double", "boolean", "timestamp"
     """
-    if df_type == "pandas":
-        return pd.DataFrame(data, columns=[column_name])
-    else:  # pyspark
-        # Use explicit schema for all PySpark DataFrames
-        from pyspark.sql.types import (
-            StructType,
-            StructField,
-            LongType,
-            StringType,
-            DoubleType,
-            BooleanType,
-            TimestampType,
-        )
+    # Use explicit schema for all PySpark DataFrames
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        LongType,
+        StringType,
+        DoubleType,
+        BooleanType,
+        TimestampType,
+    )
 
-        type_mapping = {
-            "long": LongType(),
-            "string": StringType(),
-            "double": DoubleType(),
-            "boolean": BooleanType(),
-            "timestamp": TimestampType(),
-        }
+    type_mapping = {
+        "long": LongType(),
+        "string": StringType(),
+        "double": DoubleType(),
+        "boolean": BooleanType(),
+        "timestamp": TimestampType(),
+    }
 
-        schema = StructType([StructField(column_name, type_mapping[data_type], True)])
-        return spark.createDataFrame([(val,) for val in data], schema)
+    schema = StructType([StructField(column_name, type_mapping[data_type], True)])
+    return spark.createDataFrame([(val,) for val in data], schema)
 
 
 def test_expectation_name():
@@ -72,19 +69,14 @@ def test_expectation_name():
     [
         # Basic success - 3 distinct values within range [2, 5]
         ("pandas", [1, 2, 3, 2, 1], 2, 5, "success", None, "long"),
-        ("pyspark", [1, 2, 3, 2, 1], 2, 5, "success", None, "long"),
         # Success with nulls - 3 distinct values [1, 2, None] within range [3, 4]
         ("pandas", [1, 2, None, 2, 1], 3, 4, "success", None, "long"),
-        ("pyspark", [1, 2, None, 2, 1], 3, 4, "success", None, "long"),
         # Exact minimum boundary - 3 distinct values at min boundary [3, 5]
         ("pandas", [1, 2, 3, 2, 1], 3, 5, "success", None, "long"),
-        ("pyspark", [1, 2, 3, 2, 1], 3, 5, "success", None, "long"),
         # Exact maximum boundary - 5 distinct values at max boundary [3, 5]
         ("pandas", [1, 2, 3, 4, 5, 1], 3, 5, "success", None, "long"),
-        ("pyspark", [1, 2, 3, 4, 5, 1], 3, 5, "success", None, "long"),
         # Edge case: zero range (min == max) - success with exact match
         ("pandas", [1, 2, 3, 2, 1], 3, 3, "success", None, "long"),
-        ("pyspark", [1, 2, 3, 2, 1], 3, 3, "success", None, "long"),
         # Edge case: zero range (min == max) - failure when not exact
         (
             "pandas",
@@ -95,33 +87,13 @@ def test_expectation_name():
             "Column 'col1' has 2 distinct values, expected between 3 and 3.",
             "long",
         ),
-        (
-            "pyspark",
-            [1, 2, 1, 2, 1],
-            3,
-            3,
-            "failure",
-            "Column 'col1' has 2 distinct values, expected between 3 and 3.",
-            "long",
-        ),
         # Edge case: empty DataFrame - 0 distinct values within range [0, 5]
         ("pandas", [], 0, 5, "success", None, "long"),
-        ("pyspark", [], 0, 5, "success", None, "long"),
         # Edge case: single distinct value - 1 distinct value within range [1, 1]
         ("pandas", [1, 1, 1, 1, 1], 1, 1, "success", None, "long"),
-        ("pyspark", [1, 1, 1, 1, 1], 1, 1, "success", None, "long"),
         # Too few distinct values - 2 distinct, expecting [4, 6]
         (
             "pandas",
-            [1, 2, 1, 2, 1],
-            4,
-            6,
-            "failure",
-            "Column 'col1' has 2 distinct values, expected between 4 and 6.",
-            "long",
-        ),
-        (
-            "pyspark",
             [1, 2, 1, 2, 1],
             4,
             6,
@@ -139,25 +111,13 @@ def test_expectation_name():
             "Column 'col1' has 5 distinct values, expected between 2 and 3.",
             "long",
         ),
-        (
-            "pyspark",
-            [1, 2, 3, 4, 5],
-            2,
-            3,
-            "failure",
-            "Column 'col1' has 5 distinct values, expected between 2 and 3.",
-            "long",
-        ),
         # Data type validation scenarios (consolidated from test_data_type_validation)
         # String column with mixed values including None
         ("pandas", ["A", "B", "C", "B", "A", None], 3, 5, "success", None, "string"),
-        ("pyspark", ["A", "B", "C", "B", "A", None], 3, 5, "success", None, "string"),
         # Float column
         ("pandas", [1.1, 2.2, 3.3, 2.2, 1.1], 2, 4, "success", None, "double"),
-        ("pyspark", [1.1, 2.2, 3.3, 2.2, 1.1], 2, 4, "success", None, "double"),
         # Boolean column
         ("pandas", [True, False, True, False, True], 2, 2, "success", None, "boolean"),
-        ("pyspark", [True, False, True, False, True], 2, 2, "success", None, "boolean"),
         # Datetime column - pandas with pd.to_datetime
         (
             "pandas",
@@ -168,81 +128,47 @@ def test_expectation_name():
             None,
             "timestamp",
         ),
-        # Datetime column - pyspark with datetime objects
-        (
-            "pyspark",
-            pd.to_datetime(
-                ["2023-01-01", "2023-01-02", "2023-01-03", "2023-01-02", "2023-01-01"]
-            ).to_pydatetime(),
-            2,
-            4,
-            "success",
-            None,
-            "timestamp",
-        ),
         # Negative integers
         ("pandas", [-10, -20, -30, -20, -10], 2, 4, "success", None, "long"),
-        ("pyspark", [-10, -20, -30, -20, -10], 2, 4, "success", None, "long"),
         # Mixed positive and negative integers
         ("pandas", [-1, 0, 1, 0, -1], 2, 4, "success", None, "long"),
-        ("pyspark", [-1, 0, 1, 0, -1], 2, 4, "success", None, "long"),
         # Large integers
         ("pandas", [1000000, 2000000, 3000000, 2000000, 1000000], 2, 4, "success", None, "long"),
-        ("pyspark", [1000000, 2000000, 3000000, 2000000, 1000000], 2, 4, "success", None, "long"),
         # All null values
         ("pandas", [None, None, None, None], 0, 1, "success", None, "long"),
-        ("pyspark", [None, None, None, None], 0, 1, "success", None, "long"),
     ],
     ids=[
         "pandas_success",
-        "pyspark_success",
         "pandas_success_with_nulls",
-        "pyspark_success_with_nulls",
         "pandas_exact_min_boundary",
-        "pyspark_exact_min_boundary",
         "pandas_exact_max_boundary",
-        "pyspark_exact_max_boundary",
         "pandas_zero_range_success",
-        "pyspark_zero_range_success",
         "pandas_zero_range_failure",
-        "pyspark_zero_range_failure",
         "pandas_empty_dataframe",
-        "pyspark_empty_dataframe",
         "pandas_single_value",
-        "pyspark_single_value",
         "pandas_too_few",
-        "pyspark_too_few",
         "pandas_too_many",
-        "pyspark_too_many",
         "pandas_string_with_nulls",
-        "pyspark_string_with_nulls",
         "pandas_float",
-        "pyspark_float",
         "pandas_boolean",
-        "pyspark_boolean",
         "pandas_datetime",
-        "pyspark_datetime",
         "pandas_negative_integers",
-        "pyspark_negative_integers",
         "pandas_mixed_positive_negative",
-        "pyspark_mixed_positive_negative",
         "pandas_large_integers",
-        "pyspark_large_integers",
         "pandas_all_nulls",
-        "pyspark_all_nulls",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, df_data, min_value, max_value, expected_result, expected_message, data_type, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, df_data, min_value, max_value, expected_result, expected_message, data_type
 ):
     """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
+    Test the expectation for various scenarios across pandas DataFrames.
     Tests both direct expectation validation and suite-based validation.
     Covers: success cases, success with nulls, exact boundaries, edge cases (zero range, empty, single value),
     too few values, too many values, and various data types (string, float, boolean, datetime, negative integers,
     mixed positive/negative integers, large integers, all nulls).
     """
-    data_frame = create_dataframe(df_type, df_data, "col1", spark, data_type)
+    data_frame = pd.DataFrame(df_data, columns=["col1"])
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -287,12 +213,159 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
+@pytest.mark.pyspark
 @pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
+    "df_type, df_data, min_value, max_value, expected_result, expected_message, data_type",
+    [
+        # Basic success - 3 distinct values within range [2, 5]
+        ("pyspark", [1, 2, 3, 2, 1], 2, 5, "success", None, "long"),
+        # Success with nulls - 3 distinct values [1, 2, None] within range [3, 4]
+        ("pyspark", [1, 2, None, 2, 1], 3, 4, "success", None, "long"),
+        # Exact minimum boundary - 3 distinct values at min boundary [3, 5]
+        ("pyspark", [1, 2, 3, 2, 1], 3, 5, "success", None, "long"),
+        # Exact maximum boundary - 5 distinct values at max boundary [3, 5]
+        ("pyspark", [1, 2, 3, 4, 5, 1], 3, 5, "success", None, "long"),
+        # Edge case: zero range (min == max) - success with exact match
+        ("pyspark", [1, 2, 3, 2, 1], 3, 3, "success", None, "long"),
+        # Edge case: zero range (min == max) - failure when not exact
+        (
+            "pyspark",
+            [1, 2, 1, 2, 1],
+            3,
+            3,
+            "failure",
+            "Column 'col1' has 2 distinct values, expected between 3 and 3.",
+            "long",
+        ),
+        # Edge case: empty DataFrame - 0 distinct values within range [0, 5]
+        ("pyspark", [], 0, 5, "success", None, "long"),
+        # Edge case: single distinct value - 1 distinct value within range [1, 1]
+        ("pyspark", [1, 1, 1, 1, 1], 1, 1, "success", None, "long"),
+        # Too few distinct values - 2 distinct, expecting [4, 6]
+        (
+            "pyspark",
+            [1, 2, 1, 2, 1],
+            4,
+            6,
+            "failure",
+            "Column 'col1' has 2 distinct values, expected between 4 and 6.",
+            "long",
+        ),
+        # Too many distinct values - 5 distinct, expecting [2, 3]
+        (
+            "pyspark",
+            [1, 2, 3, 4, 5],
+            2,
+            3,
+            "failure",
+            "Column 'col1' has 5 distinct values, expected between 2 and 3.",
+            "long",
+        ),
+        # Data type validation scenarios (consolidated from test_data_type_validation)
+        # String column with mixed values including None
+        ("pyspark", ["A", "B", "C", "B", "A", None], 3, 5, "success", None, "string"),
+        # Float column
+        ("pyspark", [1.1, 2.2, 3.3, 2.2, 1.1], 2, 4, "success", None, "double"),
+        # Boolean column
+        ("pyspark", [True, False, True, False, True], 2, 2, "success", None, "boolean"),
+        # Datetime column - pyspark with datetime objects
+        (
+            "pyspark",
+            pd.to_datetime(
+                ["2023-01-01", "2023-01-02", "2023-01-03", "2023-01-02", "2023-01-01"]
+            ).to_pydatetime(),
+            2,
+            4,
+            "success",
+            None,
+            "timestamp",
+        ),
+        # Negative integers
+        ("pyspark", [-10, -20, -30, -20, -10], 2, 4, "success", None, "long"),
+        # Mixed positive and negative integers
+        ("pyspark", [-1, 0, 1, 0, -1], 2, 4, "success", None, "long"),
+        # Large integers
+        ("pyspark", [1000000, 2000000, 3000000, 2000000, 1000000], 2, 4, "success", None, "long"),
+        # All null values
+        ("pyspark", [None, None, None, None], 0, 1, "success", None, "long"),
+    ],
+    ids=[
+        "pyspark_success",
+        "pyspark_success_with_nulls",
+        "pyspark_exact_min_boundary",
+        "pyspark_exact_max_boundary",
+        "pyspark_zero_range_success",
+        "pyspark_zero_range_failure",
+        "pyspark_empty_dataframe",
+        "pyspark_single_value",
+        "pyspark_too_few",
+        "pyspark_too_many",
+        "pyspark_string_with_nulls",
+        "pyspark_float",
+        "pyspark_boolean",
+        "pyspark_datetime",
+        "pyspark_negative_integers",
+        "pyspark_mixed_positive_negative",
+        "pyspark_large_integers",
+        "pyspark_all_nulls",
+    ],
 )
-def test_column_missing_error(df_type, spark):
+def test_expectation_basic_scenarios_pyspark(
+    df_type, df_data, min_value, max_value, expected_result, expected_message, data_type, spark
+):
+    """
+    Test the expectation for various scenarios across pandas and PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases, success with nulls, exact boundaries, edge cases (zero range, empty, single value),
+    too few values, too many values, and various data types (string, float, boolean, datetime, negative integers,
+    mixed positive/negative integers, large integers, all nulls).
+    """
+    data_frame = create_pyspark_dataframe(df_data, "col1", spark, data_type)
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationDistinctColumnValuesBetween",
+        column_name="col1",
+        min_value=min_value,
+        max_value=max_value,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(
+                expectation_name="ExpectationDistinctColumnValuesBetween"
+            )
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            message=expected_message,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_distinct_column_values_between(
+        column_name="col1", min_value=min_value, max_value=max_value
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+def test_column_missing_error_pandas():
     """
     Test that an error is raised when the specified column is missing in both pandas and PySpark.
     Tests both direct expectation validation and suite-based validation.
@@ -305,12 +378,43 @@ def test_column_missing_error(df_type, spark):
         max_value=5,
     )
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col2": [1, 2, 3, 4, 5]})
-        df_type_enum = DataFrameType.PANDAS
-    else:  # pyspark
-        data_frame = spark.createDataFrame([(1,), (2,), (3,), (4,), (5,)], ["col2"])
-        df_type_enum = DataFrameType.PYSPARK
+    data_frame = pd.DataFrame({"col2": [1, 2, 3, 4, 5]})
+    df_type_enum = DataFrameType.PANDAS
+
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure_message = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type=df_type_enum,
+        message="Column 'col1' does not exist in the DataFrame.",
+    )
+    assert str(result) == str(expected_failure_message), (
+        f"Expected failure message but got: {result}"
+    )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_distinct_column_values_between(
+        column_name="col1", min_value=2, max_value=5
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """
+    Test that an error is raised when the specified column is missing in both pandas and PySpark.
+    Tests both direct expectation validation and suite-based validation.
+    """
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationDistinctColumnValuesBetween",
+        column_name="col1",
+        min_value=2,
+        max_value=5,
+    )
+
+    data_frame = spark.createDataFrame([(1,), (2,), (3,), (4,), (5,)], ["col2"])
+    df_type_enum = DataFrameType.PYSPARK
 
     result = expectation.validate(data_frame=data_frame)
     expected_failure_message = DataFrameExpectationFailureMessage(

--- a/tests/expectations/aggregation/any_value_expectations/test_expect_distinct_column_values_equals.py
+++ b/tests/expectations/aggregation/any_value_expectations/test_expect_distinct_column_values_equals.py
@@ -9,15 +9,15 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark, data_type="long"):
+def create_pyspark_dataframe(data, column_name, spark, data_type="long"):
     """Helper function to create pandas or pyspark DataFrame.
 
     Args:
@@ -27,30 +27,28 @@ def create_dataframe(df_type, data, column_name, spark, data_type="long"):
         spark: Spark session (required for pyspark)
         data_type: Data type for the column - "long", "string", "double", "boolean", "timestamp"
     """
-    if df_type == "pandas":
-        return pd.DataFrame(data, columns=[column_name])
-    else:  # pyspark
-        # Use explicit schema for all PySpark DataFrames
-        from pyspark.sql.types import (
-            StructType,
-            StructField,
-            LongType,
-            StringType,
-            DoubleType,
-            BooleanType,
-            TimestampType,
-        )
 
-        type_mapping = {
-            "long": LongType(),
-            "string": StringType(),
-            "double": DoubleType(),
-            "boolean": BooleanType(),
-            "timestamp": TimestampType(),
-        }
+    # Use explicit schema for all PySpark DataFrames
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        LongType,
+        StringType,
+        DoubleType,
+        BooleanType,
+        TimestampType,
+    )
 
-        schema = StructType([StructField(column_name, type_mapping[data_type], True)])
-        return spark.createDataFrame([(val,) for val in data], schema)
+    type_mapping = {
+        "long": LongType(),
+        "string": StringType(),
+        "double": DoubleType(),
+        "boolean": BooleanType(),
+        "timestamp": TimestampType(),
+    }
+
+    schema = StructType([StructField(column_name, type_mapping[data_type], True)])
+    return spark.createDataFrame([(val,) for val in data], schema)
 
 
 def test_expectation_name():
@@ -72,21 +70,11 @@ def test_expectation_name():
     [
         # Basic success - 3 distinct values
         ("pandas", [1, 2, 3, 2, 1], 3, "success", None, "long"),
-        ("pyspark", [1, 2, 3, 2, 1], 3, "success", None, "long"),
         # Success with nulls - 3 distinct values [1, 2, None]
         ("pandas", [1, 2, None, 2, 1], 3, "success", None, "long"),
-        ("pyspark", [1, 2, None, 2, 1], 3, "success", None, "long"),
         # Too few distinct values - 2 distinct, expecting 5
         (
             "pandas",
-            [1, 2, 1, 2, 1],
-            5,
-            "failure",
-            "Column 'col1' has 2 distinct values, expected exactly 5.",
-            "long",
-        ),
-        (
-            "pyspark",
             [1, 2, 1, 2, 1],
             5,
             "failure",
@@ -102,38 +90,22 @@ def test_expectation_name():
             "Column 'col1' has 5 distinct values, expected exactly 2.",
             "long",
         ),
-        (
-            "pyspark",
-            [1, 2, 3, 4, 5],
-            2,
-            "failure",
-            "Column 'col1' has 5 distinct values, expected exactly 2.",
-            "long",
-        ),
         # Edge case: empty DataFrame - 0 distinct values
         ("pandas", [], 0, "success", None, "long"),
-        ("pyspark", [], 0, "success", None, "long"),
         # Edge case: single distinct value - 1 distinct value
         ("pandas", [5, 5, 5, 5, 5], 1, "success", None, "long"),
-        ("pyspark", [5, 5, 5, 5, 5], 1, "success", None, "long"),
         # String column with mixed values including None
         ("pandas", ["A", "B", "C", "B", "A", None], 4, "success", None, "string"),
-        ("pyspark", ["A", "B", "C", "B", "A", None], 4, "success", None, "string"),
         # String case-sensitive - 4 distinct values ["a", "A", "b", "B"]
         ("pandas", ["a", "A", "b", "B", "a", "A"], 4, "success", None, "string"),
-        ("pyspark", ["a", "A", "b", "B", "a", "A"], 4, "success", None, "string"),
         # Float column - 3 distinct values
         ("pandas", [1.1, 2.2, 3.3, 2.2, 1.1], 3, "success", None, "double"),
-        ("pyspark", [1.1, 2.2, 3.3, 2.2, 1.1], 3, "success", None, "double"),
         # Numeric precision - 3 distinct values
         ("pandas", [1.0, 1.1, 1.2, 1.0, 1.1], 3, "success", None, "double"),
-        ("pyspark", [1.0, 1.1, 1.2, 1.0, 1.1], 3, "success", None, "double"),
         # Boolean column - 2 distinct values
         ("pandas", [True, False, True, False, True], 2, "success", None, "boolean"),
-        ("pyspark", [True, False, True, False, True], 2, "success", None, "boolean"),
         # Boolean with None - 3 distinct values
         ("pandas", [True, False, None, False, True], 3, "success", None, "boolean"),
-        ("pyspark", [True, False, None, False, True], 3, "success", None, "boolean"),
         # Datetime column - 3 distinct values using datetime objects
         (
             "pandas",
@@ -149,36 +121,9 @@ def test_expectation_name():
             None,
             "timestamp",
         ),
-        (
-            "pyspark",
-            [
-                datetime(2023, 1, 1),
-                datetime(2023, 1, 2),
-                datetime(2023, 1, 3),
-                datetime(2023, 1, 2),
-                datetime(2023, 1, 1),
-            ],
-            3,
-            "success",
-            None,
-            "timestamp",
-        ),
-        # Datetime with timezone - 2 distinct values (use different actual timestamps)
+        # Datetime with timezone - 2 distinct values
         (
             "pandas",
-            [
-                datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
-                datetime(2023, 1, 2, 12, 0, 0, tzinfo=timezone.utc),
-                datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
-                datetime(2023, 1, 2, 12, 0, 0, tzinfo=timezone.utc),
-            ],
-            2,
-            "success",
-            None,
-            "timestamp",
-        ),
-        (
-            "pyspark",
             [
                 datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
                 datetime(2023, 1, 2, 12, 0, 0, tzinfo=timezone.utc),
@@ -203,65 +148,46 @@ def test_expectation_name():
         ),
         # Multiple NaN values counted as one - 3 distinct values
         ("pandas", [1, 2, None, None, None, 1, 2], 3, "success", None, "long"),
-        ("pyspark", [1, 2, None, None, None, 1, 2], 3, "success", None, "long"),
         # Strings with different whitespace - 4 distinct values
         ("pandas", ["test", " test", "test ", " test ", "test"], 4, "success", None, "string"),
-        ("pyspark", ["test", " test", "test ", " test ", "test"], 4, "success", None, "string"),
         # Numeric strings vs numeric values - 2 distinct values (pandas only - object dtype)
         ("pandas", ["1", 1, "1", 1], 2, "success", None, "object"),
     ],
     ids=[
         "pandas_success",
-        "pyspark_success",
         "pandas_success_with_nulls",
-        "pyspark_success_with_nulls",
         "pandas_too_few",
-        "pyspark_too_few",
         "pandas_too_many",
-        "pyspark_too_many",
         "pandas_empty",
-        "pyspark_empty",
         "pandas_single_value",
-        "pyspark_single_value",
         "pandas_string_with_nulls",
-        "pyspark_string_with_nulls",
         "pandas_string_case_sensitive",
-        "pyspark_string_case_sensitive",
         "pandas_float",
-        "pyspark_float",
         "pandas_numeric_precision",
-        "pyspark_numeric_precision",
         "pandas_boolean",
-        "pyspark_boolean",
         "pandas_boolean_with_none",
-        "pyspark_boolean_with_none",
         "pandas_datetime",
-        "pyspark_datetime",
         "pandas_datetime_with_timezone",
-        "pyspark_datetime_with_timezone",
         "pandas_mixed_data_types",
         "pandas_categorical",
         "pandas_duplicate_nan_handling",
-        "pyspark_duplicate_nan_handling",
         "pandas_string_whitespace",
-        "pyspark_string_whitespace",
         "pandas_numeric_string_vs_numeric",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, df_data, expected_value, expected_result, expected_message, data_type, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, df_data, expected_value, expected_result, expected_message, data_type
 ):
     """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
+    Test the expectation for various scenarios across pandas DataFrames.
     Tests both direct expectation validation and suite-based validation.
     Covers: success cases, success with nulls, edge cases (empty, single value), too few values, too many values,
     and various data types (strings, floats, booleans, datetimes, categorical, mixed types).
     """
-    # Special handling for numeric_string_vs_numeric test - needs object dtype
     if data_type == "object":
         data_frame = pd.DataFrame({"col1": df_data}, dtype=object)
     else:
-        data_frame = create_dataframe(df_type, df_data, "col1", spark, data_type)
+        data_frame = pd.DataFrame(df_data, columns=["col1"])
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -305,14 +231,157 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
+@pytest.mark.pyspark
 @pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
+    "df_type, df_data, expected_value, expected_result, expected_message, data_type",
+    [
+        # Basic success - 3 distinct values
+        ("pyspark", [1, 2, 3, 2, 1], 3, "success", None, "long"),
+        # Success with nulls - 3 distinct values [1, 2, None]
+        ("pyspark", [1, 2, None, 2, 1], 3, "success", None, "long"),
+        # Too few distinct values - 2 distinct, expecting 5
+        (
+            "pyspark",
+            [1, 2, 1, 2, 1],
+            5,
+            "failure",
+            "Column 'col1' has 2 distinct values, expected exactly 5.",
+            "long",
+        ),
+        # Too many distinct values - 5 distinct, expecting 2
+        (
+            "pyspark",
+            [1, 2, 3, 4, 5],
+            2,
+            "failure",
+            "Column 'col1' has 5 distinct values, expected exactly 2.",
+            "long",
+        ),
+        # Edge case: empty DataFrame - 0 distinct values
+        ("pyspark", [], 0, "success", None, "long"),
+        # Edge case: single distinct value - 1 distinct value
+        ("pyspark", [5, 5, 5, 5, 5], 1, "success", None, "long"),
+        # String column with mixed values including None
+        ("pyspark", ["A", "B", "C", "B", "A", None], 4, "success", None, "string"),
+        # String case-sensitive - 4 distinct values ["a", "A", "b", "B"]
+        ("pyspark", ["a", "A", "b", "B", "a", "A"], 4, "success", None, "string"),
+        # Float column - 3 distinct values
+        ("pyspark", [1.1, 2.2, 3.3, 2.2, 1.1], 3, "success", None, "double"),
+        # Numeric precision - 3 distinct values
+        ("pyspark", [1.0, 1.1, 1.2, 1.0, 1.1], 3, "success", None, "double"),
+        # Boolean column - 2 distinct values
+        ("pyspark", [True, False, True, False, True], 2, "success", None, "boolean"),
+        # Boolean with None - 3 distinct values
+        ("pyspark", [True, False, None, False, True], 3, "success", None, "boolean"),
+        # Datetime column - 3 distinct values using datetime objects
+        (
+            "pyspark",
+            [
+                datetime(2023, 1, 1),
+                datetime(2023, 1, 2),
+                datetime(2023, 1, 3),
+                datetime(2023, 1, 2),
+                datetime(2023, 1, 1),
+            ],
+            3,
+            "success",
+            None,
+            "timestamp",
+        ),
+        # Datetime with timezone - 2 distinct values
+        (
+            "pyspark",
+            [
+                datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+                datetime(2023, 1, 2, 12, 0, 0, tzinfo=timezone.utc),
+                datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+                datetime(2023, 1, 2, 12, 0, 0, tzinfo=timezone.utc),
+            ],
+            2,
+            "success",
+            None,
+            "timestamp",
+        ),
+        # Multiple NaN values counted as one - 3 distinct values
+        ("pyspark", [1, 2, None, None, None, 1, 2], 3, "success", None, "long"),
+        # Strings with different whitespace - 4 distinct values
+        ("pyspark", ["test", " test", "test ", " test ", "test"], 4, "success", None, "string"),
+    ],
+    ids=[
+        "pyspark_success",
+        "pyspark_success_with_nulls",
+        "pyspark_too_few",
+        "pyspark_too_many",
+        "pyspark_empty",
+        "pyspark_single_value",
+        "pyspark_string_with_nulls",
+        "pyspark_string_case_sensitive",
+        "pyspark_float",
+        "pyspark_numeric_precision",
+        "pyspark_boolean",
+        "pyspark_boolean_with_none",
+        "pyspark_datetime",
+        "pyspark_datetime_with_timezone",
+        "pyspark_duplicate_nan_handling",
+        "pyspark_string_whitespace",
+    ],
 )
-def test_column_missing_error(df_type, spark):
+def test_expectation_basic_scenarios_pyspark(
+    df_type, df_data, expected_value, expected_result, expected_message, data_type, spark
+):
     """
-    Test that an error is raised when the specified column is missing in both pandas and PySpark.
+    Test the expectation for various scenarios across PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases, success with nulls, edge cases (empty, single value), too few values, too many values,
+    and various data types (strings, floats, booleans, datetimes).
+    """
+    data_frame = create_pyspark_dataframe(df_data, "col1", spark, data_type)
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationDistinctColumnValuesEquals",
+        column_name="col1",
+        expected_value=expected_value,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(
+                expectation_name="ExpectationDistinctColumnValuesEquals"
+            )
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            message=expected_message,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_distinct_column_values_equals(
+        column_name="col1", expected_value=expected_value
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+def test_column_missing_error_pandas():
+    """
+    Test that an error is raised when the specified column is missing in pandas DataFrame.
     Tests both direct expectation validation and suite-based validation.
     """
     # Test 1: Direct expectation validation
@@ -322,12 +391,42 @@ def test_column_missing_error(df_type, spark):
         expected_value=3,
     )
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col2": [1, 2, 3, 4, 5]})
-        df_type_enum = DataFrameType.PANDAS
-    else:  # pyspark
-        data_frame = spark.createDataFrame([(1,), (2,), (3,), (4,), (5,)], ["col2"])
-        df_type_enum = DataFrameType.PYSPARK
+    data_frame = pd.DataFrame({"col2": [1, 2, 3, 4, 5]})
+    df_type_enum = DataFrameType.PANDAS
+
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure_message = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type=df_type_enum,
+        message="Column 'col1' does not exist in the DataFrame.",
+    )
+    assert str(result) == str(expected_failure_message), (
+        f"Expected failure message but got: {result}"
+    )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_distinct_column_values_equals(
+        column_name="col1", expected_value=3
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """
+    Test that an error is raised when the specified column is missing in PySpark DataFrame.
+    Tests both direct expectation validation and suite-based validation.
+    """
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationDistinctColumnValuesEquals",
+        column_name="col1",
+        expected_value=3,
+    )
+
+    data_frame = spark.createDataFrame([(1,), (2,), (3,), (4,), (5,)], ["col2"])
+    df_type_enum = DataFrameType.PYSPARK
 
     result = expectation.validate(data_frame=data_frame)
     expected_failure_message = DataFrameExpectationFailureMessage(

--- a/tests/expectations/aggregation/any_value_expectations/test_expect_distinct_column_values_equals.py
+++ b/tests/expectations/aggregation/any_value_expectations/test_expect_distinct_column_values_equals.py
@@ -18,10 +18,9 @@ from dataframe_expectations.result_message import (
 
 
 def create_pyspark_dataframe(data, column_name, spark, data_type="long"):
-    """Helper function to create pandas or pyspark DataFrame.
+    """Helper function to create a PySpark DataFrame.
 
     Args:
-        df_type: "pandas" or "pyspark"
         data: List of values for the column
         column_name: Name of the column
         spark: Spark session (required for pyspark)

--- a/tests/expectations/aggregation/any_value_expectations/test_expect_distinct_column_values_greater_than.py
+++ b/tests/expectations/aggregation/any_value_expectations/test_expect_distinct_column_values_greater_than.py
@@ -9,48 +9,43 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark, data_type="long"):
-    """Helper function to create pandas or pyspark DataFrame.
+def create_pyspark_dataframe(data, column_name, spark, data_type="long"):
+    """Helper function to create a PySpark DataFrame.
 
     Args:
-        df_type: "pandas" or "pyspark"
         data: List of values for the column
         column_name: Name of the column
-        spark: Spark session (required for pyspark)
+        spark: Spark session
         data_type: Data type for the column - "long", "string", "double", "boolean", "timestamp"
     """
-    if df_type == "pandas":
-        return pd.DataFrame(data, columns=[column_name])
-    else:  # pyspark
-        # Use explicit schema for all PySpark DataFrames
-        from pyspark.sql.types import (
-            StructType,
-            StructField,
-            LongType,
-            StringType,
-            DoubleType,
-            BooleanType,
-            TimestampType,
-        )
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        LongType,
+        StringType,
+        DoubleType,
+        BooleanType,
+        TimestampType,
+    )
 
-        type_mapping = {
-            "long": LongType(),
-            "string": StringType(),
-            "double": DoubleType(),
-            "boolean": BooleanType(),
-            "timestamp": TimestampType(),
-        }
+    type_mapping = {
+        "long": LongType(),
+        "string": StringType(),
+        "double": DoubleType(),
+        "boolean": BooleanType(),
+        "timestamp": TimestampType(),
+    }
 
-        schema = StructType([StructField(column_name, type_mapping[data_type], True)])
-        return spark.createDataFrame([(val,) for val in data], schema)
+    schema = StructType([StructField(column_name, type_mapping[data_type], True)])
+    return spark.createDataFrame([(val,) for val in data], schema)
 
 
 def test_expectation_name():
@@ -72,21 +67,11 @@ def test_expectation_name():
     [
         # Basic success - 3 distinct values > 2
         ("pandas", [1, 2, 3, 2, 1], 2, "success", None, "long"),
-        ("pyspark", [1, 2, 3, 2, 1], 2, "success", None, "long"),
         # Success with nulls - 3 distinct values [1, 2, None] > 2
         ("pandas", [1, 2, None, 2, 1], 2, "success", None, "long"),
-        ("pyspark", [1, 2, None, 2, 1], 2, "success", None, "long"),
         # Equal to threshold (should fail) - 3 distinct values, NOT > 3
         (
             "pandas",
-            [1, 2, 3, 2, 1],
-            3,
-            "failure",
-            "Column 'col1' has 3 distinct values, expected more than 3.",
-            "long",
-        ),
-        (
-            "pyspark",
             [1, 2, 3, 2, 1],
             3,
             "failure",
@@ -102,28 +87,11 @@ def test_expectation_name():
             "Column 'col1' has 2 distinct values, expected more than 5.",
             "long",
         ),
-        (
-            "pyspark",
-            [1, 2, 1, 2, 1],
-            5,
-            "failure",
-            "Column 'col1' has 2 distinct values, expected more than 5.",
-            "long",
-        ),
         # Zero threshold - 1 distinct value > 0
         ("pandas", [1, 1, 1], 0, "success", None, "long"),
-        ("pyspark", [1, 1, 1], 0, "success", None, "long"),
         # Empty DataFrame - 0 distinct values, NOT > 0
         (
             "pandas",
-            [],
-            0,
-            "failure",
-            "Column 'col1' has 0 distinct values, expected more than 0.",
-            "long",
-        ),
-        (
-            "pyspark",
             [],
             0,
             "failure",
@@ -139,40 +107,19 @@ def test_expectation_name():
             "Column 'col1' has 5 distinct values, expected more than 5.",
             "long",
         ),
-        (
-            "pyspark",
-            [1, 2, 3, 4, 5, 1, 2],
-            5,
-            "failure",
-            "Column 'col1' has 5 distinct values, expected more than 5.",
-            "long",
-        ),
         # Exclusive boundary test - 5 distinct values > 4
         ("pandas", [1, 2, 3, 4, 5, 1, 2], 4, "success", None, "long"),
-        ("pyspark", [1, 2, 3, 4, 5, 1, 2], 4, "success", None, "long"),
         # String column with mixed values including None - 4 distinct values > 3
         ("pandas", ["A", "B", "C", "B", "A", None], 3, "success", None, "string"),
-        ("pyspark", ["A", "B", "C", "B", "A", None], 3, "success", None, "string"),
         # String case-sensitive - 4 distinct values ["a", "A", "b", "B"] > 3
         ("pandas", ["a", "A", "b", "B", "a", "A"], 3, "success", None, "string"),
-        ("pyspark", ["a", "A", "b", "B", "a", "A"], 3, "success", None, "string"),
         # Float column - 3 distinct values > 2
         ("pandas", [1.1, 2.2, 3.3, 2.2, 1.1], 2, "success", None, "double"),
-        ("pyspark", [1.1, 2.2, 3.3, 2.2, 1.1], 2, "success", None, "double"),
         # Boolean column - 2 distinct values [True, False] > 1
         ("pandas", [True, False, True, False, True], 1, "success", None, "boolean"),
-        ("pyspark", [True, False, True, False, True], 1, "success", None, "boolean"),
         # Boolean column failure - 1 distinct value [True], NOT > 2
         (
             "pandas",
-            [True, True, True, True, True],
-            2,
-            "failure",
-            "Column 'col1' has 1 distinct values, expected more than 2.",
-            "boolean",
-        ),
-        (
-            "pyspark",
             [True, True, True, True, True],
             2,
             "failure",
@@ -188,27 +135,10 @@ def test_expectation_name():
             None,
             "timestamp",
         ),
-        # Datetime column - 3 distinct values > 2 (pyspark - uses datetime objects)
-        (
-            "pyspark",
-            [
-                datetime(2023, 1, 1),
-                datetime(2023, 1, 2),
-                datetime(2023, 1, 3),
-                datetime(2023, 1, 2),
-                datetime(2023, 1, 1),
-            ],
-            2,
-            "success",
-            None,
-            "timestamp",
-        ),
         # Multiple NaN values counted as one - 3 distinct values [1, 2, None] > 2
         ("pandas", [1, 2, None, None, None, 1, 2], 2, "success", None, "long"),
-        ("pyspark", [1, 2, None, None, None, 1, 2], 2, "success", None, "long"),
         # Strings with different whitespace - 4 distinct values > 3
         ("pandas", ["test", " test", "test ", " test ", "test"], 3, "success", None, "string"),
-        ("pyspark", ["test", " test", "test ", " test ", "test"], 3, "success", None, "string"),
         # Mixed data types - 4 distinct values ["text", 42, 3.14, None] > 3 (pandas only)
         ("pandas", ["text", 42, 3.14, None, "text", 42], 3, "success", None, "string"),
         # Categorical data - 3 distinct categories > 2 (pandas only)
@@ -225,56 +155,39 @@ def test_expectation_name():
     ],
     ids=[
         "pandas_success",
-        "pyspark_success",
         "pandas_success_with_nulls",
-        "pyspark_success_with_nulls",
         "pandas_equal_to_threshold",
-        "pyspark_equal_to_threshold",
         "pandas_below_threshold",
-        "pyspark_below_threshold",
         "pandas_zero_threshold",
-        "pyspark_zero_threshold",
         "pandas_empty",
-        "pyspark_empty",
         "pandas_exclusive_boundary_fail",
-        "pyspark_exclusive_boundary_fail",
         "pandas_exclusive_boundary_pass",
-        "pyspark_exclusive_boundary_pass",
         "pandas_string_with_nulls",
-        "pyspark_string_with_nulls",
         "pandas_string_case_sensitive",
-        "pyspark_string_case_sensitive",
         "pandas_float",
-        "pyspark_float",
         "pandas_boolean",
-        "pyspark_boolean",
         "pandas_boolean_failure",
-        "pyspark_boolean_failure",
         "pandas_datetime",
-        "pyspark_datetime",
         "pandas_duplicate_nan_handling",
-        "pyspark_duplicate_nan_handling",
         "pandas_string_whitespace",
-        "pyspark_string_whitespace",
         "pandas_mixed_data_types",
         "pandas_categorical",
         "pandas_numeric_string_vs_numeric",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, df_data, threshold, expected_result, expected_message, data_type, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, df_data, threshold, expected_result, expected_message, data_type
 ):
     """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
+    Test the expectation for various scenarios across pandas DataFrames.
     Tests both direct expectation validation and suite-based validation.
     Covers: success cases, failures (equal/below threshold), edge cases (empty, zero threshold),
     exclusive boundary, and various data types (strings, floats, booleans, datetimes, categorical, mixed types).
     """
-    # Special handling for numeric_string_vs_numeric test - needs object dtype
     if data_type == "object":
         data_frame = pd.DataFrame({"col1": df_data}, dtype=object)
     else:
-        data_frame = create_dataframe(df_type, df_data, "col1", spark, data_type)
+        data_frame = pd.DataFrame(df_data, columns=["col1"])
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -318,14 +231,166 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
+@pytest.mark.pyspark
 @pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
+    "df_type, df_data, threshold, expected_result, expected_message, data_type",
+    [
+        # Basic success - 3 distinct values > 2
+        ("pyspark", [1, 2, 3, 2, 1], 2, "success", None, "long"),
+        # Success with nulls - 3 distinct values [1, 2, None] > 2
+        ("pyspark", [1, 2, None, 2, 1], 2, "success", None, "long"),
+        # Equal to threshold (should fail) - 3 distinct values, NOT > 3
+        (
+            "pyspark",
+            [1, 2, 3, 2, 1],
+            3,
+            "failure",
+            "Column 'col1' has 3 distinct values, expected more than 3.",
+            "long",
+        ),
+        # Below threshold (should fail) - 2 distinct values, NOT > 5
+        (
+            "pyspark",
+            [1, 2, 1, 2, 1],
+            5,
+            "failure",
+            "Column 'col1' has 2 distinct values, expected more than 5.",
+            "long",
+        ),
+        # Zero threshold - 1 distinct value > 0
+        ("pyspark", [1, 1, 1], 0, "success", None, "long"),
+        # Empty DataFrame - 0 distinct values, NOT > 0
+        (
+            "pyspark",
+            [],
+            0,
+            "failure",
+            "Column 'col1' has 0 distinct values, expected more than 0.",
+            "long",
+        ),
+        # Exclusive boundary test - 5 distinct values, NOT > 5
+        (
+            "pyspark",
+            [1, 2, 3, 4, 5, 1, 2],
+            5,
+            "failure",
+            "Column 'col1' has 5 distinct values, expected more than 5.",
+            "long",
+        ),
+        # Exclusive boundary test - 5 distinct values > 4
+        ("pyspark", [1, 2, 3, 4, 5, 1, 2], 4, "success", None, "long"),
+        # String column with mixed values including None - 4 distinct values > 3
+        ("pyspark", ["A", "B", "C", "B", "A", None], 3, "success", None, "string"),
+        # String case-sensitive - 4 distinct values ["a", "A", "b", "B"] > 3
+        ("pyspark", ["a", "A", "b", "B", "a", "A"], 3, "success", None, "string"),
+        # Float column - 3 distinct values > 2
+        ("pyspark", [1.1, 2.2, 3.3, 2.2, 1.1], 2, "success", None, "double"),
+        # Boolean column - 2 distinct values [True, False] > 1
+        ("pyspark", [True, False, True, False, True], 1, "success", None, "boolean"),
+        # Boolean column failure - 1 distinct value [True], NOT > 2
+        (
+            "pyspark",
+            [True, True, True, True, True],
+            2,
+            "failure",
+            "Column 'col1' has 1 distinct values, expected more than 2.",
+            "boolean",
+        ),
+        # Datetime column - 3 distinct values > 2 (pyspark - uses datetime objects)
+        (
+            "pyspark",
+            [
+                datetime(2023, 1, 1),
+                datetime(2023, 1, 2),
+                datetime(2023, 1, 3),
+                datetime(2023, 1, 2),
+                datetime(2023, 1, 1),
+            ],
+            2,
+            "success",
+            None,
+            "timestamp",
+        ),
+        # Multiple NaN values counted as one - 3 distinct values [1, 2, None] > 2
+        ("pyspark", [1, 2, None, None, None, 1, 2], 2, "success", None, "long"),
+        # Strings with different whitespace - 4 distinct values > 3
+        ("pyspark", ["test", " test", "test ", " test ", "test"], 3, "success", None, "string"),
+    ],
+    ids=[
+        "pyspark_success",
+        "pyspark_success_with_nulls",
+        "pyspark_equal_to_threshold",
+        "pyspark_below_threshold",
+        "pyspark_zero_threshold",
+        "pyspark_empty",
+        "pyspark_exclusive_boundary_fail",
+        "pyspark_exclusive_boundary_pass",
+        "pyspark_string_with_nulls",
+        "pyspark_string_case_sensitive",
+        "pyspark_float",
+        "pyspark_boolean",
+        "pyspark_boolean_failure",
+        "pyspark_datetime",
+        "pyspark_duplicate_nan_handling",
+        "pyspark_string_whitespace",
+    ],
 )
-def test_column_missing_error(df_type, spark):
+def test_expectation_basic_scenarios_pyspark(
+    df_type, df_data, threshold, expected_result, expected_message, data_type, spark
+):
     """
-    Test that an error is raised when the specified column is missing in both pandas and PySpark.
+    Test the expectation for various scenarios across PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases, failures (equal/below threshold), edge cases (empty, zero threshold),
+    exclusive boundary, and various data types (strings, floats, booleans, datetimes).
+    """
+    data_frame = create_pyspark_dataframe(df_data, "col1", spark, data_type)
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationDistinctColumnValuesGreaterThan",
+        column_name="col1",
+        threshold=threshold,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(
+                expectation_name="ExpectationDistinctColumnValuesGreaterThan"
+            )
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            message=expected_message,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_distinct_column_values_greater_than(
+        column_name="col1", threshold=threshold
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+def test_column_missing_error_pandas():
+    """
+    Test that an error is raised when the specified column is missing in pandas.
     Tests both direct expectation validation and suite-based validation.
     """
     # Test 1: Direct expectation validation
@@ -335,12 +400,42 @@ def test_column_missing_error(df_type, spark):
         threshold=2,
     )
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col2": [1, 2, 3, 4, 5]})
-        df_type_enum = DataFrameType.PANDAS
-    else:  # pyspark
-        data_frame = spark.createDataFrame([(1,), (2,), (3,), (4,), (5,)], ["col2"])
-        df_type_enum = DataFrameType.PYSPARK
+    data_frame = pd.DataFrame({"col2": [1, 2, 3, 4, 5]})
+    df_type_enum = DataFrameType.PANDAS
+
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure_message = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type=df_type_enum,
+        message="Column 'col1' does not exist in the DataFrame.",
+    )
+    assert str(result) == str(expected_failure_message), (
+        f"Expected failure message but got: {result}"
+    )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_distinct_column_values_greater_than(
+        column_name="col1", threshold=2
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """
+    Test that an error is raised when the specified column is missing in PySpark.
+    Tests both direct expectation validation and suite-based validation.
+    """
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationDistinctColumnValuesGreaterThan",
+        column_name="col1",
+        threshold=2,
+    )
+
+    data_frame = spark.createDataFrame([(1,), (2,), (3,), (4,), (5,)], ["col2"])
+    df_type_enum = DataFrameType.PYSPARK
 
     result = expectation.validate(data_frame=data_frame)
     expected_failure_message = DataFrameExpectationFailureMessage(

--- a/tests/expectations/aggregation/any_value_expectations/test_expect_distinct_column_values_less_than.py
+++ b/tests/expectations/aggregation/any_value_expectations/test_expect_distinct_column_values_less_than.py
@@ -9,48 +9,43 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark, data_type="long"):
-    """Helper function to create pandas or pyspark DataFrame.
+def create_pyspark_dataframe(data, column_name, spark, data_type="long"):
+    """Helper function to create a PySpark DataFrame.
 
     Args:
-        df_type: "pandas" or "pyspark"
         data: List of values for the column
         column_name: Name of the column
-        spark: Spark session (required for pyspark)
+        spark: Spark session
         data_type: Data type for the column - "long", "string", "double", "boolean", "timestamp"
     """
-    if df_type == "pandas":
-        return pd.DataFrame(data, columns=[column_name])
-    else:  # pyspark
-        # Use explicit schema for all PySpark DataFrames
-        from pyspark.sql.types import (
-            StructType,
-            StructField,
-            LongType,
-            StringType,
-            DoubleType,
-            BooleanType,
-            TimestampType,
-        )
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        LongType,
+        StringType,
+        DoubleType,
+        BooleanType,
+        TimestampType,
+    )
 
-        type_mapping = {
-            "long": LongType(),
-            "string": StringType(),
-            "double": DoubleType(),
-            "boolean": BooleanType(),
-            "timestamp": TimestampType(),
-        }
+    type_mapping = {
+        "long": LongType(),
+        "string": StringType(),
+        "double": DoubleType(),
+        "boolean": BooleanType(),
+        "timestamp": TimestampType(),
+    }
 
-        schema = StructType([StructField(column_name, type_mapping[data_type], True)])
-        return spark.createDataFrame([(val,) for val in data], schema)
+    schema = StructType([StructField(column_name, type_mapping[data_type], True)])
+    return spark.createDataFrame([(val,) for val in data], schema)
 
 
 def test_expectation_name():
@@ -72,27 +67,15 @@ def test_expectation_name():
     [
         # Basic success - 3 distinct values < 5
         ("pandas", [1, 2, 3, 2, 1], 5, "success", None, "long"),
-        ("pyspark", [1, 2, 3, 2, 1], 5, "success", None, "long"),
         # Success with nulls - 3 distinct values [1, 2, None] < 5
         ("pandas", [1, 2, None, 2, 1], 5, "success", None, "long"),
-        ("pyspark", [1, 2, None, 2, 1], 5, "success", None, "long"),
         # Empty DataFrame - 0 distinct values < 1
         ("pandas", [], 1, "success", None, "long"),
-        ("pyspark", [], 1, "success", None, "long"),
         # Single value - 1 distinct value < 3
         ("pandas", [5, 5, 5, 5, 5], 3, "success", None, "long"),
-        ("pyspark", [5, 5, 5, 5, 5], 3, "success", None, "long"),
         # Equal to threshold (should fail) - 3 distinct values, NOT < 3
         (
             "pandas",
-            [1, 2, 3, 2, 1],
-            3,
-            "failure",
-            "Column 'col1' has 3 distinct values, expected fewer than 3.",
-            "long",
-        ),
-        (
-            "pyspark",
             [1, 2, 3, 2, 1],
             3,
             "failure",
@@ -108,25 +91,9 @@ def test_expectation_name():
             "Column 'col1' has 5 distinct values, expected fewer than 2.",
             "long",
         ),
-        (
-            "pyspark",
-            [1, 2, 3, 4, 5],
-            2,
-            "failure",
-            "Column 'col1' has 5 distinct values, expected fewer than 2.",
-            "long",
-        ),
         # Zero threshold edge case - empty DataFrame, 0 distinct values NOT < 0
         (
             "pandas",
-            [],
-            0,
-            "failure",
-            "Column 'col1' has 0 distinct values, expected fewer than 0.",
-            "long",
-        ),
-        (
-            "pyspark",
             [],
             0,
             "failure",
@@ -142,14 +109,6 @@ def test_expectation_name():
             "Column 'col1' has 1 distinct values, expected fewer than 0.",
             "long",
         ),
-        (
-            "pyspark",
-            [1, 1, 1],
-            0,
-            "failure",
-            "Column 'col1' has 1 distinct values, expected fewer than 0.",
-            "long",
-        ),
         # Exclusive boundary test - 3 distinct values, NOT < 3
         (
             "pandas",
@@ -159,29 +118,16 @@ def test_expectation_name():
             "Column 'col1' has 3 distinct values, expected fewer than 3.",
             "long",
         ),
-        (
-            "pyspark",
-            [1, 2, 3, 1, 2],
-            3,
-            "failure",
-            "Column 'col1' has 3 distinct values, expected fewer than 3.",
-            "long",
-        ),
         # Exclusive boundary test - 3 distinct values < 4
         ("pandas", [1, 2, 3, 1, 2], 4, "success", None, "long"),
-        ("pyspark", [1, 2, 3, 1, 2], 4, "success", None, "long"),
         # String column with mixed values including None - 4 distinct values < 5
         ("pandas", ["A", "B", "C", "B", "A", None], 5, "success", None, "string"),
-        ("pyspark", ["A", "B", "C", "B", "A", None], 5, "success", None, "string"),
         # String case-sensitive - 4 distinct values ["a", "A", "b", "B"] < 5
         ("pandas", ["a", "A", "b", "B", "a", "A"], 5, "success", None, "string"),
-        ("pyspark", ["a", "A", "b", "B", "a", "A"], 5, "success", None, "string"),
         # Float column - 3 distinct values < 5
         ("pandas", [1.1, 2.2, 3.3, 2.2, 1.1], 5, "success", None, "double"),
-        ("pyspark", [1.1, 2.2, 3.3, 2.2, 1.1], 5, "success", None, "double"),
         # Boolean column - 2 distinct values [True, False] < 3
         ("pandas", [True, False, True, False, True], 3, "success", None, "boolean"),
-        ("pyspark", [True, False, True, False, True], 3, "success", None, "boolean"),
         # Boolean column failure - 2 distinct values [True, False], NOT < 2
         (
             "pandas",
@@ -191,36 +137,12 @@ def test_expectation_name():
             "Column 'col1' has 2 distinct values, expected fewer than 2.",
             "boolean",
         ),
-        (
-            "pyspark",
-            [True, False, True, False, True],
-            2,
-            "failure",
-            "Column 'col1' has 2 distinct values, expected fewer than 2.",
-            "boolean",
-        ),
         # Boolean single value - 1 distinct value [True] < 2
         ("pandas", [True, True, True, True, True], 2, "success", None, "boolean"),
-        ("pyspark", [True, True, True, True, True], 2, "success", None, "boolean"),
         # Datetime column - 3 distinct values < 5 (pandas only - uses pd.to_datetime)
         (
             "pandas",
             pd.to_datetime(["2023-01-01", "2023-01-02", "2023-01-03", "2023-01-02", "2023-01-01"]),
-            5,
-            "success",
-            None,
-            "timestamp",
-        ),
-        # Datetime column - 3 distinct values < 5 (pyspark - uses datetime objects)
-        (
-            "pyspark",
-            [
-                datetime(2023, 1, 1),
-                datetime(2023, 1, 2),
-                datetime(2023, 1, 3),
-                datetime(2023, 1, 2),
-                datetime(2023, 1, 1),
-            ],
             5,
             "success",
             None,
@@ -239,71 +161,49 @@ def test_expectation_name():
         ),
         # Multiple NaN values counted as one - 3 distinct values [1, 2, None] < 5
         ("pandas", [1, 2, None, None, None, 1, 2], 5, "success", None, "long"),
-        ("pyspark", [1, 2, None, None, None, 1, 2], 5, "success", None, "long"),
         # Strings with different whitespace - 4 distinct values < 5
         ("pandas", ["test", " test", "test ", " test ", "test"], 5, "success", None, "string"),
-        ("pyspark", ["test", " test", "test ", " test ", "test"], 5, "success", None, "string"),
         # Numeric strings vs numeric values - 2 distinct values < 3 (pandas only - object dtype)
         ("pandas", ["1", 1, "1", 1], 3, "success", None, "object"),
     ],
     ids=[
         "pandas_success",
-        "pyspark_success",
         "pandas_success_with_nulls",
-        "pyspark_success_with_nulls",
         "pandas_empty",
-        "pyspark_empty",
         "pandas_single_value",
-        "pyspark_single_value",
         "pandas_equal_to_threshold",
-        "pyspark_equal_to_threshold",
         "pandas_above_threshold",
-        "pyspark_above_threshold",
         "pandas_zero_threshold_empty",
-        "pyspark_zero_threshold_empty",
         "pandas_zero_threshold_non_empty",
-        "pyspark_zero_threshold_non_empty",
         "pandas_exclusive_boundary_fail",
-        "pyspark_exclusive_boundary_fail",
         "pandas_exclusive_boundary_pass",
-        "pyspark_exclusive_boundary_pass",
         "pandas_string_with_nulls",
-        "pyspark_string_with_nulls",
         "pandas_string_case_sensitive",
-        "pyspark_string_case_sensitive",
         "pandas_float",
-        "pyspark_float",
         "pandas_boolean",
-        "pyspark_boolean",
         "pandas_boolean_failure",
-        "pyspark_boolean_failure",
         "pandas_boolean_single_value",
-        "pyspark_boolean_single_value",
         "pandas_datetime",
-        "pyspark_datetime",
         "pandas_mixed_data_types",
         "pandas_categorical",
         "pandas_duplicate_nan_handling",
-        "pyspark_duplicate_nan_handling",
         "pandas_string_whitespace",
-        "pyspark_string_whitespace",
         "pandas_numeric_string_vs_numeric",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, df_data, threshold, expected_result, expected_message, data_type, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, df_data, threshold, expected_result, expected_message, data_type
 ):
     """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
+    Test the expectation for various scenarios across pandas DataFrames.
     Tests both direct expectation validation and suite-based validation.
     Covers: success cases, failures (equal/above threshold), edge cases (empty, zero threshold),
     exclusive boundary, and various data types (strings, floats, booleans, datetimes, categorical, mixed types).
     """
-    # Special handling for numeric_string_vs_numeric test - needs object dtype
     if data_type == "object":
         data_frame = pd.DataFrame({"col1": df_data}, dtype=object)
     else:
-        data_frame = create_dataframe(df_type, df_data, "col1", spark, data_type)
+        data_frame = pd.DataFrame(df_data, columns=["col1"])
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -347,14 +247,182 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
+@pytest.mark.pyspark
 @pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
+    "df_type, df_data, threshold, expected_result, expected_message, data_type",
+    [
+        # Basic success - 3 distinct values < 5
+        ("pyspark", [1, 2, 3, 2, 1], 5, "success", None, "long"),
+        # Success with nulls - 3 distinct values [1, 2, None] < 5
+        ("pyspark", [1, 2, None, 2, 1], 5, "success", None, "long"),
+        # Empty DataFrame - 0 distinct values < 1
+        ("pyspark", [], 1, "success", None, "long"),
+        # Single value - 1 distinct value < 3
+        ("pyspark", [5, 5, 5, 5, 5], 3, "success", None, "long"),
+        # Equal to threshold (should fail) - 3 distinct values, NOT < 3
+        (
+            "pyspark",
+            [1, 2, 3, 2, 1],
+            3,
+            "failure",
+            "Column 'col1' has 3 distinct values, expected fewer than 3.",
+            "long",
+        ),
+        # Above threshold (should fail) - 5 distinct values, NOT < 2
+        (
+            "pyspark",
+            [1, 2, 3, 4, 5],
+            2,
+            "failure",
+            "Column 'col1' has 5 distinct values, expected fewer than 2.",
+            "long",
+        ),
+        # Zero threshold edge case - empty DataFrame, 0 distinct values NOT < 0
+        (
+            "pyspark",
+            [],
+            0,
+            "failure",
+            "Column 'col1' has 0 distinct values, expected fewer than 0.",
+            "long",
+        ),
+        # Zero threshold edge case - non-empty DataFrame, 1 distinct value NOT < 0
+        (
+            "pyspark",
+            [1, 1, 1],
+            0,
+            "failure",
+            "Column 'col1' has 1 distinct values, expected fewer than 0.",
+            "long",
+        ),
+        # Exclusive boundary test - 3 distinct values, NOT < 3
+        (
+            "pyspark",
+            [1, 2, 3, 1, 2],
+            3,
+            "failure",
+            "Column 'col1' has 3 distinct values, expected fewer than 3.",
+            "long",
+        ),
+        # Exclusive boundary test - 3 distinct values < 4
+        ("pyspark", [1, 2, 3, 1, 2], 4, "success", None, "long"),
+        # String column with mixed values including None - 4 distinct values < 5
+        ("pyspark", ["A", "B", "C", "B", "A", None], 5, "success", None, "string"),
+        # String case-sensitive - 4 distinct values ["a", "A", "b", "B"] < 5
+        ("pyspark", ["a", "A", "b", "B", "a", "A"], 5, "success", None, "string"),
+        # Float column - 3 distinct values < 5
+        ("pyspark", [1.1, 2.2, 3.3, 2.2, 1.1], 5, "success", None, "double"),
+        # Boolean column - 2 distinct values [True, False] < 3
+        ("pyspark", [True, False, True, False, True], 3, "success", None, "boolean"),
+        # Boolean column failure - 2 distinct values [True, False], NOT < 2
+        (
+            "pyspark",
+            [True, False, True, False, True],
+            2,
+            "failure",
+            "Column 'col1' has 2 distinct values, expected fewer than 2.",
+            "boolean",
+        ),
+        # Boolean single value - 1 distinct value [True] < 2
+        ("pyspark", [True, True, True, True, True], 2, "success", None, "boolean"),
+        # Datetime column - 3 distinct values < 5 (pyspark - uses datetime objects)
+        (
+            "pyspark",
+            [
+                datetime(2023, 1, 1),
+                datetime(2023, 1, 2),
+                datetime(2023, 1, 3),
+                datetime(2023, 1, 2),
+                datetime(2023, 1, 1),
+            ],
+            5,
+            "success",
+            None,
+            "timestamp",
+        ),
+        # Multiple NaN values counted as one - 3 distinct values [1, 2, None] < 5
+        ("pyspark", [1, 2, None, None, None, 1, 2], 5, "success", None, "long"),
+        # Strings with different whitespace - 4 distinct values < 5
+        ("pyspark", ["test", " test", "test ", " test ", "test"], 5, "success", None, "string"),
+    ],
+    ids=[
+        "pyspark_success",
+        "pyspark_success_with_nulls",
+        "pyspark_empty",
+        "pyspark_single_value",
+        "pyspark_equal_to_threshold",
+        "pyspark_above_threshold",
+        "pyspark_zero_threshold_empty",
+        "pyspark_zero_threshold_non_empty",
+        "pyspark_exclusive_boundary_fail",
+        "pyspark_exclusive_boundary_pass",
+        "pyspark_string_with_nulls",
+        "pyspark_string_case_sensitive",
+        "pyspark_float",
+        "pyspark_boolean",
+        "pyspark_boolean_failure",
+        "pyspark_boolean_single_value",
+        "pyspark_datetime",
+        "pyspark_duplicate_nan_handling",
+        "pyspark_string_whitespace",
+    ],
 )
-def test_column_missing_error(df_type, spark):
+def test_expectation_basic_scenarios_pyspark(
+    df_type, df_data, threshold, expected_result, expected_message, data_type, spark
+):
     """
-    Test that an error is raised when the specified column is missing in both pandas and PySpark.
+    Test the expectation for various scenarios across PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases, failures (equal/above threshold), edge cases (empty, zero threshold),
+    exclusive boundary, and various data types (strings, floats, booleans, datetimes).
+    """
+    data_frame = create_pyspark_dataframe(df_data, "col1", spark, data_type)
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationDistinctColumnValuesLessThan",
+        column_name="col1",
+        threshold=threshold,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(
+                expectation_name="ExpectationDistinctColumnValuesLessThan"
+            )
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            message=expected_message,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_distinct_column_values_less_than(
+        column_name="col1", threshold=threshold
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+def test_column_missing_error_pandas():
+    """
+    Test that an error is raised when the specified column is missing in pandas.
     Tests both direct expectation validation and suite-based validation.
     """
     # Test 1: Direct expectation validation
@@ -364,12 +432,42 @@ def test_column_missing_error(df_type, spark):
         threshold=5,
     )
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col2": [1, 2, 3, 4, 5]})
-        df_type_enum = DataFrameType.PANDAS
-    else:  # pyspark
-        data_frame = spark.createDataFrame([(1,), (2,), (3,), (4,), (5,)], ["col2"])
-        df_type_enum = DataFrameType.PYSPARK
+    data_frame = pd.DataFrame({"col2": [1, 2, 3, 4, 5]})
+    df_type_enum = DataFrameType.PANDAS
+
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure_message = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type=df_type_enum,
+        message="Column 'col1' does not exist in the DataFrame.",
+    )
+    assert str(result) == str(expected_failure_message), (
+        f"Expected failure message but got: {result}"
+    )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_distinct_column_values_less_than(
+        column_name="col1", threshold=5
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """
+    Test that an error is raised when the specified column is missing in PySpark.
+    Tests both direct expectation validation and suite-based validation.
+    """
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationDistinctColumnValuesLessThan",
+        column_name="col1",
+        threshold=5,
+    )
+
+    data_frame = spark.createDataFrame([(1,), (2,), (3,), (4,), (5,)], ["col2"])
+    df_type_enum = DataFrameType.PYSPARK
 
     result = expectation.validate(data_frame=data_frame)
     expected_failure_message = DataFrameExpectationFailureMessage(

--- a/tests/expectations/aggregation/any_value_expectations/test_expect_max_null_count.py
+++ b/tests/expectations/aggregation/any_value_expectations/test_expect_max_null_count.py
@@ -8,20 +8,16 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, df_data, spark):
-    """Helper function to create pandas or pyspark DataFrame with explicit schema for PySpark."""
-    if df_type == "pandas":
-        return pd.DataFrame(df_data)
-
-    # PySpark: requires explicit schema to handle all-null columns
+def create_pyspark_dataframe(df_data, spark):
+    """Helper function to create a PySpark DataFrame with explicit schema."""
     from pyspark.sql.types import StructType, StructField, IntegerType, StringType, DoubleType
 
     if not df_data:
@@ -54,23 +50,12 @@ def create_dataframe(df_type, df_data, spark):
             "success",
             None,
         ),
-        (
-            "pyspark",
-            {"col1": [1, 2, 3, 4, 5], "col2": ["a", "b", "c", "d", "e"]},
-            "col1",
-            5,
-            "success",
-            None,
-        ),
         # Within threshold - 2 nulls < 3
         ("pandas", {"col1": [1, None, 3, None, 5]}, "col1", 3, "success", None),
-        ("pyspark", {"col1": [1, None, 3, None, 5]}, "col1", 3, "success", None),
         # Exactly at threshold - 2 nulls <= 2
         ("pandas", {"col1": [1, 2, None, 4, None]}, "col1", 2, "success", None),
-        ("pyspark", {"col1": [1, 2, None, 4, None]}, "col1", 2, "success", None),
         # With NaN - 1 null <= 2
         ("pandas", {"col1": [1, 2, 3], "col2": [4.0, np.nan, 6.0]}, "col2", 2, "success", None),
-        ("pyspark", {"col1": [1, 2, 3], "col2": [4.0, None, 6.0]}, "col2", 2, "success", None),
         # Exceeds threshold - 3 nulls > 1
         (
             "pandas",
@@ -79,14 +64,6 @@ def create_dataframe(df_type, df_data, spark):
             1,
             "failure",
             "Column 'col1' has 3 null values, expected at most 1.",
-        ),
-        (
-            "pyspark",
-            {"col1": [1, None, None]},
-            "col1",
-            1,
-            "failure",
-            "Column 'col1' has 2 null values, expected at most 1.",
         ),
         # All nulls in column - 3 nulls > 1
         (
@@ -97,14 +74,6 @@ def create_dataframe(df_type, df_data, spark):
             "failure",
             "Column 'col1' has 3 null values, expected at most 1.",
         ),
-        (
-            "pyspark",
-            {"col1": [None, None, None]},
-            "col1",
-            2,
-            "failure",
-            "Column 'col1' has 3 null values, expected at most 2.",
-        ),
         # Zero threshold failure - 1 null > 0
         (
             "pandas",
@@ -114,20 +83,10 @@ def create_dataframe(df_type, df_data, spark):
             "failure",
             "Column 'col1' has 1 null values, expected at most 0.",
         ),
-        (
-            "pyspark",
-            {"col1": [1, None, 3]},
-            "col1",
-            0,
-            "failure",
-            "Column 'col1' has 1 null values, expected at most 0.",
-        ),
         # Zero threshold success - 0 nulls <= 0
         ("pandas", {"col1": [1, 2, 3], "col2": [None, None, None]}, "col1", 0, "success", None),
-        ("pyspark", {"col1": [1, 2, 3], "col2": [None, None, None]}, "col1", 0, "success", None),
         # Empty DataFrame - 0 nulls <= 5
         ("pandas", {"col1": []}, "col1", 5, "success", None),
-        ("pyspark", {}, "col1", 5, "success", None),
         # Single null value - 1 null > 0
         (
             "pandas",
@@ -137,68 +96,42 @@ def create_dataframe(df_type, df_data, spark):
             "failure",
             "Column 'col1' has 1 null values, expected at most 0.",
         ),
-        (
-            "pyspark",
-            {"col1": [None]},
-            "col1",
-            0,
-            "failure",
-            "Column 'col1' has 1 null values, expected at most 0.",
-        ),
         # Single non-null value - 0 nulls <= 0
         ("pandas", {"col1": [1]}, "col1", 0, "success", None),
-        ("pyspark", {"col1": [1]}, "col1", 0, "success", None),
         # Other columns with nulls don't affect - 0 nulls in col1 <= 1
         ("pandas", {"col1": [1, 2, 3], "col2": [None, None, None]}, "col1", 1, "success", None),
-        ("pyspark", {"col1": [1, 2, 3], "col2": [None, None, None]}, "col1", 1, "success", None),
         # Mixed data types with nulls - 2 nulls <= 2
         ("pandas", {"col1": [1, "text", None, 3.14, None]}, "col1", 2, "success", None),
-        ("pyspark", {"col1": [1, 2, None, 4, None]}, "col1", 2, "success", None),
         # Large threshold - 2 nulls <= 1000000
         ("pandas", {"col1": [1, None, 3, None, 5]}, "col1", 1000000, "success", None),
-        ("pyspark", {"col1": [1, None, 3, None, 5]}, "col1", 1000000, "success", None),
     ],
     ids=[
         "pandas_no_nulls",
-        "pyspark_no_nulls",
         "pandas_within_threshold",
-        "pyspark_within_threshold",
         "pandas_exactly_at_threshold",
-        "pyspark_exactly_at_threshold",
         "pandas_with_nan",
-        "pyspark_with_nan",
         "pandas_exceeds_threshold",
-        "pyspark_exceeds_threshold",
         "pandas_all_nulls",
-        "pyspark_all_nulls",
         "pandas_zero_threshold_failure",
-        "pyspark_zero_threshold_failure",
         "pandas_zero_threshold_success",
-        "pyspark_zero_threshold_success",
         "pandas_empty",
-        "pyspark_empty",
         "pandas_single_null",
-        "pyspark_single_null",
         "pandas_single_not_null",
-        "pyspark_single_not_null",
         "pandas_other_columns_ignored",
-        "pyspark_other_columns_ignored",
         "pandas_mixed_data_types",
-        "pyspark_mixed_data_types",
         "pandas_large_threshold",
-        "pyspark_large_threshold",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, df_data, column_name, max_count, expected_result, expected_message, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, df_data, column_name, max_count, expected_result, expected_message
 ):
     """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
+    Test the expectation for various scenarios across pandas DataFrames.
     Tests both direct expectation validation and suite-based validation.
     Covers: success cases, failures (exceeds threshold), edge cases (empty, zero threshold, single values),
     boundary conditions, column isolation, and various data types.
     """
-    data_frame = create_dataframe(df_type, df_data, spark)
+    data_frame = pd.DataFrame(df_data, columns=[column_name])
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -240,14 +173,145 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
+@pytest.mark.pyspark
 @pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
+    "df_type, df_data, column_name, max_count, expected_result, expected_message",
+    [
+        # No nulls - should pass
+        (
+            "pyspark",
+            {"col1": [1, 2, 3, 4, 5], "col2": ["a", "b", "c", "d", "e"]},
+            "col1",
+            5,
+            "success",
+            None,
+        ),
+        # Within threshold - 2 nulls < 3
+        ("pyspark", {"col1": [1, None, 3, None, 5]}, "col1", 3, "success", None),
+        # Exactly at threshold - 2 nulls <= 2
+        ("pyspark", {"col1": [1, 2, None, 4, None]}, "col1", 2, "success", None),
+        # With NaN - 1 null <= 2
+        ("pyspark", {"col1": [1, 2, 3], "col2": [4.0, None, 6.0]}, "col2", 2, "success", None),
+        # Exceeds threshold - 2 nulls > 1
+        (
+            "pyspark",
+            {"col1": [1, None, None]},
+            "col1",
+            1,
+            "failure",
+            "Column 'col1' has 2 null values, expected at most 1.",
+        ),
+        # All nulls in column - 3 nulls > 2
+        (
+            "pyspark",
+            {"col1": [None, None, None]},
+            "col1",
+            2,
+            "failure",
+            "Column 'col1' has 3 null values, expected at most 2.",
+        ),
+        # Zero threshold failure - 1 null > 0
+        (
+            "pyspark",
+            {"col1": [1, None, 3]},
+            "col1",
+            0,
+            "failure",
+            "Column 'col1' has 1 null values, expected at most 0.",
+        ),
+        # Zero threshold success - 0 nulls <= 0
+        ("pyspark", {"col1": [1, 2, 3], "col2": [None, None, None]}, "col1", 0, "success", None),
+        # Empty DataFrame - 0 nulls <= 5
+        ("pyspark", {}, "col1", 5, "success", None),
+        # Single null value - 1 null > 0
+        (
+            "pyspark",
+            {"col1": [None]},
+            "col1",
+            0,
+            "failure",
+            "Column 'col1' has 1 null values, expected at most 0.",
+        ),
+        # Single non-null value - 0 nulls <= 0
+        ("pyspark", {"col1": [1]}, "col1", 0, "success", None),
+        # Other columns with nulls don't affect - 0 nulls in col1 <= 1
+        ("pyspark", {"col1": [1, 2, 3], "col2": [None, None, None]}, "col1", 1, "success", None),
+        # Mixed data types with nulls - 2 nulls <= 2
+        ("pyspark", {"col1": [1, 2, None, 4, None]}, "col1", 2, "success", None),
+        # Large threshold - 2 nulls <= 1000000
+        ("pyspark", {"col1": [1, None, 3, None, 5]}, "col1", 1000000, "success", None),
+    ],
+    ids=[
+        "pyspark_no_nulls",
+        "pyspark_within_threshold",
+        "pyspark_exactly_at_threshold",
+        "pyspark_with_nan",
+        "pyspark_exceeds_threshold",
+        "pyspark_all_nulls",
+        "pyspark_zero_threshold_failure",
+        "pyspark_zero_threshold_success",
+        "pyspark_empty",
+        "pyspark_single_null",
+        "pyspark_single_not_null",
+        "pyspark_other_columns_ignored",
+        "pyspark_mixed_data_types",
+        "pyspark_large_threshold",
+    ],
 )
-def test_column_missing_error(df_type, spark):
+def test_expectation_basic_scenarios_pyspark(
+    df_type, df_data, column_name, max_count, expected_result, expected_message, spark
+):
     """
-    Test that an error is raised when the specified column is missing in both pandas and PySpark.
+    Test the expectation for various scenarios across PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases, failures (exceeds threshold), edge cases (empty, zero threshold, single values),
+    boundary conditions, column isolation, and various data types.
+    """
+    data_frame = create_pyspark_dataframe(df_data, spark)
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationMaxNullCount",
+        column_name=column_name,
+        max_count=max_count,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationMaxNullCount")
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            message=expected_message,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_max_null_count(
+        column_name=column_name, max_count=max_count
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+def test_column_missing_error_pandas():
+    """
+    Test that an error is raised when the specified column is missing in pandas.
     Tests both direct expectation validation and suite-based validation.
     """
     # Test 1: Direct expectation validation
@@ -257,10 +321,38 @@ def test_column_missing_error(df_type, spark):
         max_count=5,
     )
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col2": [1, 2, 3, 4, 5]})
-    else:  # pyspark
-        data_frame = spark.createDataFrame([(1,), (2,), (3,)], ["col2"])
+    data_frame = pd.DataFrame({"col2": [1, 2, 3, 4, 5]})
+
+    result = expectation.validate(data_frame=data_frame)
+    # The error message might vary, but should be a failure
+    assert isinstance(result, DataFrameExpectationFailureMessage), (
+        f"Expected DataFrameExpectationFailureMessage but got: {type(result)}"
+    )
+    result_str = str(result)
+    assert "col1" in result_str, f"Expected 'col1' in result message: {result_str}"
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_max_null_count(
+        column_name="col1", max_count=5
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """
+    Test that an error is raised when the specified column is missing in PySpark.
+    Tests both direct expectation validation and suite-based validation.
+    """
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationMaxNullCount",
+        column_name="col1",
+        max_count=5,
+    )
+
+    data_frame = spark.createDataFrame([(1,), (2,), (3,)], ["col2"])
 
     result = expectation.validate(data_frame=data_frame)
     # The error message might vary, but should be a failure

--- a/tests/expectations/aggregation/any_value_expectations/test_expect_max_null_percentage.py
+++ b/tests/expectations/aggregation/any_value_expectations/test_expect_max_null_percentage.py
@@ -8,20 +8,16 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, df_data, spark):
-    """Helper function to create pandas or pyspark DataFrame with explicit schema for PySpark."""
-    if df_type == "pandas":
-        return pd.DataFrame(df_data)
-
-    # PySpark: requires explicit schema to handle all-null columns
+def create_pyspark_dataframe(df_data, spark):
+    """Helper function to create a PySpark DataFrame with explicit schema."""
     from pyspark.sql.types import StructType, StructField, IntegerType, StringType, DoubleType
 
     if not df_data:
@@ -54,17 +50,8 @@ def create_dataframe(df_type, df_data, spark):
             "success",
             None,
         ),
-        (
-            "pyspark",
-            {"col1": [1, 2, 3, 4, 5], "col2": ["a", "b", "c", "d", "e"]},
-            "col1",
-            10.0,
-            "success",
-            None,
-        ),
         # Within threshold - 25% < 30%
         ("pandas", {"col1": [1, None, 3, 4]}, "col1", 30.0, "success", None),
-        ("pyspark", {"col1": [1, None, 3, 4]}, "col1", 30.0, "success", None),
         # Exactly at threshold - 20% == 20%
         (
             "pandas",
@@ -74,10 +61,8 @@ def create_dataframe(df_type, df_data, spark):
             "success",
             None,
         ),
-        ("pyspark", {"col1": [1, 2, None, 4, 5]}, "col1", 20.0, "success", None),
         # With NaN - 33.33% < 50%
         ("pandas", {"col1": [1, 2, 3], "col2": [4.0, np.nan, 6.0]}, "col2", 50.0, "success", None),
-        ("pyspark", {"col1": [1, 2, 3], "col2": [4.0, None, 6.0]}, "col2", 50.0, "success", None),
         # Exceeds threshold - 50% > 20%
         (
             "pandas",
@@ -86,14 +71,6 @@ def create_dataframe(df_type, df_data, spark):
             20.0,
             "failure",
             "Column 'col1' has 50.00% null values, expected at most 20.00%.",
-        ),
-        (
-            "pyspark",
-            {"col1": [1, None, None], "col2": ["a", "b", "c"]},
-            "col1",
-            25.0,
-            "failure",
-            "Column 'col1' has 66.67% null values, expected at most 25.00%.",
         ),
         # All nulls in column - 100% > 50%
         (
@@ -104,25 +81,9 @@ def create_dataframe(df_type, df_data, spark):
             "failure",
             "Column 'col1' has 100.00% null values, expected at most 50.00%.",
         ),
-        (
-            "pyspark",
-            {"col1": [None, None, None]},
-            "col1",
-            75.0,
-            "failure",
-            "Column 'col1' has 100.00% null values, expected at most 75.00%.",
-        ),
         # Zero threshold failure - 33.33% > 0%
         (
             "pandas",
-            {"col1": [1, None, 3]},
-            "col1",
-            0.0,
-            "failure",
-            "Column 'col1' has 33.33% null values, expected at most 0.00%.",
-        ),
-        (
-            "pyspark",
             {"col1": [1, None, 3]},
             "col1",
             0.0,
@@ -138,10 +99,8 @@ def create_dataframe(df_type, df_data, spark):
             "success",
             None,
         ),
-        ("pyspark", {"col1": [None, None], "col2": [None, None]}, "col1", 100.0, "success", None),
         # Empty DataFrame - 0% <= 10%
         ("pandas", {"col1": []}, "col1", 10.0, "success", None),
-        ("pyspark", {}, "col1", 10.0, "success", None),
         # Single null value - 100% > 50%
         (
             "pandas",
@@ -151,20 +110,10 @@ def create_dataframe(df_type, df_data, spark):
             "failure",
             "Column 'col1' has 100.00% null values, expected at most 50.00%.",
         ),
-        (
-            "pyspark",
-            {"col1": [None]},
-            "col1",
-            50.0,
-            "failure",
-            "Column 'col1' has 100.00% null values, expected at most 50.00%.",
-        ),
         # Single non-null value - 0% <= 10%
         ("pandas", {"col1": [1]}, "col1", 10.0, "success", None),
-        ("pyspark", {"col1": [1]}, "col1", 10.0, "success", None),
         # Other columns with nulls don't affect - 0% in col1 <= 10%
         ("pandas", {"col1": [1, 2, 3], "col2": [None, None, None]}, "col1", 10.0, "success", None),
-        ("pyspark", {"col1": [1, 2, 3], "col2": [None, None, None]}, "col1", 10.0, "success", None),
         # Mixed data types with nulls - 25% < 50%
         (
             "pandas",
@@ -178,63 +127,36 @@ def create_dataframe(df_type, df_data, spark):
             "success",
             None,
         ),
-        (
-            "pyspark",
-            {
-                "int_col": [1, None, 3, 4],
-                "str_col": ["a", "b", None, "d"],
-                "float_col": [1.1, 2.2, 3.3, None],
-            },
-            "float_col",
-            50.0,
-            "success",
-            None,
-        ),
         # Precision boundary - 25% == 25%
         ("pandas", {"col1": [1, None, 3, 4]}, "col1", 25.0, "success", None),
-        ("pyspark", {"col1": [1, None, 3, 4]}, "col1", 25.0, "success", None),
     ],
     ids=[
         "pandas_no_nulls",
-        "pyspark_no_nulls",
         "pandas_within_threshold",
-        "pyspark_within_threshold",
         "pandas_exactly_at_threshold",
-        "pyspark_exactly_at_threshold",
         "pandas_with_nan",
-        "pyspark_with_nan",
         "pandas_exceeds_threshold",
-        "pyspark_exceeds_threshold",
         "pandas_all_nulls",
-        "pyspark_all_nulls",
         "pandas_zero_threshold_failure",
-        "pyspark_zero_threshold_failure",
         "pandas_hundred_threshold_success",
-        "pyspark_hundred_threshold_success",
         "pandas_empty",
-        "pyspark_empty",
         "pandas_single_null",
-        "pyspark_single_null",
         "pandas_single_not_null",
-        "pyspark_single_not_null",
         "pandas_other_columns_ignored",
-        "pyspark_other_columns_ignored",
         "pandas_mixed_data_types",
-        "pyspark_mixed_data_types",
         "pandas_precision_boundary",
-        "pyspark_precision_boundary",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, df_data, column_name, max_percentage, expected_result, expected_message, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, df_data, column_name, max_percentage, expected_result, expected_message
 ):
     """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
+    Test the expectation for various scenarios across pandas DataFrames.
     Tests both direct expectation validation and suite-based validation.
     Covers: success cases, failures (exceeds threshold), edge cases (empty, zero/hundred threshold, single values),
     boundary conditions, column isolation, mixed data types, and precision boundaries.
     """
-    data_frame = create_dataframe(df_type, df_data, spark)
+    data_frame = pd.DataFrame(df_data, columns=[column_name])
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -252,7 +174,7 @@ def test_expectation_basic_scenarios(
     else:  # failure
         expected_failure_message = DataFrameExpectationFailureMessage(
             expectation_str=str(expectation),
-            data_frame_type=str(df_type),
+            data_frame_type=df_type,
             message=expected_message,
         )
         assert str(result) == str(expected_failure_message), (
@@ -276,30 +198,167 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
+@pytest.mark.pyspark
 @pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
+    "df_type, df_data, column_name, max_percentage, expected_result, expected_message",
+    [
+        # No nulls - should pass
+        (
+            "pyspark",
+            {"col1": [1, 2, 3, 4, 5], "col2": ["a", "b", "c", "d", "e"]},
+            "col1",
+            10.0,
+            "success",
+            None,
+        ),
+        # Within threshold - 25% < 30%
+        ("pyspark", {"col1": [1, None, 3, 4]}, "col1", 30.0, "success", None),
+        # Exactly at threshold - 20% == 20%
+        ("pyspark", {"col1": [1, 2, None, 4, 5]}, "col1", 20.0, "success", None),
+        # With NaN - 33.33% < 50%
+        ("pyspark", {"col1": [1, 2, 3], "col2": [4.0, None, 6.0]}, "col2", 50.0, "success", None),
+        # Exceeds threshold - 66.67% > 25%
+        (
+            "pyspark",
+            {"col1": [1, None, None], "col2": ["a", "b", "c"]},
+            "col1",
+            25.0,
+            "failure",
+            "Column 'col1' has 66.67% null values, expected at most 25.00%.",
+        ),
+        # All nulls in column - 100% > 75%
+        (
+            "pyspark",
+            {"col1": [None, None, None]},
+            "col1",
+            75.0,
+            "failure",
+            "Column 'col1' has 100.00% null values, expected at most 75.00%.",
+        ),
+        # Zero threshold failure - 33.33% > 0%
+        (
+            "pyspark",
+            {"col1": [1, None, 3]},
+            "col1",
+            0.0,
+            "failure",
+            "Column 'col1' has 33.33% null values, expected at most 0.00%.",
+        ),
+        # Hundred threshold success - 100% <= 100%
+        ("pyspark", {"col1": [None, None], "col2": [None, None]}, "col1", 100.0, "success", None),
+        # Empty DataFrame - 0% <= 10%
+        ("pyspark", {}, "col1", 10.0, "success", None),
+        # Single null value - 100% > 50%
+        (
+            "pyspark",
+            {"col1": [None]},
+            "col1",
+            50.0,
+            "failure",
+            "Column 'col1' has 100.00% null values, expected at most 50.00%.",
+        ),
+        # Single non-null value - 0% <= 10%
+        ("pyspark", {"col1": [1]}, "col1", 10.0, "success", None),
+        # Other columns with nulls don't affect - 0% in col1 <= 10%
+        ("pyspark", {"col1": [1, 2, 3], "col2": [None, None, None]}, "col1", 10.0, "success", None),
+        # Mixed data types with nulls - 25% < 50%
+        (
+            "pyspark",
+            {
+                "int_col": [1, None, 3, 4],
+                "str_col": ["a", "b", None, "d"],
+                "float_col": [1.1, 2.2, 3.3, None],
+            },
+            "float_col",
+            50.0,
+            "success",
+            None,
+        ),
+        # Precision boundary - 25% == 25%
+        ("pyspark", {"col1": [1, None, 3, 4]}, "col1", 25.0, "success", None),
+    ],
+    ids=[
+        "pyspark_no_nulls",
+        "pyspark_within_threshold",
+        "pyspark_exactly_at_threshold",
+        "pyspark_with_nan",
+        "pyspark_exceeds_threshold",
+        "pyspark_all_nulls",
+        "pyspark_zero_threshold_failure",
+        "pyspark_hundred_threshold_success",
+        "pyspark_empty",
+        "pyspark_single_null",
+        "pyspark_single_not_null",
+        "pyspark_other_columns_ignored",
+        "pyspark_mixed_data_types",
+        "pyspark_precision_boundary",
+    ],
 )
-def test_column_missing_error(df_type, spark):
+def test_expectation_basic_scenarios_pyspark(
+    df_type, df_data, column_name, max_percentage, expected_result, expected_message, spark
+):
     """
-    Test that an error is raised when the specified column is missing in both pandas and PySpark.
+    Test the expectation for various scenarios across PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases, failures (exceeds threshold), edge cases (empty, zero/hundred threshold, single values),
+    boundary conditions, column isolation, mixed data types, and precision boundaries.
+    """
+    data_frame = create_pyspark_dataframe(df_data, spark)
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationMaxNullPercentage",
+        column_name=column_name,
+        max_percentage=max_percentage,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationMaxNullPercentage")
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=df_type,
+            message=expected_message,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_max_null_percentage(
+        column_name=column_name, max_percentage=max_percentage
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+def test_column_missing_error_pandas():
+    """
+    Test that an error is raised when the specified column is missing in pandas.
     Tests both direct expectation validation and suite-based validation.
     """
-    # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
         expectation_name="ExpectationMaxNullPercentage",
         column_name="nonexistent_col",
         max_percentage=50.0,
     )
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
-    else:  # pyspark
-        data_frame = spark.createDataFrame([(1, 4), (2, 5), (3, 6)], ["col1", "col2"])
+    data_frame = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
 
     result = expectation.validate(data_frame=data_frame)
-    # The error message might vary, but should be a failure
     assert isinstance(result, DataFrameExpectationFailureMessage), (
         f"Expected DataFrameExpectationFailureMessage but got: {type(result)}"
     )
@@ -308,7 +367,36 @@ def test_column_missing_error(df_type, spark):
         f"Expected 'nonexistent_col' in result message: {result_str}"
     )
 
-    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_max_null_percentage(
+        column_name="nonexistent_col", max_percentage=50.0
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """
+    Test that an error is raised when the specified column is missing in PySpark.
+    Tests both direct expectation validation and suite-based validation.
+    """
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationMaxNullPercentage",
+        column_name="nonexistent_col",
+        max_percentage=50.0,
+    )
+
+    data_frame = spark.createDataFrame([(1, 4), (2, 5), (3, 6)], ["col1", "col2"])
+
+    result = expectation.validate(data_frame=data_frame)
+    assert isinstance(result, DataFrameExpectationFailureMessage), (
+        f"Expected DataFrameExpectationFailureMessage but got: {type(result)}"
+    )
+    result_str = str(result)
+    assert "nonexistent_col" in result_str, (
+        f"Expected 'nonexistent_col' in result message: {result_str}"
+    )
+
     expectations_suite = DataFrameExpectationsSuite().expect_max_null_percentage(
         column_name="nonexistent_col", max_percentage=50.0
     )

--- a/tests/expectations/aggregation/any_value_expectations/test_expect_max_rows.py
+++ b/tests/expectations/aggregation/any_value_expectations/test_expect_max_rows.py
@@ -7,19 +7,16 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, df_data, spark):
-    """Helper function to create pandas or pyspark DataFrame."""
-    if df_type == "pandas":
-        return pd.DataFrame(df_data)
-
+def create_pyspark_dataframe(df_data, spark):
+    """Helper function to create a PySpark DataFrame."""
     # PySpark
     from pyspark.sql.types import (
         StructType,
@@ -53,7 +50,6 @@ def create_dataframe(df_type, df_data, spark):
     [
         # Exact count - 3 rows == 3 max
         ("pandas", {"col1": [1, 2, 3], "col2": ["a", "b", "c"]}, 3, "success", None),
-        ("pyspark", {"col1": [1, 2, 3], "col2": ["a", "b", "c"]}, 3, "success", None),
         # Below max - 5 rows < 10 max
         (
             "pandas",
@@ -62,19 +58,10 @@ def create_dataframe(df_type, df_data, spark):
             "success",
             None,
         ),
-        (
-            "pyspark",
-            {"col1": [1, 2, 3, 4, 5], "col2": ["a", "b", "c", "d", "e"]},
-            10,
-            "success",
-            None,
-        ),
         # Single row - 1 row == 1 max
         ("pandas", {"col1": [42]}, 1, "success", None),
-        ("pyspark", {"col1": [42]}, 1, "success", None),
         # Empty DataFrame - 0 rows <= 5 max
         ("pandas", {"col1": []}, 5, "success", None),
-        ("pyspark", {}, 5, "success", None),
         # Exceeds max - 5 rows > 3 max
         (
             "pandas",
@@ -83,19 +70,10 @@ def create_dataframe(df_type, df_data, spark):
             "failure",
             "DataFrame has 5 rows, expected at most 3.",
         ),
-        (
-            "pyspark",
-            {"col1": [1, 2, 3, 4, 5], "col2": ["a", "b", "c", "d", "e"]},
-            3,
-            "failure",
-            "DataFrame has 5 rows, expected at most 3.",
-        ),
         # Zero max with data - 1 row > 0 max
         ("pandas", {"col1": [1]}, 0, "failure", "DataFrame has 1 rows, expected at most 0."),
-        ("pyspark", {"col1": [1]}, 0, "failure", "DataFrame has 1 rows, expected at most 0."),
         # Zero max empty - 0 rows == 0 max
         ("pandas", {"col1": []}, 0, "success", None),
-        ("pyspark", {}, 0, "success", None),
         # Large dataset - 150 rows > 100 max
         (
             "pandas",
@@ -103,13 +81,6 @@ def create_dataframe(df_type, df_data, spark):
             100,
             "failure",
             "DataFrame has 150 rows, expected at most 100.",
-        ),
-        (
-            "pyspark",
-            {"col1": list(range(75)), "col2": [f"value_{i}" for i in range(75)]},
-            50,
-            "failure",
-            "DataFrame has 75 rows, expected at most 50.",
         ),
         # With nulls - 5 rows > 4 max (nulls don't affect row count)
         (
@@ -119,28 +90,9 @@ def create_dataframe(df_type, df_data, spark):
             "failure",
             "DataFrame has 5 rows, expected at most 4.",
         ),
-        (
-            "pyspark",
-            {"col1": [1, None, 3, None, 5], "col2": [None, "b", None, "d", None]},
-            4,
-            "failure",
-            "DataFrame has 5 rows, expected at most 4.",
-        ),
         # Multiple columns - 4 rows > 3 max
         (
             "pandas",
-            {
-                "col1": [1, 2, 3, 4],
-                "col2": ["a", "b", "c", "d"],
-                "col3": [1.1, 2.2, 3.3, 4.4],
-                "col4": [True, False, True, False],
-            },
-            3,
-            "failure",
-            "DataFrame has 4 rows, expected at most 3.",
-        ),
-        (
-            "pyspark",
             {
                 "col1": [1, 2, 3, 4],
                 "col2": ["a", "b", "c", "d"],
@@ -165,6 +117,147 @@ def create_dataframe(df_type, df_data, spark):
             "success",
             None,
         ),
+        # High max rows - 3 rows << 1000000 max
+        ("pandas", {"col1": [1, 2, 3]}, 1000000, "success", None),
+        # Boundary condition 1 - 1 row == 1 max
+        ("pandas", {"col1": [1]}, 1, "success", None),
+        # Boundary condition 2 - 2 rows > 1 max
+        ("pandas", {"col1": [1, 2]}, 1, "failure", "DataFrame has 2 rows, expected at most 1."),
+        # Identical values - 4 rows > 3 max
+        (
+            "pandas",
+            {"col1": [42, 42, 42, 42], "col2": ["same", "same", "same", "same"]},
+            3,
+            "failure",
+            "DataFrame has 4 rows, expected at most 3.",
+        ),
+    ],
+    ids=[
+        "pandas_exact_count",
+        "pandas_below_max",
+        "pandas_single_row",
+        "pandas_empty",
+        "pandas_exceeds_max",
+        "pandas_zero_max_with_data",
+        "pandas_zero_max_empty",
+        "pandas_large_dataset",
+        "pandas_with_nulls",
+        "pandas_multiple_columns",
+        "pandas_mixed_data_types",
+        "pandas_high_max_rows",
+        "pandas_boundary_condition_1",
+        "pandas_boundary_condition_2",
+        "pandas_identical_values",
+    ],
+)
+def test_expectation_basic_scenarios_pandas(
+    df_type, df_data, max_rows, expected_result, expected_message
+):
+    """
+    Test the expectation for various scenarios across pandas DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases, failures (exceeds max), edge cases (empty, zero max, single row),
+    boundary conditions, large datasets, nulls, multiple columns, mixed data types, and identical values.
+    """
+    data_frame = pd.DataFrame(df_data, columns=["col1"])
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationMaxRows",
+        max_rows=max_rows,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationMaxRows")
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            message=expected_message,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_max_rows(max_rows=max_rows)
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+@pytest.mark.parametrize(
+    "df_type, df_data, max_rows, expected_result, expected_message",
+    [
+        # Exact count - 3 rows == 3 max
+        ("pyspark", {"col1": [1, 2, 3], "col2": ["a", "b", "c"]}, 3, "success", None),
+        # Below max - 5 rows < 10 max
+        (
+            "pyspark",
+            {"col1": [1, 2, 3, 4, 5], "col2": ["a", "b", "c", "d", "e"]},
+            10,
+            "success",
+            None,
+        ),
+        # Single row - 1 row == 1 max
+        ("pyspark", {"col1": [42]}, 1, "success", None),
+        # Empty DataFrame - 0 rows <= 5 max
+        ("pyspark", {}, 5, "success", None),
+        # Exceeds max - 5 rows > 3 max
+        (
+            "pyspark",
+            {"col1": [1, 2, 3, 4, 5], "col2": ["a", "b", "c", "d", "e"]},
+            3,
+            "failure",
+            "DataFrame has 5 rows, expected at most 3.",
+        ),
+        # Zero max with data - 1 row > 0 max
+        ("pyspark", {"col1": [1]}, 0, "failure", "DataFrame has 1 rows, expected at most 0."),
+        # Zero max empty - 0 rows == 0 max
+        ("pyspark", {}, 0, "success", None),
+        # Large dataset - 150 rows > 100 max
+        (
+            "pyspark",
+            {"col1": list(range(75)), "col2": [f"value_{i}" for i in range(75)]},
+            50,
+            "failure",
+            "DataFrame has 75 rows, expected at most 50.",
+        ),
+        # With nulls - 5 rows > 4 max (nulls don't affect row count)
+        (
+            "pyspark",
+            {"col1": [1, None, 3, None, 5], "col2": [None, "b", None, "d", None]},
+            4,
+            "failure",
+            "DataFrame has 5 rows, expected at most 4.",
+        ),
+        # Multiple columns - 4 rows > 3 max
+        (
+            "pyspark",
+            {
+                "col1": [1, 2, 3, 4],
+                "col2": ["a", "b", "c", "d"],
+                "col3": [1.1, 2.2, 3.3, 4.4],
+                "col4": [True, False, True, False],
+            },
+            3,
+            "failure",
+            "DataFrame has 4 rows, expected at most 3.",
+        ),
+        # Mixed data types - 5 rows <= 10 max
         (
             "pyspark",
             {
@@ -179,22 +272,12 @@ def create_dataframe(df_type, df_data, spark):
             None,
         ),
         # High max rows - 3 rows << 1000000 max
-        ("pandas", {"col1": [1, 2, 3]}, 1000000, "success", None),
         ("pyspark", {"col1": [1, 2, 3]}, 1000000, "success", None),
         # Boundary condition 1 - 1 row == 1 max
-        ("pandas", {"col1": [1]}, 1, "success", None),
         ("pyspark", {"col1": [1]}, 1, "success", None),
         # Boundary condition 2 - 2 rows > 1 max
-        ("pandas", {"col1": [1, 2]}, 1, "failure", "DataFrame has 2 rows, expected at most 1."),
         ("pyspark", {"col1": [1, 2]}, 1, "failure", "DataFrame has 2 rows, expected at most 1."),
         # Identical values - 4 rows > 3 max
-        (
-            "pandas",
-            {"col1": [42, 42, 42, 42], "col2": ["same", "same", "same", "same"]},
-            3,
-            "failure",
-            "DataFrame has 4 rows, expected at most 3.",
-        ),
         (
             "pyspark",
             {"col1": [42, 42, 42, 42], "col2": ["same", "same", "same", "same"]},
@@ -204,39 +287,24 @@ def create_dataframe(df_type, df_data, spark):
         ),
     ],
     ids=[
-        "pandas_exact_count",
         "pyspark_exact_count",
-        "pandas_below_max",
         "pyspark_below_max",
-        "pandas_single_row",
         "pyspark_single_row",
-        "pandas_empty",
         "pyspark_empty",
-        "pandas_exceeds_max",
         "pyspark_exceeds_max",
-        "pandas_zero_max_with_data",
         "pyspark_zero_max_with_data",
-        "pandas_zero_max_empty",
         "pyspark_zero_max_empty",
-        "pandas_large_dataset",
         "pyspark_large_dataset",
-        "pandas_with_nulls",
         "pyspark_with_nulls",
-        "pandas_multiple_columns",
         "pyspark_multiple_columns",
-        "pandas_mixed_data_types",
         "pyspark_mixed_data_types",
-        "pandas_high_max_rows",
         "pyspark_high_max_rows",
-        "pandas_boundary_condition_1",
         "pyspark_boundary_condition_1",
-        "pandas_boundary_condition_2",
         "pyspark_boundary_condition_2",
-        "pandas_identical_values",
         "pyspark_identical_values",
     ],
 )
-def test_expectation_basic_scenarios(
+def test_expectation_basic_scenarios_pyspark(
     df_type, df_data, max_rows, expected_result, expected_message, spark
 ):
     """
@@ -245,7 +313,7 @@ def test_expectation_basic_scenarios(
     Covers: success cases, failures (exceeds max), edge cases (empty, zero max, single row),
     boundary conditions, large datasets, nulls, multiple columns, mixed data types, and identical values.
     """
-    data_frame = create_dataframe(df_type, df_data, spark)
+    data_frame = create_pyspark_dataframe(df_type, df_data, spark)
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(

--- a/tests/expectations/aggregation/any_value_expectations/test_expect_max_rows.py
+++ b/tests/expectations/aggregation/any_value_expectations/test_expect_max_rows.py
@@ -313,7 +313,7 @@ def test_expectation_basic_scenarios_pyspark(
     Covers: success cases, failures (exceeds max), edge cases (empty, zero max, single row),
     boundary conditions, large datasets, nulls, multiple columns, mixed data types, and identical values.
     """
-    data_frame = create_pyspark_dataframe(df_type, df_data, spark)
+    data_frame = create_pyspark_dataframe(df_data, spark)
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(

--- a/tests/expectations/aggregation/any_value_expectations/test_expect_min_rows.py
+++ b/tests/expectations/aggregation/any_value_expectations/test_expect_min_rows.py
@@ -7,20 +7,21 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, df_data, spark):
-    """Helper function to create pandas or pyspark DataFrame."""
-    if df_type == "pandas":
-        return pd.DataFrame(df_data)
+def create_pyspark_dataframe(df_data, spark):
+    """Helper function to create a PySpark DataFrame.
 
-    # PySpark
+    Args:
+        df_data: dict mapping column names to lists of values, or empty dict
+        spark: Spark session
+    """
     from pyspark.sql.types import (
         StructType,
         StructField,
@@ -53,7 +54,6 @@ def create_dataframe(df_type, df_data, spark):
     [
         # Exact count - 3 rows == 3 min
         ("pandas", {"col1": [1, 2, 3], "col2": ["a", "b", "c"]}, 3, "success", None),
-        ("pyspark", {"col1": [1, 2, 3], "col2": ["a", "b", "c"]}, 3, "success", None),
         # Above min - 5 rows > 3 min
         (
             "pandas",
@@ -62,32 +62,15 @@ def create_dataframe(df_type, df_data, spark):
             "success",
             None,
         ),
-        (
-            "pyspark",
-            {"col1": [1, 2, 3, 4, 5], "col2": ["a", "b", "c", "d", "e"]},
-            3,
-            "success",
-            None,
-        ),
         # Single row - 1 row == 1 min
         ("pandas", {"col1": [42]}, 1, "success", None),
-        ("pyspark", {"col1": [42]}, 1, "success", None),
         # Zero min empty - 0 rows == 0 min
         ("pandas", {"col1": []}, 0, "success", None),
-        ("pyspark", {}, 0, "success", None),
         # Zero min with data - 3 rows >= 0 min
         ("pandas", {"col1": [1, 2, 3]}, 0, "success", None),
-        ("pyspark", {"col1": [1, 2, 3]}, 0, "success", None),
         # With nulls - 5 rows >= 3 min (nulls don't affect row count)
         (
             "pandas",
-            {"col1": [1, None, 3, None, 5], "col2": [None, "b", None, "d", None]},
-            3,
-            "success",
-            None,
-        ),
-        (
-            "pyspark",
             {"col1": [1, None, 3, None, 5], "col2": [None, "b", None, "d", None]},
             3,
             "success",
@@ -101,31 +84,15 @@ def create_dataframe(df_type, df_data, spark):
             "failure",
             "DataFrame has 3 rows, expected at least 5.",
         ),
-        (
-            "pyspark",
-            {"col1": [1, 2, 3], "col2": ["a", "b", "c"]},
-            5,
-            "failure",
-            "DataFrame has 3 rows, expected at least 5.",
-        ),
         # Empty needs min - 0 rows < 2 min
         ("pandas", {"col1": []}, 2, "failure", "DataFrame has 0 rows, expected at least 2."),
-        ("pyspark", {}, 2, "failure", "DataFrame has 0 rows, expected at least 2."),
         # Single row needs more - 1 row < 3 min
         ("pandas", {"col1": [1]}, 3, "failure", "DataFrame has 1 rows, expected at least 3."),
-        ("pyspark", {"col1": [1]}, 3, "failure", "DataFrame has 1 rows, expected at least 3."),
         # Large dataset success - 150 rows >= 100 min
         (
             "pandas",
             {"col1": list(range(150)), "col2": [f"value_{i}" for i in range(150)]},
             100,
-            "success",
-            None,
-        ),
-        (
-            "pyspark",
-            {"col1": list(range(75)), "col2": [f"value_{i}" for i in range(75)]},
-            50,
             "success",
             None,
         ),
@@ -137,28 +104,9 @@ def create_dataframe(df_type, df_data, spark):
             "failure",
             "DataFrame has 150 rows, expected at least 200.",
         ),
-        (
-            "pyspark",
-            {"col1": list(range(75)), "col2": [f"value_{i}" for i in range(75)]},
-            100,
-            "failure",
-            "DataFrame has 75 rows, expected at least 100.",
-        ),
         # Multiple columns - 4 rows >= 3 min
         (
             "pandas",
-            {
-                "col1": [1, 2, 3, 4],
-                "col2": ["a", "b", "c", "d"],
-                "col3": [1.1, 2.2, 3.3, 4.4],
-                "col4": [True, False, True, False],
-            },
-            3,
-            "success",
-            None,
-        ),
-        (
-            "pyspark",
             {
                 "col1": [1, 2, 3, 4],
                 "col2": ["a", "b", "c", "d"],
@@ -183,32 +131,11 @@ def create_dataframe(df_type, df_data, spark):
             "success",
             None,
         ),
-        (
-            "pyspark",
-            {
-                "int_col": [1, 2, 3, 4, 5],
-                "str_col": ["a", "b", "c", "d", "e"],
-                "float_col": [1.1, 2.2, 3.3, 4.4, 5.5],
-                "bool_col": [True, False, True, False, True],
-                "null_col": [None, None, None, None, None],
-            },
-            3,
-            "success",
-            None,
-        ),
         # Low min count - 3 rows >= 1 min
         ("pandas", {"col1": [1, 2, 3]}, 1, "success", None),
-        ("pyspark", {"col1": [1, 2, 3]}, 1, "success", None),
         # High min count - 3 rows < 1000000 min
         (
             "pandas",
-            {"col1": [1, 2, 3]},
-            1000000,
-            "failure",
-            "DataFrame has 3 rows, expected at least 1000000.",
-        ),
-        (
-            "pyspark",
             {"col1": [1, 2, 3]},
             1000000,
             "failure",
@@ -222,30 +149,13 @@ def create_dataframe(df_type, df_data, spark):
             "success",
             None,
         ),
-        (
-            "pyspark",
-            {"col1": [42, 42, 42, 42], "col2": ["same", "same", "same", "same"]},
-            3,
-            "success",
-            None,
-        ),
         # Boundary condition - 1 row == 1 min (edge case equals actual)
         ("pandas", {"col1": [1]}, 1, "success", None),
-        ("pyspark", {"col1": [1]}, 1, "success", None),
         # Progressive counts - 5 rows meets various minimums
         ("pandas", {"col1": [1, 2, 3, 4, 5]}, 5, "success", None),
-        ("pyspark", {"col1": [1, 2, 3, 4, 5]}, 5, "success", None),
         ("pandas", {"col1": [1, 2, 3, 4, 5]}, 4, "success", None),
-        ("pyspark", {"col1": [1, 2, 3, 4, 5]}, 4, "success", None),
         (
             "pandas",
-            {"col1": [1, 2, 3, 4, 5]},
-            6,
-            "failure",
-            "DataFrame has 5 rows, expected at least 6.",
-        ),
-        (
-            "pyspark",
             {"col1": [1, 2, 3, 4, 5]},
             6,
             "failure",
@@ -254,58 +164,38 @@ def create_dataframe(df_type, df_data, spark):
     ],
     ids=[
         "pandas_exact_count",
-        "pyspark_exact_count",
         "pandas_above_min",
-        "pyspark_above_min",
         "pandas_single_row",
-        "pyspark_single_row",
         "pandas_zero_min_empty",
-        "pyspark_zero_min_empty",
         "pandas_zero_min_with_data",
-        "pyspark_zero_min_with_data",
         "pandas_with_nulls",
-        "pyspark_with_nulls",
         "pandas_below_min",
-        "pyspark_below_min",
         "pandas_empty_needs_min",
-        "pyspark_empty_needs_min",
         "pandas_single_row_needs_more",
-        "pyspark_single_row_needs_more",
         "pandas_large_dataset",
-        "pyspark_large_dataset",
         "pandas_large_dataset_failure",
-        "pyspark_large_dataset_failure",
         "pandas_multiple_columns",
-        "pyspark_multiple_columns",
         "pandas_mixed_data_types",
-        "pyspark_mixed_data_types",
         "pandas_low_min_count",
-        "pyspark_low_min_count",
         "pandas_high_min_count",
-        "pyspark_high_min_count",
         "pandas_identical_values",
-        "pyspark_identical_values",
         "pandas_boundary_condition",
-        "pyspark_boundary_condition",
         "pandas_progressive_count_at_min",
-        "pyspark_progressive_count_at_min",
         "pandas_progressive_count_below_min",
-        "pyspark_progressive_count_below_min",
         "pandas_progressive_count_above_min",
-        "pyspark_progressive_count_above_min",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, df_data, min_rows, expected_result, expected_message, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, df_data, min_rows, expected_result, expected_message
 ):
     """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
+    Test the expectation for various scenarios across pandas DataFrames.
     Tests both direct expectation validation and suite-based validation.
     Covers: success cases (exact, above min, zero min), failures (below min, empty), edge cases,
     boundary conditions, large datasets, nulls, multiple columns, mixed data types, identical values,
     progressive counts, and dataframe structure variations.
     """
-    data_frame = create_dataframe(df_type, df_data, spark)
+    data_frame = pd.DataFrame(df_data)
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -322,7 +212,193 @@ def test_expectation_basic_scenarios(
     else:  # failure
         expected_failure_message = DataFrameExpectationFailureMessage(
             expectation_str=str(expectation),
-            data_frame_type=str(df_type),
+            data_frame_type=df_type,
+            message=expected_message,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_min_rows(min_rows=min_rows)
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+@pytest.mark.parametrize(
+    "df_type, df_data, min_rows, expected_result, expected_message",
+    [
+        # Exact count - 3 rows == 3 min
+        ("pyspark", {"col1": [1, 2, 3], "col2": ["a", "b", "c"]}, 3, "success", None),
+        # Above min - 5 rows > 3 min
+        (
+            "pyspark",
+            {"col1": [1, 2, 3, 4, 5], "col2": ["a", "b", "c", "d", "e"]},
+            3,
+            "success",
+            None,
+        ),
+        # Single row - 1 row == 1 min
+        ("pyspark", {"col1": [42]}, 1, "success", None),
+        # Zero min empty - 0 rows == 0 min
+        ("pyspark", {}, 0, "success", None),
+        # Zero min with data - 3 rows >= 0 min
+        ("pyspark", {"col1": [1, 2, 3]}, 0, "success", None),
+        # With nulls - 5 rows >= 3 min (nulls don't affect row count)
+        (
+            "pyspark",
+            {"col1": [1, None, 3, None, 5], "col2": [None, "b", None, "d", None]},
+            3,
+            "success",
+            None,
+        ),
+        # Below min - 3 rows < 5 min
+        (
+            "pyspark",
+            {"col1": [1, 2, 3], "col2": ["a", "b", "c"]},
+            5,
+            "failure",
+            "DataFrame has 3 rows, expected at least 5.",
+        ),
+        # Empty needs min - 0 rows < 2 min
+        ("pyspark", {}, 2, "failure", "DataFrame has 0 rows, expected at least 2."),
+        # Single row needs more - 1 row < 3 min
+        ("pyspark", {"col1": [1]}, 3, "failure", "DataFrame has 1 rows, expected at least 3."),
+        # Large dataset success - 75 rows >= 50 min
+        (
+            "pyspark",
+            {"col1": list(range(75)), "col2": [f"value_{i}" for i in range(75)]},
+            50,
+            "success",
+            None,
+        ),
+        # Large dataset failure - 75 rows < 100 min
+        (
+            "pyspark",
+            {"col1": list(range(75)), "col2": [f"value_{i}" for i in range(75)]},
+            100,
+            "failure",
+            "DataFrame has 75 rows, expected at least 100.",
+        ),
+        # Multiple columns - 4 rows >= 3 min
+        (
+            "pyspark",
+            {
+                "col1": [1, 2, 3, 4],
+                "col2": ["a", "b", "c", "d"],
+                "col3": [1.1, 2.2, 3.3, 4.4],
+                "col4": [True, False, True, False],
+            },
+            3,
+            "success",
+            None,
+        ),
+        # Mixed data types - 5 rows >= 3 min
+        (
+            "pyspark",
+            {
+                "int_col": [1, 2, 3, 4, 5],
+                "str_col": ["a", "b", "c", "d", "e"],
+                "float_col": [1.1, 2.2, 3.3, 4.4, 5.5],
+                "bool_col": [True, False, True, False, True],
+                "null_col": [None, None, None, None, None],
+            },
+            3,
+            "success",
+            None,
+        ),
+        # Low min count - 3 rows >= 1 min
+        ("pyspark", {"col1": [1, 2, 3]}, 1, "success", None),
+        # High min count - 3 rows < 1000000 min
+        (
+            "pyspark",
+            {"col1": [1, 2, 3]},
+            1000000,
+            "failure",
+            "DataFrame has 3 rows, expected at least 1000000.",
+        ),
+        # Identical values - 4 rows >= 3 min
+        (
+            "pyspark",
+            {"col1": [42, 42, 42, 42], "col2": ["same", "same", "same", "same"]},
+            3,
+            "success",
+            None,
+        ),
+        # Boundary condition - 1 row == 1 min (edge case equals actual)
+        ("pyspark", {"col1": [1]}, 1, "success", None),
+        # Progressive counts - 5 rows meets various minimums
+        ("pyspark", {"col1": [1, 2, 3, 4, 5]}, 5, "success", None),
+        ("pyspark", {"col1": [1, 2, 3, 4, 5]}, 4, "success", None),
+        (
+            "pyspark",
+            {"col1": [1, 2, 3, 4, 5]},
+            6,
+            "failure",
+            "DataFrame has 5 rows, expected at least 6.",
+        ),
+    ],
+    ids=[
+        "pyspark_exact_count",
+        "pyspark_above_min",
+        "pyspark_single_row",
+        "pyspark_zero_min_empty",
+        "pyspark_zero_min_with_data",
+        "pyspark_with_nulls",
+        "pyspark_below_min",
+        "pyspark_empty_needs_min",
+        "pyspark_single_row_needs_more",
+        "pyspark_large_dataset",
+        "pyspark_large_dataset_failure",
+        "pyspark_multiple_columns",
+        "pyspark_mixed_data_types",
+        "pyspark_low_min_count",
+        "pyspark_high_min_count",
+        "pyspark_identical_values",
+        "pyspark_boundary_condition",
+        "pyspark_progressive_count_at_min",
+        "pyspark_progressive_count_below_min",
+        "pyspark_progressive_count_above_min",
+    ],
+)
+def test_expectation_basic_scenarios_pyspark(
+    df_type, df_data, min_rows, expected_result, expected_message, spark
+):
+    """
+    Test the expectation for various scenarios across PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases (exact, above min, zero min), failures (below min, empty), edge cases,
+    boundary conditions, large datasets, nulls, multiple columns, mixed data types, identical values,
+    progressive counts, and dataframe structure variations.
+    """
+    data_frame = create_pyspark_dataframe(df_data, spark)
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationMinRows",
+        min_rows=min_rows,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationMinRows")
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=df_type,
             message=expected_message,
         )
         assert str(result) == str(expected_failure_message), (

--- a/tests/expectations/aggregation/any_value_expectations/test_expect_unique_rows.py
+++ b/tests/expectations/aggregation/any_value_expectations/test_expect_unique_rows.py
@@ -15,7 +15,7 @@ from dataframe_expectations.result_message import (
 )
 
 
-def create_pyspark_dataframe(df_type, df_data, spark):
+def create_pyspark_dataframe(df_data, spark):
     """Helper function to create pandas or pyspark DataFrame."""
     from pyspark.sql.types import StructType, StructField, IntegerType
 
@@ -210,49 +210,51 @@ def test_expectation_basic_scenarios_pandas(
             None,
             None,
         ),
-        # Pandas success - single row
+        # PySpark success - single row
         (
-            "pandas",
-            {"col1": [1]},
+            "pyspark",
+            ([(1,)], ["col1"]),
             ["col1"],
             "success",
             None,
             None,
         ),
-        # Pandas failure - specific columns with duplicates
+        # PySpark failure - specific columns with duplicates
         (
-            "pandas",
-            {"col1": [1, 2, 1, 3], "col2": [10, 20, 10, 30], "col3": [100, 200, 300, 400]},
+            "pyspark",
+            ([(1, 10, 100), (2, 20, 200), (1, 10, 300), (3, 30, 400)], ["col1", "col2", "col3"]),
             ["col1", "col2"],
             "failure",
-            pd.DataFrame({"col1": [1], "col2": [10], "#duplicates": [2]}),
+            ([(1, 10, 2)], ["col1", "col2", "#duplicates"]),
             "Found 2 duplicate row(s). duplicate rows found for columns ['col1', 'col2']",
         ),
-        # Pandas failure - all columns with duplicates
+        # PySpark failure - all columns with duplicates
         (
-            "pandas",
-            {"col1": [1, 2, 1], "col2": [10, 20, 10], "col3": [100, 200, 100]},
+            "pyspark",
+            ([(1, 10, 100), (2, 20, 200), (1, 10, 100)], ["col1", "col2", "col3"]),
             [],
             "failure",
-            pd.DataFrame({"col1": [1], "col2": [10], "col3": [100], "#duplicates": [2]}),
+            ([(1, 10, 100, 2)], ["col1", "col2", "col3", "#duplicates"]),
             "Found 2 duplicate row(s). duplicate rows found",
         ),
-        # Pandas failure - multiple duplicate groups
+        # PySpark failure - multiple duplicate groups
         (
-            "pandas",
-            {"col1": [1, 2, 1, 3, 2, 3], "col2": [10, 20, 30, 40, 50, 60]},
+            "pyspark",
+            ([(1, 10), (2, 20), (1, 30), (3, 40), (2, 50), (3, 60)], ["col1", "col2"]),
             ["col1"],
             "failure",
-            pd.DataFrame({"col1": [1, 2, 3], "#duplicates": [2, 2, 2]}),
+            ([(1, 2), (2, 2), (3, 2)], ["col1", "#duplicates"]),
             "Found 6 duplicate row(s). duplicate rows found for columns ['col1']",
         ),
-        # Pandas failure - with nulls (nulls counted as duplicates)
+        # PySpark failure - with nulls (nulls counted as duplicates)
+        # expected_violations=None: Spark cannot infer a schema from all-null group keys,
+        # so we perform a message-only assertion for this case.
         (
-            "pandas",
-            {"col1": [1, None, 1, None], "col2": [10, None, 20, None]},
+            "pyspark",
+            ([(1, 10), (None, None), (1, 20), (None, None)], ["col1", "col2"]),
             ["col1", "col2"],
             "failure",
-            pd.DataFrame({"col1": [None], "col2": [None], "#duplicates": [2]}),
+            None,
             "Found 2 duplicate row(s). duplicate rows found for columns ['col1', 'col2']",
         ),
     ],
@@ -267,7 +269,7 @@ def test_expectation_basic_scenarios_pandas(
         "pyspark_with_nulls",
     ],
 )
-def test_expectation_basic_scenarios(
+def test_expectation_basic_scenarios_pyspark(
     df_type, df_data, column_names, expected_result, expected_violations, expected_message, spark
 ):
     """
@@ -294,26 +296,31 @@ def test_expectation_basic_scenarios(
             DataFrameExpectationSuccessMessage(expectation_name="ExpectationUniqueRows")
         ), f"Expected success message but got: {result}"
     else:  # failure
-        # Create violations DataFrame
-        if isinstance(expected_violations[0], StructType):
-            # Schema and data provided separately
-            schema, data = expected_violations
-            violations_df = spark.createDataFrame(data, schema)
+        if expected_violations is None:
+            # Message-only check — used when violations contain all-null group keys
+            # because Spark cannot infer a schema from an all-null row.
+            assert expected_message in str(result), f"Expected failure message but got: {result}"
         else:
-            # Rows and columns provided
-            rows, columns = expected_violations
-            violations_df = spark.createDataFrame(rows, columns)
+            # Create violations DataFrame
+            if isinstance(expected_violations[0], StructType):
+                # Schema and data provided separately
+                schema, data = expected_violations
+                violations_df = spark.createDataFrame(data, schema)
+            else:
+                # Rows and columns provided
+                rows, columns = expected_violations
+                violations_df = spark.createDataFrame(rows, columns)
 
-        expected_failure_message = DataFrameExpectationFailureMessage(
-            expectation_str=str(expectation),
-            data_frame_type=str(df_type),
-            violations_data_frame=violations_df,
-            message=expected_message,
-            limit_violations=5,
-        )
-        assert str(result) == str(expected_failure_message), (
-            f"Expected failure message but got: {result}"
-        )
+            expected_failure_message = DataFrameExpectationFailureMessage(
+                expectation_str=str(expectation),
+                data_frame_type=str(df_type),
+                violations_data_frame=violations_df,
+                message=expected_message,
+                limit_violations=5,
+            )
+            assert str(result) == str(expected_failure_message), (
+                f"Expected failure message but got: {result}"
+            )
 
     # Test 2: Suite-based validation
     expectations_suite = DataFrameExpectationsSuite().expect_unique_rows(column_names=column_names)
@@ -372,7 +379,7 @@ def test_column_missing_error_pyspark(spark):
         column_names=["nonexistent_col"],
     )
 
-    data_frame = spark.createDataFrame([(1,), (2,), (3,)], ["col1"])
+    data_frame = create_pyspark_dataframe(([(1,), (2,), (3,)], ["col1"]), spark)
 
     # Test 1: Direct expectation validation
     result = expectation.validate(data_frame=data_frame)

--- a/tests/expectations/aggregation/any_value_expectations/test_expect_unique_rows.py
+++ b/tests/expectations/aggregation/any_value_expectations/test_expect_unique_rows.py
@@ -1,6 +1,5 @@
 import pytest
 import pandas as pd
-from pyspark.sql.types import IntegerType, StructField, StructType
 
 from dataframe_expectations.registry import (
     DataFrameExpectationRegistry,
@@ -8,20 +7,16 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, df_data, spark):
+def create_pyspark_dataframe(df_type, df_data, spark):
     """Helper function to create pandas or pyspark DataFrame."""
-    if df_type == "pandas":
-        return pd.DataFrame(df_data)
-
-    # PySpark
     from pyspark.sql.types import StructType, StructField, IntegerType
 
     if not df_data:
@@ -56,28 +51,10 @@ def test_expectation_name():
             None,
             None,
         ),
-        # PySpark success - specific columns
-        (
-            "pyspark",
-            ([(1, 10, 100), (2, 20, 100), (3, 30, 100), (1, 20, 100)], ["col1", "col2", "col3"]),
-            ["col1", "col2"],
-            "success",
-            None,
-            None,
-        ),
         # Pandas success - all columns (empty list)
         (
             "pandas",
             {"col1": [1, 2, 3], "col2": [10, 20, 30], "col3": [100, 200, 300]},
-            [],
-            "success",
-            None,
-            None,
-        ),
-        # PySpark success - all columns
-        (
-            "pyspark",
-            ([(1, 10, 100), (2, 20, 200), (3, 30, 300)], ["col1", "col2", "col3"]),
             [],
             "success",
             None,
@@ -92,28 +69,10 @@ def test_expectation_name():
             None,
             None,
         ),
-        # PySpark success - empty DataFrame
-        (
-            "pyspark",
-            ([], "col1: int"),
-            ["col1"],
-            "success",
-            None,
-            None,
-        ),
         # Pandas success - single row
         (
             "pandas",
             {"col1": [1]},
-            ["col1"],
-            "success",
-            None,
-            None,
-        ),
-        # PySpark success - single row
-        (
-            "pyspark",
-            ([(1,)], ["col1"]),
             ["col1"],
             "success",
             None,
@@ -128,15 +87,6 @@ def test_expectation_name():
             pd.DataFrame({"col1": [1], "col2": [10], "#duplicates": [2]}),
             "Found 2 duplicate row(s). duplicate rows found for columns ['col1', 'col2']",
         ),
-        # PySpark failure - specific columns with duplicates
-        (
-            "pyspark",
-            ([(1, 10, 100), (2, 20, 200), (1, 10, 300), (3, 30, 400)], ["col1", "col2", "col3"]),
-            ["col1", "col2"],
-            "failure",
-            ([(1, 10, 2)], ["col1", "col2", "#duplicates"]),
-            "Found 2 duplicate row(s). duplicate rows found for columns ['col1', 'col2']",
-        ),
         # Pandas failure - all columns with duplicates
         (
             "pandas",
@@ -144,15 +94,6 @@ def test_expectation_name():
             [],
             "failure",
             pd.DataFrame({"col1": [1], "col2": [10], "col3": [100], "#duplicates": [2]}),
-            "Found 2 duplicate row(s). duplicate rows found",
-        ),
-        # PySpark failure - all columns with duplicates
-        (
-            "pyspark",
-            ([(1, 10, 100), (2, 20, 200), (1, 10, 100)], ["col1", "col2", "col3"]),
-            [],
-            "failure",
-            ([(1, 10, 100, 2)], ["col1", "col2", "col3", "#duplicates"]),
             "Found 2 duplicate row(s). duplicate rows found",
         ),
         # Pandas failure - multiple duplicate groups
@@ -164,15 +105,6 @@ def test_expectation_name():
             pd.DataFrame({"col1": [1, 2, 3], "#duplicates": [2, 2, 2]}),
             "Found 6 duplicate row(s). duplicate rows found for columns ['col1']",
         ),
-        # PySpark failure - multiple duplicate groups
-        (
-            "pyspark",
-            ([(1, 10), (2, 20), (1, 30), (3, 40), (2, 50), (3, 60)], ["col1", "col2"]),
-            ["col1"],
-            "failure",
-            ([(1, 2), (2, 2), (3, 2)], ["col1", "#duplicates"]),
-            "Found 6 duplicate row(s). duplicate rows found for columns ['col1']",
-        ),
         # Pandas failure - with nulls (nulls counted as duplicates)
         (
             "pandas",
@@ -182,54 +114,28 @@ def test_expectation_name():
             pd.DataFrame({"col1": [None], "col2": [None], "#duplicates": [2]}),
             "Found 2 duplicate row(s). duplicate rows found for columns ['col1', 'col2']",
         ),
-        # PySpark failure - with nulls
-        (
-            "pyspark",
-            ([(1, 10), (None, None), (1, 20), (None, None)], ["col1", "col2"]),
-            ["col1", "col2"],
-            "failure",
-            (
-                StructType(
-                    [
-                        StructField("col1", IntegerType(), True),
-                        StructField("col2", IntegerType(), True),
-                        StructField("#duplicates", IntegerType(), True),
-                    ]
-                ),
-                [(None, None, 2)],
-            ),
-            "Found 2 duplicate row(s). duplicate rows found for columns ['col1', 'col2']",
-        ),
     ],
     ids=[
         "pandas_success_specific_columns",
-        "pyspark_success_specific_columns",
         "pandas_success_all_columns",
-        "pyspark_success_all_columns",
         "pandas_empty",
-        "pyspark_empty",
         "pandas_single_row",
-        "pyspark_single_row",
         "pandas_violations_specific_columns",
-        "pyspark_violations_specific_columns",
         "pandas_violations_all_columns",
-        "pyspark_violations_all_columns",
         "pandas_multiple_duplicate_groups",
-        "pyspark_multiple_duplicate_groups",
         "pandas_with_nulls",
-        "pyspark_with_nulls",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, df_data, column_names, expected_result, expected_violations, expected_message, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, df_data, column_names, expected_result, expected_violations, expected_message
 ):
     """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
+    Test the expectation for various scenarios across pandas DataFrames.
     Tests both direct expectation validation and suite-based validation.
     Covers: success cases (specific columns, all columns, empty, single row),
     failure cases (duplicates on specific/all columns, multiple groups, with nulls).
     """
-    data_frame = create_dataframe(df_type, df_data, spark)
+    data_frame = pd.DataFrame(df_data)
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -245,17 +151,7 @@ def test_expectation_basic_scenarios(
         ), f"Expected success message but got: {result}"
     else:  # failure
         # Create violations DataFrame
-        if df_type == "pandas":
-            violations_df = expected_violations
-        else:  # pyspark
-            if isinstance(expected_violations[0], StructType):
-                # Schema and data provided separately
-                schema, data = expected_violations
-                violations_df = spark.createDataFrame(data, schema)
-            else:
-                # Rows and columns provided
-                rows, columns = expected_violations
-                violations_df = spark.createDataFrame(rows, columns)
+        violations_df = expected_violations
 
         expected_failure_message = DataFrameExpectationFailureMessage(
             expectation_str=str(expectation),
@@ -283,12 +179,158 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
+@pytest.mark.pyspark
 @pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
+    "df_type, df_data, column_names, expected_result, expected_violations, expected_message",
+    [
+        # PySpark success - specific columns
+        (
+            "pyspark",
+            ([(1, 10, 100), (2, 20, 100), (3, 30, 100), (1, 20, 100)], ["col1", "col2", "col3"]),
+            ["col1", "col2"],
+            "success",
+            None,
+            None,
+        ),
+        # PySpark success - all columns
+        (
+            "pyspark",
+            ([(1, 10, 100), (2, 20, 200), (3, 30, 300)], ["col1", "col2", "col3"]),
+            [],
+            "success",
+            None,
+            None,
+        ),
+        # PySpark success - empty DataFrame
+        (
+            "pyspark",
+            ([], "col1: int"),
+            ["col1"],
+            "success",
+            None,
+            None,
+        ),
+        # Pandas success - single row
+        (
+            "pandas",
+            {"col1": [1]},
+            ["col1"],
+            "success",
+            None,
+            None,
+        ),
+        # Pandas failure - specific columns with duplicates
+        (
+            "pandas",
+            {"col1": [1, 2, 1, 3], "col2": [10, 20, 10, 30], "col3": [100, 200, 300, 400]},
+            ["col1", "col2"],
+            "failure",
+            pd.DataFrame({"col1": [1], "col2": [10], "#duplicates": [2]}),
+            "Found 2 duplicate row(s). duplicate rows found for columns ['col1', 'col2']",
+        ),
+        # Pandas failure - all columns with duplicates
+        (
+            "pandas",
+            {"col1": [1, 2, 1], "col2": [10, 20, 10], "col3": [100, 200, 100]},
+            [],
+            "failure",
+            pd.DataFrame({"col1": [1], "col2": [10], "col3": [100], "#duplicates": [2]}),
+            "Found 2 duplicate row(s). duplicate rows found",
+        ),
+        # Pandas failure - multiple duplicate groups
+        (
+            "pandas",
+            {"col1": [1, 2, 1, 3, 2, 3], "col2": [10, 20, 30, 40, 50, 60]},
+            ["col1"],
+            "failure",
+            pd.DataFrame({"col1": [1, 2, 3], "#duplicates": [2, 2, 2]}),
+            "Found 6 duplicate row(s). duplicate rows found for columns ['col1']",
+        ),
+        # Pandas failure - with nulls (nulls counted as duplicates)
+        (
+            "pandas",
+            {"col1": [1, None, 1, None], "col2": [10, None, 20, None]},
+            ["col1", "col2"],
+            "failure",
+            pd.DataFrame({"col1": [None], "col2": [None], "#duplicates": [2]}),
+            "Found 2 duplicate row(s). duplicate rows found for columns ['col1', 'col2']",
+        ),
+    ],
+    ids=[
+        "pyspark_success_specific_columns",
+        "pyspark_success_all_columns",
+        "pyspark_empty",
+        "pyspark_single_row",
+        "pyspark_violations_specific_columns",
+        "pyspark_violations_all_columns",
+        "pyspark_multiple_duplicate_groups",
+        "pyspark_with_nulls",
+    ],
 )
-def test_column_missing_error(df_type, spark):
+def test_expectation_basic_scenarios(
+    df_type, df_data, column_names, expected_result, expected_violations, expected_message, spark
+):
+    """
+    Test the expectation for various scenarios across PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases (specific columns, all columns, empty, single row),
+    failure cases (duplicates on specific/all columns, multiple groups, with nulls).
+    """
+
+    from pyspark.sql.types import StructType
+
+    data_frame = create_pyspark_dataframe(df_data, spark)
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationUniqueRows",
+        column_names=column_names,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationUniqueRows")
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        # Create violations DataFrame
+        if isinstance(expected_violations[0], StructType):
+            # Schema and data provided separately
+            schema, data = expected_violations
+            violations_df = spark.createDataFrame(data, schema)
+        else:
+            # Rows and columns provided
+            rows, columns = expected_violations
+            violations_df = spark.createDataFrame(rows, columns)
+
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            violations_data_frame=violations_df,
+            message=expected_message,
+            limit_violations=5,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_unique_rows(column_names=column_names)
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+def test_column_missing_error_pandas():
     """
     Test that an error is raised when specified columns are missing.
     Tests both direct expectation validation and suite-based validation.
@@ -298,16 +340,45 @@ def test_column_missing_error(df_type, spark):
         column_names=["nonexistent_col"],
     )
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col1": [1, 2, 3]})
-    else:  # pyspark
-        data_frame = spark.createDataFrame([(1,), (2,), (3,)], ["col1"])
+    data_frame = pd.DataFrame({"col1": [1, 2, 3]})
 
     # Test 1: Direct expectation validation
     result = expectation.validate(data_frame=data_frame)
     expected_failure_message = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message="Column 'nonexistent_col' does not exist in the DataFrame.",
+    )
+    assert str(result) == str(expected_failure_message), (
+        f"Expected failure message but got: {result}"
+    )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_unique_rows(
+        column_names=["nonexistent_col"]
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """
+    Test that an error is raised when specified columns are missing.
+    Tests both direct expectation validation and suite-based validation.
+    """
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationUniqueRows",
+        column_names=["nonexistent_col"],
+    )
+
+    data_frame = spark.createDataFrame([(1,), (2,), (3,)], ["col1"])
+
+    # Test 1: Direct expectation validation
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure_message = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message="Column 'nonexistent_col' does not exist in the DataFrame.",
     )
     assert str(result) == str(expected_failure_message), (

--- a/tests/expectations/aggregation/numerical_expectations/test_expect_column_max_between.py
+++ b/tests/expectations/aggregation/numerical_expectations/test_expect_column_max_between.py
@@ -7,36 +7,33 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark):
-    """Helper function to create pandas or pyspark DataFrame."""
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        from pyspark.sql.types import DoubleType, StructField, StructType
+def create_pyspark_dataframe(data, column_name, spark):
+    """Helper function to create a PySpark DataFrame."""
+    from pyspark.sql.types import DoubleType, StructField, StructType
 
-        # Handle empty or all-null data with explicit schema
-        if not data or all(v is None for v in data):
-            schema = StructType([StructField(column_name, DoubleType(), True)])
-            return spark.createDataFrame([[v] for v in data], schema=schema)
+    # Handle empty or all-null data with explicit schema
+    if not data or all(v is None for v in data):
+        schema = StructType([StructField(column_name, DoubleType(), True)])
+        return spark.createDataFrame([[v] for v in data], schema=schema)
 
-        # Use explicit DoubleType schema if the data contains any float values
-        # This ensures consistent type handling for mixed int/float data
-        has_float = any(isinstance(v, float) for v in data if v is not None)
-        if has_float:
-            float_data = [[float(v) if v is not None else None] for v in data]
-            schema = StructType([StructField(column_name, DoubleType(), True)])
-            return spark.createDataFrame(float_data, schema=schema)
-        else:
-            # For pure integer data, let PySpark infer the schema
-            return spark.createDataFrame([[v] for v in data], schema=[column_name])
+    # Use explicit DoubleType schema if the data contains any float values
+    # This ensures consistent type handling for mixed int/float data
+    has_float = any(isinstance(v, float) for v in data if v is not None)
+    if has_float:
+        float_data = [[float(v) if v is not None else None] for v in data]
+        schema = StructType([StructField(column_name, DoubleType(), True)])
+        return spark.createDataFrame(float_data, schema=schema)
+    else:
+        # For pure integer data, let PySpark infer the schema
+        return spark.createDataFrame([[v] for v in data], schema=[column_name])
 
 
 def test_expectation_name():
@@ -72,45 +69,27 @@ def test_expectation_description():
     [
         # Basic success
         ("pandas", [20, 25, 30, 35], 30, 40, "success", None),
-        ("pyspark", [20, 25, 30, 35], 30, 40, "success", None),
         # Single row
         ("pandas", [35], 30, 40, "success", None),
-        ("pyspark", [35], 30, 40, "success", None),
         # Negative values
         ("pandas", [-20, -15, -10, -3], -5, 0, "success", None),
-        ("pyspark", [-20, -15, -10, -3], -5, 0, "success", None),
         # Float values
         ("pandas", [1.1, 2.5, 3.7, 3.8], 3.5, 4.0, "success", None),
-        ("pyspark", [1.1, 2.5, 3.7, 3.8], 3.5, 4.0, "success", None),
         # Identical values
         ("pandas", [25, 25, 25, 25], 24, 26, "success", None),
-        ("pyspark", [25, 25, 25, 25], 24, 26, "success", None),
         # Mixed types
         ("pandas", [20, 25.5, 30, 37], 35, 40, "success", None),
-        ("pyspark", [20, 25.5, 30, 37], 35, 40, "success", None),
         # Zero values
         ("pandas", [-5, 0, 0, -2], -1, 1, "success", None),
-        ("pyspark", [-5, 0, 0, -2], -1, 1, "success", None),
         # With nulls
         ("pandas", [20, None, 35, None, 25], 30, 40, "success", None),
-        ("pyspark", [20, None, 35, None, 25], 30, 40, "success", None),
         # Boundary exact min
         ("pandas", [20, 25, 30, 35], 35, 40, "success", None),
-        ("pyspark", [20, 25, 30, 35], 35, 40, "success", None),
         # Boundary exact max
         ("pandas", [20, 25, 30, 35], 30, 35, "success", None),
-        ("pyspark", [20, 25, 30, 35], 30, 35, "success", None),
         # Max below range
         (
             "pandas",
-            [20, 25, 30, 35],
-            40,
-            50,
-            "failure",
-            "Column 'col1' maximum value 35 is not between 40 and 50.",
-        ),
-        (
-            "pyspark",
             [20, 25, 30, 35],
             40,
             50,
@@ -126,57 +105,35 @@ def test_expectation_description():
             "failure",
             "Column 'col1' contains only null values.",
         ),
-        (
-            "pyspark",
-            [None, None, None],
-            30,
-            40,
-            "failure",
-            "Column 'col1' contains only null values.",
-        ),
         # Empty
         ("pandas", [], 30, 40, "failure", "Column 'col1' contains only null values."),
-        ("pyspark", [], 30, 40, "failure", "Column 'col1' contains only null values."),
     ],
     ids=[
         "pandas_basic_success",
-        "pyspark_basic_success",
         "pandas_single_row",
-        "pyspark_single_row",
         "pandas_negative_values",
-        "pyspark_negative_values",
         "pandas_float_values",
-        "pyspark_float_values",
         "pandas_identical_values",
-        "pyspark_identical_values",
         "pandas_mixed_types",
-        "pyspark_mixed_types",
         "pandas_zero_values",
-        "pyspark_zero_values",
         "pandas_with_nulls",
-        "pyspark_with_nulls",
         "pandas_boundary_exact_min",
-        "pyspark_boundary_exact_min",
         "pandas_boundary_exact_max",
-        "pyspark_boundary_exact_max",
         "pandas_max_below_range",
-        "pyspark_max_below_range",
         "pandas_all_nulls",
-        "pyspark_all_nulls",
         "pandas_empty",
-        "pyspark_empty",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, data, min_value, max_value, expected_result, expected_message, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, data, min_value, max_value, expected_result, expected_message
 ):
     """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
+    Test the expectation for various scenarios across pandas DataFrames.
     Tests both direct expectation validation and suite-based validation.
     Covers: success cases, boundary conditions, failures (out of range, nulls, empty),
     and various data types (integers, floats, negatives, nulls, mixed types).
     """
-    data_frame = create_dataframe(df_type, data, "col1", spark)
+    data_frame = pd.DataFrame({"col1": data})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -219,19 +176,124 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
+@pytest.mark.pyspark
 @pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
+    "df_type, data, min_value, max_value, expected_result, expected_message",
+    [
+        # Basic success
+        ("pyspark", [20, 25, 30, 35], 30, 40, "success", None),
+        # Single row
+        ("pyspark", [35], 30, 40, "success", None),
+        # Negative values
+        ("pyspark", [-20, -15, -10, -3], -5, 0, "success", None),
+        # Float values
+        ("pyspark", [1.1, 2.5, 3.7, 3.8], 3.5, 4.0, "success", None),
+        # Identical values
+        ("pyspark", [25, 25, 25, 25], 24, 26, "success", None),
+        # Mixed types
+        ("pyspark", [20, 25.5, 30, 37], 35, 40, "success", None),
+        # Zero values
+        ("pyspark", [-5, 0, 0, -2], -1, 1, "success", None),
+        # With nulls
+        ("pyspark", [20, None, 35, None, 25], 30, 40, "success", None),
+        # Boundary exact min
+        ("pyspark", [20, 25, 30, 35], 35, 40, "success", None),
+        # Boundary exact max
+        ("pyspark", [20, 25, 30, 35], 30, 35, "success", None),
+        # Max below range
+        (
+            "pyspark",
+            [20, 25, 30, 35],
+            40,
+            50,
+            "failure",
+            "Column 'col1' maximum value 35 is not between 40 and 50.",
+        ),
+        # All nulls
+        (
+            "pyspark",
+            [None, None, None],
+            30,
+            40,
+            "failure",
+            "Column 'col1' contains only null values.",
+        ),
+        # Empty
+        ("pyspark", [], 30, 40, "failure", "Column 'col1' contains only null values."),
+    ],
+    ids=[
+        "pyspark_basic_success",
+        "pyspark_single_row",
+        "pyspark_negative_values",
+        "pyspark_float_values",
+        "pyspark_identical_values",
+        "pyspark_mixed_types",
+        "pyspark_zero_values",
+        "pyspark_with_nulls",
+        "pyspark_boundary_exact_min",
+        "pyspark_boundary_exact_max",
+        "pyspark_max_below_range",
+        "pyspark_all_nulls",
+        "pyspark_empty",
+    ],
 )
-def test_column_missing_error(df_type, spark):
-    """Test that an error is raised when the specified column is missing in both pandas and PySpark."""
+def test_expectation_basic_scenarios_pyspark(
+    df_type, data, min_value, max_value, expected_result, expected_message, spark
+):
+    """
+    Test the expectation for various scenarios across PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases, boundary conditions, failures (out of range, nulls, empty),
+    and various data types (integers, floats, negatives, nulls, mixed types).
+    """
+    data_frame = create_pyspark_dataframe(data, "col1", spark)
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationColumnMaxBetween",
+        column_name="col1",
+        min_value=min_value,
+        max_value=max_value,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationColumnQuantileBetween")
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            message=expected_message,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_column_max_between(
+        column_name="col1", min_value=min_value, max_value=max_value
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+def test_column_missing_error_pandas():
+    """Test that an error is raised when the specified column is missing in pandas."""
     expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col1": [20, 25, 30, 35]})
-    else:  # pyspark
-        data_frame = spark.createDataFrame([(20,), (25,), (30,), (35,)], ["col1"])
+    data_frame = pd.DataFrame({"col1": [20, 25, 30, 35]})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -243,7 +305,37 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=data_frame)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_column_max_between(
+        column_name="nonexistent_col", min_value=30, max_value=40
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test that an error is raised when the specified column is missing in PySpark."""
+    expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
+
+    data_frame = spark.createDataFrame([(20,), (25,), (30,), (35,)], ["col1"])
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationColumnMaxBetween",
+        column_name="nonexistent_col",
+        min_value=30,
+        max_value=40,
+    )
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message=expected_message,
     )
     assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"

--- a/tests/expectations/aggregation/numerical_expectations/test_expect_column_max_between.py
+++ b/tests/expectations/aggregation/numerical_expectations/test_expect_column_max_between.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 import pandas as pd
 
 from dataframe_expectations.registry import (
@@ -350,8 +351,6 @@ def test_column_missing_error_pyspark(spark):
 
 def test_large_dataset_performance():
     """Test the expectation with a larger dataset to ensure performance."""
-    import numpy as np
-
     # Create a larger dataset with max around 60
     large_data = np.random.uniform(10, 60, 1000).tolist()
     data_frame = pd.DataFrame({"col1": large_data})

--- a/tests/expectations/aggregation/numerical_expectations/test_expect_column_mean_between.py
+++ b/tests/expectations/aggregation/numerical_expectations/test_expect_column_mean_between.py
@@ -7,36 +7,33 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark):
-    """Helper function to create pandas or pyspark DataFrame."""
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        from pyspark.sql.types import DoubleType, StructField, StructType
+def create_pyspark_dataframe(data, column_name, spark):
+    """Helper function to create a PySpark DataFrame."""
+    from pyspark.sql.types import DoubleType, StructField, StructType
 
-        # Handle empty or all-null data with explicit schema
-        if not data or all(v is None for v in data):
-            schema = StructType([StructField(column_name, DoubleType(), True)])
-            return spark.createDataFrame([[v] for v in data], schema=schema)
+    # Handle empty or all-null data with explicit schema
+    if not data or all(v is None for v in data):
+        schema = StructType([StructField(column_name, DoubleType(), True)])
+        return spark.createDataFrame([[v] for v in data], schema=schema)
 
-        # Use explicit DoubleType schema if the data contains any float values
-        # This ensures consistent type handling for mixed int/float data
-        has_float = any(isinstance(v, float) for v in data if v is not None)
-        if has_float:
-            float_data = [[float(v) if v is not None else None] for v in data]
-            schema = StructType([StructField(column_name, DoubleType(), True)])
-            return spark.createDataFrame(float_data, schema=schema)
-        else:
-            # For pure integer data, let PySpark infer the schema
-            return spark.createDataFrame([[v] for v in data], schema=[column_name])
+    # Use explicit DoubleType schema if the data contains any float values
+    # This ensures consistent type handling for mixed int/float data
+    has_float = any(isinstance(v, float) for v in data if v is not None)
+    if has_float:
+        float_data = [[float(v) if v is not None else None] for v in data]
+        schema = StructType([StructField(column_name, DoubleType(), True)])
+        return spark.createDataFrame(float_data, schema=schema)
+    else:
+        # For pure integer data, let PySpark infer the schema
+        return spark.createDataFrame([[v] for v in data], schema=[column_name])
 
 
 def test_expectation_name():
@@ -72,45 +69,27 @@ def test_expectation_description():
     [
         # Basic success scenarios
         ("pandas", [20, 25, 30, 35], 25, 30, "success", None),  # mean = 27.5
-        ("pyspark", [20, 25, 30, 35], 25, 30, "success", None),  # mean = 27.5
         # Single row scenarios
         ("pandas", [25], 20, 30, "success", None),  # mean = 25
-        ("pyspark", [25], 20, 30, "success", None),  # mean = 25
         # Negative value scenarios
         ("pandas", [-20, -15, -10, -5], -15, -10, "success", None),  # mean = -12.5
-        ("pyspark", [-20, -15, -10, -5], -15, -10, "success", None),  # mean = -12.5
         # Float value scenarios
         ("pandas", [1.1, 2.5, 3.7, 3.8], 2.5, 3.0, "success", None),  # mean = 2.775
-        ("pyspark", [1.1, 2.5, 3.7, 3.8], 2.5, 3.0, "success", None),  # mean ≈ 2.775
         # Identical value scenarios
         ("pandas", [25, 25, 25, 25], 24, 26, "success", None),  # mean = 25
-        ("pyspark", [25, 25, 25, 25], 24, 26, "success", None),  # mean = 25
         # Mixed type scenarios
         ("pandas", [20, 25.5, 30, 37], 27, 29, "success", None),  # mean = 28.125
-        ("pyspark", [20, 25.5, 30, 37], 27, 29, "success", None),  # mean ≈ 28.125
         # Zero scenarios
         ("pandas", [-5, 0, 0, 5], -2, 2, "success", None),  # mean = 0
-        ("pyspark", [-5, 0, 0, 5], -2, 2, "success", None),  # mean = 0
         # Null scenarios
         ("pandas", [20, None, 30, None, 40], 25, 35, "success", None),  # mean = 30
-        ("pyspark", [20, None, 30, None, 40], 25, 35, "success", None),  # mean = 30
         # Boundary scenarios - exact min boundary (mean = 27.5)
         ("pandas", [20, 25, 30, 35], 27.5, 30, "success", None),
-        ("pyspark", [20, 25, 30, 35], 27.5, 30, "success", None),
         # Boundary scenarios - exact max boundary (mean = 27.5)
         ("pandas", [20, 25, 30, 35], 25, 27.5, "success", None),
-        ("pyspark", [20, 25, 30, 35], 25, 27.5, "success", None),
         # Failure scenarios - mean too low
         (
             "pandas",
-            [20, 25, 30, 35],
-            30,
-            35,
-            "failure",
-            "Column 'col1' mean value 27.5 is not between 30 and 35.",
-        ),
-        (
-            "pyspark",
             [20, 25, 30, 35],
             30,
             35,
@@ -126,14 +105,6 @@ def test_expectation_description():
             "failure",
             "Column 'col1' mean value 27.5 is not between 20 and 25.",
         ),
-        (
-            "pyspark",
-            [20, 25, 30, 35],
-            20,
-            25,
-            "failure",
-            "Column 'col1' mean value 27.5 is not between 20 and 25.",
-        ),
         # Failure scenarios - all nulls
         (
             "pandas",
@@ -143,74 +114,45 @@ def test_expectation_description():
             "failure",
             "Column 'col1' contains only null values.",
         ),
-        (
-            "pyspark",
-            [None, None, None],
-            25,
-            30,
-            "failure",
-            "Column 'col1' contains only null values.",
-        ),
         # Failure scenarios - empty
         ("pandas", [], 25, 30, "failure", "Column 'col1' contains only null values."),
-        ("pyspark", [], 25, 30, "failure", "Column 'col1' contains only null values."),
         # Outlier scenarios - high
         ("pandas", [1, 2, 3, 100], 20, 30, "success", None),  # mean = 26.5
-        ("pyspark", [1, 2, 3, 100], 20, 30, "success", None),  # mean = 26.5
         # Outlier scenarios - low
         ("pandas", [-100, 10, 20, 30], -15, -5, "success", None),  # mean = -10
-        ("pyspark", [-100, 10, 20, 30], -15, -5, "success", None),  # mean = -10
         # Outlier scenarios - extreme
         ("pandas", [1, 2, 3, 4, 5, 1000], 150, 200, "success", None),  # mean ≈ 169.17
-        ("pyspark", [1, 2, 3, 4, 5, 1000], 150, 200, "success", None),  # mean ≈ 169.17
     ],
     ids=[
         "pandas_basic_success",
-        "pyspark_basic_success",
         "pandas_single_row",
-        "pyspark_single_row",
         "pandas_negative_values",
-        "pyspark_negative_values",
         "pandas_float_values",
-        "pyspark_float_values",
         "pandas_identical_values",
-        "pyspark_identical_values",
         "pandas_mixed_types",
-        "pyspark_mixed_types",
         "pandas_with_zeros",
-        "pyspark_with_zeros",
         "pandas_with_nulls",
-        "pyspark_with_nulls",
         "pandas_boundary_exact_min",
-        "pyspark_boundary_exact_min",
         "pandas_boundary_exact_max",
-        "pyspark_boundary_exact_max",
         "pandas_mean_too_low",
-        "pyspark_mean_too_low",
         "pandas_mean_too_high",
-        "pyspark_mean_too_high",
         "pandas_all_nulls",
-        "pyspark_all_nulls",
         "pandas_empty",
-        "pyspark_empty",
         "pandas_outlier_high",
-        "pyspark_outlier_high",
         "pandas_outlier_low",
-        "pyspark_outlier_low",
         "pandas_outlier_extreme",
-        "pyspark_outlier_extreme",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, data, min_value, max_value, expected_result, expected_message, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, data, min_value, max_value, expected_result, expected_message
 ):
     """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
+    Test the expectation for various scenarios across pandas DataFrames.
     Tests both direct expectation validation and suite-based validation.
     Covers: success cases, boundary conditions, failures (mean out of range, nulls, empty),
     and various data types (integers, floats, negatives, nulls, mixed types, outliers).
     """
-    data_frame = create_dataframe(df_type, data, "col1", spark)
+    data_frame = pd.DataFrame({"col1": data})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -253,19 +195,143 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
+@pytest.mark.pyspark
 @pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
+    "df_type, data, min_value, max_value, expected_result, expected_message",
+    [
+        # Basic success scenarios
+        ("pyspark", [20, 25, 30, 35], 25, 30, "success", None),  # mean = 27.5
+        # Single row scenarios
+        ("pyspark", [25], 20, 30, "success", None),  # mean = 25
+        # Negative value scenarios
+        ("pyspark", [-20, -15, -10, -5], -15, -10, "success", None),  # mean = -12.5
+        # Float value scenarios
+        ("pyspark", [1.1, 2.5, 3.7, 3.8], 2.5, 3.0, "success", None),  # mean ≈ 2.775
+        # Identical value scenarios
+        ("pyspark", [25, 25, 25, 25], 24, 26, "success", None),  # mean = 25
+        # Mixed type scenarios
+        ("pyspark", [20, 25.5, 30, 37], 27, 29, "success", None),  # mean ≈ 28.125
+        # Zero scenarios
+        ("pyspark", [-5, 0, 0, 5], -2, 2, "success", None),  # mean = 0
+        # Null scenarios
+        ("pyspark", [20, None, 30, None, 40], 25, 35, "success", None),  # mean = 30
+        # Boundary scenarios - exact min boundary (mean = 27.5)
+        ("pyspark", [20, 25, 30, 35], 27.5, 30, "success", None),
+        # Boundary scenarios - exact max boundary (mean = 27.5)
+        ("pyspark", [20, 25, 30, 35], 25, 27.5, "success", None),
+        # Failure scenarios - mean too low
+        (
+            "pyspark",
+            [20, 25, 30, 35],
+            30,
+            35,
+            "failure",
+            "Column 'col1' mean value 27.5 is not between 30 and 35.",
+        ),
+        # Failure scenarios - mean too high
+        (
+            "pyspark",
+            [20, 25, 30, 35],
+            20,
+            25,
+            "failure",
+            "Column 'col1' mean value 27.5 is not between 20 and 25.",
+        ),
+        # Failure scenarios - all nulls
+        (
+            "pyspark",
+            [None, None, None],
+            25,
+            30,
+            "failure",
+            "Column 'col1' contains only null values.",
+        ),
+        # Failure scenarios - empty
+        ("pyspark", [], 25, 30, "failure", "Column 'col1' contains only null values."),
+        # Outlier scenarios - high
+        ("pyspark", [1, 2, 3, 100], 20, 30, "success", None),  # mean = 26.5
+        # Outlier scenarios - low
+        ("pyspark", [-100, 10, 20, 30], -15, -5, "success", None),  # mean = -10
+        # Outlier scenarios - extreme
+        ("pyspark", [1, 2, 3, 4, 5, 1000], 150, 200, "success", None),  # mean ≈ 169.17
+    ],
+    ids=[
+        "pyspark_basic_success",
+        "pyspark_single_row",
+        "pyspark_negative_values",
+        "pyspark_float_values",
+        "pyspark_identical_values",
+        "pyspark_mixed_types",
+        "pyspark_with_zeros",
+        "pyspark_with_nulls",
+        "pyspark_boundary_exact_min",
+        "pyspark_boundary_exact_max",
+        "pyspark_mean_too_low",
+        "pyspark_mean_too_high",
+        "pyspark_all_nulls",
+        "pyspark_empty",
+        "pyspark_outlier_high",
+        "pyspark_outlier_low",
+        "pyspark_outlier_extreme",
+    ],
 )
-def test_column_missing_error(df_type, spark):
-    """Test that an error is raised when the specified column is missing in both pandas and PySpark."""
+def test_expectation_basic_scenarios_pyspark(
+    df_type, data, min_value, max_value, expected_result, expected_message, spark
+):
+    """
+    Test the expectation for various scenarios across PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases, boundary conditions, failures (mean out of range, nulls, empty),
+    and various data types (integers, floats, negatives, nulls, mixed types, outliers).
+    """
+    data_frame = create_pyspark_dataframe(data, "col1", spark)
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationColumnMeanBetween",
+        column_name="col1",
+        min_value=min_value,
+        max_value=max_value,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationColumnMeanBetween")
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            message=expected_message,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_column_mean_between(
+        column_name="col1", min_value=min_value, max_value=max_value
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+def test_column_missing_error_pandas():
+    """Test that an error is raised when the specified column is missing in pandas."""
     expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col1": [20, 25, 30, 35]})
-    else:  # pyspark
-        data_frame = spark.createDataFrame([(20,), (25,), (30,), (35,)], ["col1"])
+    data_frame = pd.DataFrame({"col1": [20, 25, 30, 35]})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -277,7 +343,37 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=data_frame)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_column_mean_between(
+        column_name="nonexistent_col", min_value=25, max_value=30
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test that an error is raised when the specified column is missing in PySpark."""
+    expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
+
+    data_frame = spark.createDataFrame([(20,), (25,), (30,), (35,)], ["col1"])
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationColumnMeanBetween",
+        column_name="nonexistent_col",
+        min_value=25,
+        max_value=30,
+    )
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message=expected_message,
     )
     assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"

--- a/tests/expectations/aggregation/numerical_expectations/test_expect_column_mean_between.py
+++ b/tests/expectations/aggregation/numerical_expectations/test_expect_column_mean_between.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 import pandas as pd
 
 from dataframe_expectations.registry import (
@@ -419,8 +420,6 @@ def test_precision_handling():
 
 def test_large_dataset_performance():
     """Test the expectation with a larger dataset to ensure performance."""
-    import numpy as np
-
     # Create a larger dataset with mean around 50
     large_data = np.random.normal(50, 10, 1000).tolist()
     data_frame = pd.DataFrame({"col1": large_data})

--- a/tests/expectations/aggregation/numerical_expectations/test_expect_column_median_between.py
+++ b/tests/expectations/aggregation/numerical_expectations/test_expect_column_median_between.py
@@ -14,28 +14,25 @@ from dataframe_expectations.result_message import (
 )
 
 
-def create_dataframe(df_type, data, column_name, spark):
-    """Helper function to create pandas or pyspark DataFrame."""
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        from pyspark.sql.types import DoubleType, StructField, StructType
+def create_pyspark_dataframe(data, column_name, spark):
+    """Helper function to create a PySpark DataFrame."""
+    from pyspark.sql.types import DoubleType, StructField, StructType
 
-        # Handle empty or all-null data with explicit schema
-        if not data or all(v is None for v in data):
-            schema = StructType([StructField(column_name, DoubleType(), True)])
-            return spark.createDataFrame([[v] for v in data], schema=schema)
+    # Handle empty or all-null data with explicit schema
+    if not data or all(v is None for v in data):
+        schema = StructType([StructField(column_name, DoubleType(), True)])
+        return spark.createDataFrame([[v] for v in data], schema=schema)
 
-        # Use explicit DoubleType schema if the data contains any float values
-        # This ensures consistent type handling for mixed int/float data
-        has_float = any(isinstance(v, float) for v in data if v is not None)
-        if has_float:
-            float_data = [[float(v) if v is not None else None] for v in data]
-            schema = StructType([StructField(column_name, DoubleType(), True)])
-            return spark.createDataFrame(float_data, schema=schema)
-        else:
-            # For pure integer data, let PySpark infer the schema
-            return spark.createDataFrame([[v] for v in data], schema=[column_name])
+    # Use explicit DoubleType schema if the data contains any float values
+    # This ensures consistent type handling for mixed int/float data
+    has_float = any(isinstance(v, float) for v in data if v is not None)
+    if has_float:
+        float_data = [[float(v) if v is not None else None] for v in data]
+        schema = StructType([StructField(column_name, DoubleType(), True)])
+        return spark.createDataFrame(float_data, schema=schema)
+    else:
+        # For pure integer data, let PySpark infer the schema
+        return spark.createDataFrame([[v] for v in data], schema=[column_name])
 
 
 def test_expectation_name():
@@ -79,84 +76,53 @@ def test_expectation_description():
     [
         # Basic success scenarios
         ("pandas", [20, 25, 30, 35], 25, 30, True, None),  # median = 27.5
-        ("pyspark", [20, 25, 30, 35], 25, 30, True, None),  # median ≈ 27.5
         # Single row scenarios
         ("pandas", [25], 20, 30, True, None),  # median = 25
-        ("pyspark", [25], 20, 30, True, None),  # median = 25
         # Negative value scenarios
         ("pandas", [-20, -15, -10, -5], -15, -10, True, None),  # median = -12.5
-        ("pyspark", [-20, -15, -10, -5], -15, -10, True, None),  # median ≈ -12.5
         # Float value scenarios
         ("pandas", [1.1, 2.5, 3.7, 3.8], 2.5, 3.5, True, None),  # median = 3.1
-        ("pyspark", [1.1, 2.5, 3.7, 3.8], 2.5, 3.5, True, None),  # median ≈ 3.1
         # Identical value scenarios
         ("pandas", [25, 25, 25, 25], 24, 26, True, None),  # median = 25
-        ("pyspark", [25, 25, 25, 25], 24, 26, True, None),  # median = 25
         # Mixed type scenarios
         ("pandas", [20, 25.5, 30, 37], 27, 29, True, None),  # median = 27.75
-        ("pyspark", [20, 25.5, 30, 37], 27, 29, True, None),  # median ≈ 27.75
         # Zero scenarios
         ("pandas", [-5, 0, 0, 5], -1, 1, True, None),  # median = 0
-        ("pyspark", [-5, 0, 0, 5], -1, 1, True, None),  # median = 0
         # Null scenarios
         ("pandas", [20, None, 30, None, 40], 25, 35, True, None),  # median = 30
-        ("pyspark", [20, None, 30, None, 40], 25, 35, True, None),  # median ≈ 30
         # Odd count scenarios
         ("pandas", [10, 20, 30], 19, 21, True, None),  # median = 20
-        ("pyspark", [10, 20, 30], 19, 21, True, None),  # median ≈ 20
         # Even count scenarios
         ("pandas", [10, 20, 30, 40], 24, 26, True, None),  # median = 25
-        ("pyspark", [10, 20, 30, 40], 24, 26, True, None),  # median ≈ 25
         # Boundary scenarios - exact minimum
         ("pandas", [20, 25, 30, 35], 27.5, 30, True, None),  # median = 27.5
-        ("pyspark", [20, 25, 30, 35], 27.5, 30, True, None),  # median = 27.5
         # Boundary scenarios - exact maximum
         ("pandas", [20, 25, 30, 35], 25, 27.5, True, None),  # median = 27.5
-        ("pyspark", [20, 25, 30, 35], 25, 27.5, True, None),  # median = 27.5
         # Median calculation - odd count (middle element)
         ("pandas", [1, 2, 3], 1.9, 2.1, True, None),
-        ("pyspark", [1, 2, 3], 1.9, 2.1, True, None),
         # Median calculation - even count (average of middle two)
         ("pandas", [1, 2, 3, 4], 2.4, 2.6, True, None),
-        ("pyspark", [1, 2, 3, 4], 2.4, 2.6, True, None),
         # Median calculation - single element
         ("pandas", [5], 4.9, 5.1, True, None),
-        ("pyspark", [5], 4.9, 5.1, True, None),
         # Median calculation - all identical values
         ("pandas", [10, 10, 10], 9.9, 10.1, True, None),
-        ("pyspark", [10, 10, 10], 9.9, 10.1, True, None),
         # Median calculation - two elements (average)
         ("pandas", [1, 100], 50.4, 50.6, True, None),
-        ("pyspark", [1, 100], 50.4, 50.6, True, None),
         # Median calculation - odd count with outlier
         ("pandas", [1, 2, 100], 1.9, 2.1, True, None),
-        ("pyspark", [1, 2, 100], 1.9, 2.1, True, None),
         # Median calculation - even count with outliers
         ("pandas", [1, 2, 99, 100], 50.4, 50.6, True, None),
-        ("pyspark", [1, 2, 99, 100], 50.4, 50.6, True, None),
         # Outlier resistance - high outlier
         ("pandas", [1, 2, 3, 1000], 1.5, 2.5, True, None),
-        ("pyspark", [1, 2, 3, 1000], 1.5, 2.5, True, None),
         # Outlier resistance - low outlier
         ("pandas", [-1000, 10, 20, 30], 14, 16, True, None),
-        ("pyspark", [-1000, 10, 20, 30], 14, 16, True, None),
         # Outlier resistance - extreme high outlier
         ("pandas", [1, 2, 3, 4, 5, 1000000], 2.5, 3.5, True, None),
-        ("pyspark", [1, 2, 3, 4, 5, 1000000], 2.5, 3.5, True, None),
         # Outlier resistance - extreme low outlier
         ("pandas", [-1000000, 1, 2, 3, 4, 5], 2.4, 2.6, True, None),
-        ("pyspark", [-1000000, 1, 2, 3, 4, 5], 2.4, 2.6, True, None),
         # Failure scenarios - median too low
         (
             "pandas",
-            [20, 25, 30, 35],
-            30,
-            35,
-            False,
-            "Column 'col1' median value 27.5 is not between 30 and 35.",
-        ),
-        (
-            "pyspark",
             [20, 25, 30, 35],
             30,
             35,
@@ -172,14 +138,6 @@ def test_expectation_description():
             False,
             "Column 'col1' median value 27.5 is not between 20 and 25.",
         ),
-        (
-            "pyspark",
-            [20, 25, 30, 35],
-            20,
-            25,
-            False,
-            "Column 'col1' median value 27.5 is not between 20 and 25.",
-        ),
         # Failure scenarios - median out of range
         (
             "pandas",
@@ -189,85 +147,47 @@ def test_expectation_description():
             False,
             "Column 'col1' median value 20.0 is not between 25 and 30.",
         ),
-        (
-            "pyspark",
-            [10, 20, 30],
-            25,
-            30,
-            False,
-            "Column 'col1' median value 20.0 is not between 25 and 30.",
-        ),
         # Failure scenarios - all nulls
         ("pandas", [None, None, None], 25, 30, False, "Column 'col1' contains only null values."),
-        ("pyspark", [None, None, None], 25, 30, False, "Column 'col1' contains only null values."),
         # Failure scenarios - empty
         ("pandas", [], 25, 30, False, "Column 'col1' contains only null values."),
-        ("pyspark", [], 25, 30, False, "Column 'col1' contains only null values."),
     ],
     ids=[
         "pandas_basic_success",
-        "pyspark_basic_success",
         "pandas_single_row",
-        "pyspark_single_row",
         "pandas_negative_values",
-        "pyspark_negative_values",
         "pandas_float_values",
-        "pyspark_float_values",
         "pandas_identical_values",
-        "pyspark_identical_values",
         "pandas_mixed_types",
-        "pyspark_mixed_types",
         "pandas_with_zeros",
-        "pyspark_with_zeros",
         "pandas_with_nulls",
-        "pyspark_with_nulls",
         "pandas_odd_count",
-        "pyspark_odd_count",
         "pandas_even_count",
-        "pyspark_even_count",
         "pandas_boundary_exact_min",
-        "pyspark_boundary_exact_min",
         "pandas_boundary_exact_max",
-        "pyspark_boundary_exact_max",
         "pandas_calc_odd_count",
-        "pyspark_calc_odd_count",
         "pandas_calc_even_count",
-        "pyspark_calc_even_count",
         "pandas_calc_single_element",
-        "pyspark_calc_single_element",
         "pandas_calc_all_identical",
-        "pyspark_calc_all_identical",
         "pandas_calc_two_elements",
-        "pyspark_calc_two_elements",
         "pandas_calc_odd_with_outlier",
-        "pyspark_calc_odd_with_outlier",
         "pandas_calc_even_with_outliers",
-        "pyspark_calc_even_with_outliers",
         "pandas_outlier_high",
-        "pyspark_outlier_high",
         "pandas_outlier_low",
-        "pyspark_outlier_low",
         "pandas_outlier_extreme_high",
-        "pyspark_outlier_extreme_high",
         "pandas_outlier_extreme_low",
-        "pyspark_outlier_extreme_low",
         "pandas_median_too_low",
-        "pyspark_median_too_low",
         "pandas_median_too_high",
-        "pyspark_median_too_high",
         "pandas_median_out_of_range",
-        "pyspark_median_out_of_range",
         "pandas_all_nulls",
-        "pyspark_all_nulls",
         "pandas_empty",
-        "pyspark_empty",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, data, min_value, max_value, should_succeed, expected_message, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, data, min_value, max_value, should_succeed, expected_message
 ):
-    """Test basic expectation scenarios for both pandas and PySpark DataFrames."""
-    df = create_dataframe(df_type, data, "col1", spark)
+    """Test basic expectation scenarios for pandas DataFrames."""
+    df = pd.DataFrame({"col1": data})
 
     # Test through registry
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -304,17 +224,163 @@ def test_expectation_basic_scenarios(
             suite.build().run(data_frame=df)
 
 
+@pytest.mark.pyspark
 @pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
+    "df_type, data, min_value, max_value, should_succeed, expected_message",
+    [
+        # Basic success scenarios
+        ("pyspark", [20, 25, 30, 35], 25, 30, True, None),  # median ≈ 27.5
+        # Single row scenarios
+        ("pyspark", [25], 20, 30, True, None),  # median = 25
+        # Negative value scenarios
+        ("pyspark", [-20, -15, -10, -5], -15, -10, True, None),  # median ≈ -12.5
+        # Float value scenarios
+        ("pyspark", [1.1, 2.5, 3.7, 3.8], 2.5, 3.5, True, None),  # median ≈ 3.1
+        # Identical value scenarios
+        ("pyspark", [25, 25, 25, 25], 24, 26, True, None),  # median = 25
+        # Mixed type scenarios
+        ("pyspark", [20, 25.5, 30, 37], 27, 29, True, None),  # median ≈ 27.75
+        # Zero scenarios
+        ("pyspark", [-5, 0, 0, 5], -1, 1, True, None),  # median = 0
+        # Null scenarios
+        ("pyspark", [20, None, 30, None, 40], 25, 35, True, None),  # median ≈ 30
+        # Odd count scenarios
+        ("pyspark", [10, 20, 30], 19, 21, True, None),  # median ≈ 20
+        # Even count scenarios
+        ("pyspark", [10, 20, 30, 40], 24, 26, True, None),  # median ≈ 25
+        # Boundary scenarios - exact minimum
+        ("pyspark", [20, 25, 30, 35], 27.5, 30, True, None),  # median = 27.5
+        # Boundary scenarios - exact maximum
+        ("pyspark", [20, 25, 30, 35], 25, 27.5, True, None),  # median = 27.5
+        # Median calculation - odd count (middle element)
+        ("pyspark", [1, 2, 3], 1.9, 2.1, True, None),
+        # Median calculation - even count (average of middle two)
+        ("pyspark", [1, 2, 3, 4], 2.4, 2.6, True, None),
+        # Median calculation - single element
+        ("pyspark", [5], 4.9, 5.1, True, None),
+        # Median calculation - all identical values
+        ("pyspark", [10, 10, 10], 9.9, 10.1, True, None),
+        # Median calculation - two elements (average)
+        ("pyspark", [1, 100], 50.4, 50.6, True, None),
+        # Median calculation - odd count with outlier
+        ("pyspark", [1, 2, 100], 1.9, 2.1, True, None),
+        # Median calculation - even count with outliers
+        ("pyspark", [1, 2, 99, 100], 50.4, 50.6, True, None),
+        # Outlier resistance - high outlier
+        ("pyspark", [1, 2, 3, 1000], 1.5, 2.5, True, None),
+        # Outlier resistance - low outlier
+        ("pyspark", [-1000, 10, 20, 30], 14, 16, True, None),
+        # Outlier resistance - extreme high outlier
+        ("pyspark", [1, 2, 3, 4, 5, 1000000], 2.5, 3.5, True, None),
+        # Outlier resistance - extreme low outlier
+        ("pyspark", [-1000000, 1, 2, 3, 4, 5], 2.4, 2.6, True, None),
+        # Failure scenarios - median too low
+        (
+            "pyspark",
+            [20, 25, 30, 35],
+            30,
+            35,
+            False,
+            "Column 'col1' median value 27.5 is not between 30 and 35.",
+        ),
+        # Failure scenarios - median too high
+        (
+            "pyspark",
+            [20, 25, 30, 35],
+            20,
+            25,
+            False,
+            "Column 'col1' median value 27.5 is not between 20 and 25.",
+        ),
+        # Failure scenarios - median out of range
+        (
+            "pyspark",
+            [10, 20, 30],
+            25,
+            30,
+            False,
+            "Column 'col1' median value 20.0 is not between 25 and 30.",
+        ),
+        # Failure scenarios - all nulls
+        ("pyspark", [None, None, None], 25, 30, False, "Column 'col1' contains only null values."),
+        # Failure scenarios - empty
+        ("pyspark", [], 25, 30, False, "Column 'col1' contains only null values."),
+    ],
+    ids=[
+        "pyspark_basic_success",
+        "pyspark_single_row",
+        "pyspark_negative_values",
+        "pyspark_float_values",
+        "pyspark_identical_values",
+        "pyspark_mixed_types",
+        "pyspark_with_zeros",
+        "pyspark_with_nulls",
+        "pyspark_odd_count",
+        "pyspark_even_count",
+        "pyspark_boundary_exact_min",
+        "pyspark_boundary_exact_max",
+        "pyspark_calc_odd_count",
+        "pyspark_calc_even_count",
+        "pyspark_calc_single_element",
+        "pyspark_calc_all_identical",
+        "pyspark_calc_two_elements",
+        "pyspark_calc_odd_with_outlier",
+        "pyspark_calc_even_with_outliers",
+        "pyspark_outlier_high",
+        "pyspark_outlier_low",
+        "pyspark_outlier_extreme_high",
+        "pyspark_outlier_extreme_low",
+        "pyspark_median_too_low",
+        "pyspark_median_too_high",
+        "pyspark_median_out_of_range",
+        "pyspark_all_nulls",
+        "pyspark_empty",
+    ],
 )
-def test_column_missing_error(df_type, spark):
-    """Test missing column error for both pandas and PySpark DataFrames."""
-    if df_type == "pandas":
-        df = pd.DataFrame({"col1": [20, 25, 30, 35]})
-    else:
-        df = spark.createDataFrame([(20,), (25,), (30,), (35,)], ["col1"])
+def test_expectation_basic_scenarios_pyspark(
+    df_type, data, min_value, max_value, should_succeed, expected_message, spark
+):
+    """Test basic expectation scenarios for PySpark DataFrames."""
+    df = create_pyspark_dataframe(data, "col1", spark)
 
+    # Test through registry
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationColumnMedianBetween",
+        column_name="col1",
+        min_value=min_value,
+        max_value=max_value,
+    )
+    result = expectation.validate(data_frame=df)
+
+    if should_succeed:
+        assert isinstance(result, DataFrameExpectationSuccessMessage), (
+            f"Expected success but got: {result}"
+        )
+    else:
+        assert isinstance(result, DataFrameExpectationFailureMessage), (
+            f"Expected failure but got: {result}"
+        )
+        assert expected_message in str(result), (
+            f"Expected message '{expected_message}' in result: {result}"
+        )
+
+    # Test through suite
+    suite = DataFrameExpectationsSuite().expect_column_median_between(
+        column_name="col1", min_value=min_value, max_value=max_value
+    )
+
+    if should_succeed:
+        suite_result = suite.build().run(data_frame=df)
+        assert suite_result is not None, "Expected SuiteExecutionResult"
+        assert suite_result.success, "Expected all expectations to pass"
+    else:
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            suite.build().run(data_frame=df)
+
+
+def test_column_missing_error_pandas():
+    """Test missing column error for pandas DataFrames."""
+    df = pd.DataFrame({"col1": [20, 25, 30, 35]})
     expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
 
     # Test through registry
@@ -327,7 +393,36 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=df)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure)
+
+    # Test through suite
+    suite = DataFrameExpectationsSuite().expect_column_median_between(
+        column_name="nonexistent_col", min_value=25, max_value=30
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        suite.build().run(data_frame=df)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test missing column error for PySpark DataFrames."""
+    df = spark.createDataFrame([(20,), (25,), (30,), (35,)], ["col1"])
+    expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
+
+    # Test through registry
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationColumnMedianBetween",
+        column_name="nonexistent_col",
+        min_value=25,
+        max_value=30,
+    )
+    result = expectation.validate(data_frame=df)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message=expected_message,
     )
     assert str(result) == str(expected_failure)

--- a/tests/expectations/aggregation/numerical_expectations/test_expect_column_median_between.py
+++ b/tests/expectations/aggregation/numerical_expectations/test_expect_column_median_between.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 import pandas as pd
 
 from dataframe_expectations.registry import (
@@ -448,8 +449,6 @@ def test_precision_handling():
 
     for data, description in precision_tests:
         data_frame = pd.DataFrame({"col1": data})
-        import numpy as np
-
         calculated_median = np.median(data)
 
         # Use a small range around the calculated median
@@ -470,8 +469,6 @@ def test_precision_handling():
 
 def test_large_dataset_performance():
     """Test the expectation with a larger dataset to ensure performance."""
-    import numpy as np
-
     # Create a larger dataset with median around 50
     large_data = np.random.normal(50, 10, 1001).tolist()  # Use odd count for deterministic median
     data_frame = pd.DataFrame({"col1": large_data})

--- a/tests/expectations/aggregation/numerical_expectations/test_expect_column_min_between.py
+++ b/tests/expectations/aggregation/numerical_expectations/test_expect_column_min_between.py
@@ -1,6 +1,5 @@
 import pytest
 import pandas as pd
-from pyspark.sql.types import DoubleType, StructField, StructType
 
 from dataframe_expectations.registry import (
     DataFrameExpectationRegistry,
@@ -15,26 +14,25 @@ from dataframe_expectations.result_message import (
 )
 
 
-def create_dataframe(df_type, data, column_name, spark):
-    """Create a pandas or PySpark DataFrame."""
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    elif df_type == "pyspark":
-        # Handle empty or all-null data with explicit schema
-        if not data or all(v is None for v in data):
-            schema = StructType([StructField(column_name, DoubleType(), True)])
-            return spark.createDataFrame([[v] for v in data], schema=schema)
+def create_pyspark_dataframe(data, column_name, spark):
+    """Helper function to create a PySpark DataFrame."""
+    from pyspark.sql.types import DoubleType, StructField, StructType
 
-        # Use explicit DoubleType schema if the data contains any float values
-        # This ensures consistent type handling for mixed int/float data
-        has_float = any(isinstance(v, float) for v in data if v is not None)
-        if has_float:
-            float_data = [[float(v) if v is not None else None] for v in data]
-            schema = StructType([StructField(column_name, DoubleType(), True)])
-            return spark.createDataFrame(float_data, schema=schema)
-        else:
-            # For pure integer data, let PySpark infer the schema
-            return spark.createDataFrame([[v] for v in data], schema=[column_name])
+    # Handle empty or all-null data with explicit schema
+    if not data or all(v is None for v in data):
+        schema = StructType([StructField(column_name, DoubleType(), True)])
+        return spark.createDataFrame([[v] for v in data], schema=schema)
+
+    # Use explicit DoubleType schema if the data contains any float values
+    # This ensures consistent type handling for mixed int/float data
+    has_float = any(isinstance(v, float) for v in data if v is not None)
+    if has_float:
+        float_data = [[float(v) if v is not None else None] for v in data]
+        schema = StructType([StructField(column_name, DoubleType(), True)])
+        return spark.createDataFrame(float_data, schema=schema)
+    else:
+        # For pure integer data, let PySpark infer the schema
+        return spark.createDataFrame([[v] for v in data], schema=[column_name])
 
 
 def test_expectation_name():
@@ -78,84 +76,53 @@ def test_expectation_description():
     [
         # Basic success scenarios
         ("pandas", [20, 25, 30, 35], 15, 25, True, None),  # min = 20
-        ("pyspark", [20, 25, 30, 35], 15, 25, True, None),  # min = 20
         # Single row scenarios
         ("pandas", [25], 20, 30, True, None),  # min = 25
-        ("pyspark", [25], 20, 30, True, None),  # min = 25
         # Negative value scenarios
         ("pandas", [-20, -15, -10, -5], -25, -15, True, None),  # min = -20
-        ("pyspark", [-20, -15, -10, -5], -25, -15, True, None),  # min = -20
         # Float value scenarios
         ("pandas", [1.1, 2.5, 3.7, 3.8], 1.0, 1.5, True, None),  # min = 1.1
-        ("pyspark", [1.1, 2.5, 3.7, 3.8], 1.0, 1.5, True, None),  # min = 1.1
         # Identical value scenarios
         ("pandas", [25, 25, 25, 25], 24, 26, True, None),  # min = 25
-        ("pyspark", [25, 25, 25, 25], 24, 26, True, None),  # min = 25
         # Mixed type scenarios
         ("pandas", [20, 25.5, 30, 37], 15, 25, True, None),  # min = 20
-        ("pyspark", [20, 25.5, 30, 37], 15, 25, True, None),  # min = 20
         # Zero scenarios
         ("pandas", [-5, 0, 0, 2], -10, -1, True, None),  # min = -5
-        ("pyspark", [-5, 0, 0, 2], -10, -1, True, None),  # min = -5
         # Null scenarios
         ("pandas", [20, None, 35, None, 25], 15, 25, True, None),  # min = 20
-        ("pyspark", [20, None, 35, None, 25], 15, 25, True, None),  # min = 20
         # Boundary scenarios - exact minimum
         ("pandas", [20, 25, 30, 35], 20, 25, True, None),  # min = 20
-        ("pyspark", [20, 25, 30, 35], 20, 25, True, None),  # min = 20
         # Boundary scenarios - exact maximum
         ("pandas", [20, 25, 30, 35], 15, 20, True, None),  # min = 20
-        ("pyspark", [20, 25, 30, 35], 15, 20, True, None),  # min = 20
         # Minimum calculation - mixed order
         ("pandas", [100, 50, 75, 25], 24, 26, True, None),  # min = 25
-        ("pyspark", [100, 50, 75, 25], 24, 26, True, None),  # min = 25
         # Minimum calculation - zero
         ("pandas", [0, 1, 2, 3], -0.1, 0.1, True, None),  # min = 0
-        ("pyspark", [0, 1, 2, 3], -0.1, 0.1, True, None),  # min = 0
         # Minimum calculation - negative
         ("pandas", [-10, -5, -1, -20], -20.1, -19.9, True, None),  # min = -20
-        ("pyspark", [-10, -5, -1, -20], -20.1, -19.9, True, None),  # min = -20
         # Minimum calculation - small differences
         ("pandas", [1.001, 1.002, 1.003], 1.0, 1.002, True, None),  # min = 1.001
-        ("pyspark", [1.001, 1.002, 1.003], 1.0, 1.002, True, None),  # min = 1.001
         # Minimum calculation - large numbers
         ("pandas", [1e6, 1e5, 1e4], 1e4 - 100, 1e4 + 100, True, None),  # min = 1e4
-        ("pyspark", [1e6, 1e5, 1e4], 1e4 - 100, 1e4 + 100, True, None),  # min = 1e4
         # Minimum calculation - very small numbers
         ("pandas", [1e-6, 1e-5, 1e-4], 1e-7, 1e-5, True, None),  # min = 1e-6
-        ("pyspark", [1e-6, 1e-5, 1e-4], 1e-7, 1e-5, True, None),  # min = 1e-6
         # Outlier impact - extreme low outlier
         ("pandas", [1, 2, 3, -1000], -1100, -900, True, None),
-        ("pyspark", [1, 2, 3, -1000], -1100, -900, True, None),
         # Outlier impact - significant outlier
         ("pandas", [100, 200, 300, 50], 40, 60, True, None),
-        ("pyspark", [100, 200, 300, 50], 40, 60, True, None),
         # Outlier impact - small outlier
         ("pandas", [1.5, 2.0, 2.5, 0.1], 0.05, 0.15, True, None),
-        ("pyspark", [1.5, 2.0, 2.5, 0.1], 0.05, 0.15, True, None),
         # Identical values - integer repetition
         ("pandas", [42, 42, 42, 42], 41.9, 42.1, True, None),
-        ("pyspark", [42, 42, 42, 42], 41.9, 42.1, True, None),
         # Identical values - float repetition
         ("pandas", [3.14, 3.14, 3.14], 3.13, 3.15, True, None),
-        ("pyspark", [3.14, 3.14, 3.14], 3.13, 3.15, True, None),
         # Identical values - negative repetition
         ("pandas", [-7, -7, -7, -7, -7], -7.1, -6.9, True, None),
-        ("pyspark", [-7, -7, -7, -7, -7], -7.1, -6.9, True, None),
         # Identical values - zero repetition
         ("pandas", [0, 0, 0], -0.1, 0.1, True, None),
-        ("pyspark", [0, 0, 0], -0.1, 0.1, True, None),
         # Failure scenarios - minimum too low
         (
             "pandas",
-            [20, 25, 30, 35],
-            25,
-            35,
-            False,
-            "Column 'col1' minimum value 20 is not between 25 and 35.",
-        ),
-        (
-            "pyspark",
             [20, 25, 30, 35],
             25,
             35,
@@ -171,83 +138,46 @@ def test_expectation_description():
             False,
             "Column 'col1' minimum value 20 is not between 10 and 15.",
         ),
-        (
-            "pyspark",
-            [20, 25, 30, 35],
-            10,
-            15,
-            False,
-            "Column 'col1' minimum value 20 is not between 10 and 15.",
-        ),
         # Failure scenarios - all nulls
         ("pandas", [None, None, None], 15, 25, False, "Column 'col1' contains only null values."),
-        ("pyspark", [None, None, None], 15, 25, False, "Column 'col1' contains only null values."),
         # Failure scenarios - empty
         ("pandas", [], 15, 25, False, "Column 'col1' contains only null values."),
-        ("pyspark", [], 15, 25, False, "Column 'col1' contains only null values."),
     ],
     ids=[
         "pandas_basic_success",
-        "pyspark_basic_success",
         "pandas_single_row",
-        "pyspark_single_row",
         "pandas_negative_values",
-        "pyspark_negative_values",
         "pandas_float_values",
-        "pyspark_float_values",
         "pandas_identical_values",
-        "pyspark_identical_values",
         "pandas_mixed_types",
-        "pyspark_mixed_types",
         "pandas_with_zeros",
-        "pyspark_with_zeros",
         "pandas_with_nulls",
-        "pyspark_with_nulls",
         "pandas_boundary_exact_min",
-        "pyspark_boundary_exact_min",
         "pandas_boundary_exact_max",
-        "pyspark_boundary_exact_max",
         "pandas_calc_mixed_order",
-        "pyspark_calc_mixed_order",
         "pandas_calc_zero",
-        "pyspark_calc_zero",
         "pandas_calc_negative",
-        "pyspark_calc_negative",
         "pandas_calc_small_differences",
-        "pyspark_calc_small_differences",
         "pandas_calc_large_numbers",
-        "pyspark_calc_large_numbers",
         "pandas_calc_very_small_numbers",
-        "pyspark_calc_very_small_numbers",
         "pandas_outlier_extreme_low",
-        "pyspark_outlier_extreme_low",
         "pandas_outlier_significant",
-        "pyspark_outlier_significant",
         "pandas_outlier_small",
-        "pyspark_outlier_small",
         "pandas_identical_integer",
-        "pyspark_identical_integer",
         "pandas_identical_float",
-        "pyspark_identical_float",
         "pandas_identical_negative",
-        "pyspark_identical_negative",
         "pandas_identical_zero",
-        "pyspark_identical_zero",
         "pandas_min_too_low",
-        "pyspark_min_too_low",
         "pandas_min_too_high",
-        "pyspark_min_too_high",
         "pandas_all_nulls",
-        "pyspark_all_nulls",
         "pandas_empty",
-        "pyspark_empty",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, data, min_value, max_value, should_succeed, expected_message, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, data, min_value, max_value, should_succeed, expected_message
 ):
-    """Test basic expectation scenarios for both pandas and PySpark DataFrames."""
-    df = create_dataframe(df_type, data, "col1", spark)
+    """Test basic expectation scenarios for pandas DataFrames."""
+    df = pd.DataFrame({"col1": data})
 
     # Test through registry
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -284,17 +214,153 @@ def test_expectation_basic_scenarios(
             suite.build().run(data_frame=df)
 
 
+@pytest.mark.pyspark
 @pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
+    "df_type, data, min_value, max_value, should_succeed, expected_message",
+    [
+        # Basic success scenarios
+        ("pyspark", [20, 25, 30, 35], 15, 25, True, None),  # min = 20
+        # Single row scenarios
+        ("pyspark", [25], 20, 30, True, None),  # min = 25
+        # Negative value scenarios
+        ("pyspark", [-20, -15, -10, -5], -25, -15, True, None),  # min = -20
+        # Float value scenarios
+        ("pyspark", [1.1, 2.5, 3.7, 3.8], 1.0, 1.5, True, None),  # min = 1.1
+        # Identical value scenarios
+        ("pyspark", [25, 25, 25, 25], 24, 26, True, None),  # min = 25
+        # Mixed type scenarios
+        ("pyspark", [20, 25.5, 30, 37], 15, 25, True, None),  # min = 20
+        # Zero scenarios
+        ("pyspark", [-5, 0, 0, 2], -10, -1, True, None),  # min = -5
+        # Null scenarios
+        ("pyspark", [20, None, 35, None, 25], 15, 25, True, None),  # min = 20
+        # Boundary scenarios - exact minimum
+        ("pyspark", [20, 25, 30, 35], 20, 25, True, None),  # min = 20
+        # Boundary scenarios - exact maximum
+        ("pyspark", [20, 25, 30, 35], 15, 20, True, None),  # min = 20
+        # Minimum calculation - mixed order
+        ("pyspark", [100, 50, 75, 25], 24, 26, True, None),  # min = 25
+        # Minimum calculation - zero
+        ("pyspark", [0, 1, 2, 3], -0.1, 0.1, True, None),  # min = 0
+        # Minimum calculation - negative
+        ("pyspark", [-10, -5, -1, -20], -20.1, -19.9, True, None),  # min = -20
+        # Minimum calculation - small differences
+        ("pyspark", [1.001, 1.002, 1.003], 1.0, 1.002, True, None),  # min = 1.001
+        # Minimum calculation - large numbers
+        ("pyspark", [1e6, 1e5, 1e4], 1e4 - 100, 1e4 + 100, True, None),  # min = 1e4
+        # Minimum calculation - very small numbers
+        ("pyspark", [1e-6, 1e-5, 1e-4], 1e-7, 1e-5, True, None),  # min = 1e-6
+        # Outlier impact - extreme low outlier
+        ("pyspark", [1, 2, 3, -1000], -1100, -900, True, None),
+        # Outlier impact - significant outlier
+        ("pyspark", [100, 200, 300, 50], 40, 60, True, None),
+        # Outlier impact - small outlier
+        ("pyspark", [1.5, 2.0, 2.5, 0.1], 0.05, 0.15, True, None),
+        # Identical values - integer repetition
+        ("pyspark", [42, 42, 42, 42], 41.9, 42.1, True, None),
+        # Identical values - float repetition
+        ("pyspark", [3.14, 3.14, 3.14], 3.13, 3.15, True, None),
+        # Identical values - negative repetition
+        ("pyspark", [-7, -7, -7, -7, -7], -7.1, -6.9, True, None),
+        # Identical values - zero repetition
+        ("pyspark", [0, 0, 0], -0.1, 0.1, True, None),
+        # Failure scenarios - minimum too low
+        (
+            "pyspark",
+            [20, 25, 30, 35],
+            25,
+            35,
+            False,
+            "Column 'col1' minimum value 20 is not between 25 and 35.",
+        ),
+        # Failure scenarios - minimum too high
+        (
+            "pyspark",
+            [20, 25, 30, 35],
+            10,
+            15,
+            False,
+            "Column 'col1' minimum value 20 is not between 10 and 15.",
+        ),
+        # Failure scenarios - all nulls
+        ("pyspark", [None, None, None], 15, 25, False, "Column 'col1' contains only null values."),
+        # Failure scenarios - empty
+        ("pyspark", [], 15, 25, False, "Column 'col1' contains only null values."),
+    ],
+    ids=[
+        "pyspark_basic_success",
+        "pyspark_single_row",
+        "pyspark_negative_values",
+        "pyspark_float_values",
+        "pyspark_identical_values",
+        "pyspark_mixed_types",
+        "pyspark_with_zeros",
+        "pyspark_with_nulls",
+        "pyspark_boundary_exact_min",
+        "pyspark_boundary_exact_max",
+        "pyspark_calc_mixed_order",
+        "pyspark_calc_zero",
+        "pyspark_calc_negative",
+        "pyspark_calc_small_differences",
+        "pyspark_calc_large_numbers",
+        "pyspark_calc_very_small_numbers",
+        "pyspark_outlier_extreme_low",
+        "pyspark_outlier_significant",
+        "pyspark_outlier_small",
+        "pyspark_identical_integer",
+        "pyspark_identical_float",
+        "pyspark_identical_negative",
+        "pyspark_identical_zero",
+        "pyspark_min_too_low",
+        "pyspark_min_too_high",
+        "pyspark_all_nulls",
+        "pyspark_empty",
+    ],
 )
-def test_column_missing_error(df_type, spark):
-    """Test missing column error for both pandas and PySpark DataFrames."""
-    if df_type == "pandas":
-        df = pd.DataFrame({"col1": [20, 25, 30, 35]})
-    else:
-        df = spark.createDataFrame([(20,), (25,), (30,), (35,)], ["col1"])
+def test_expectation_basic_scenarios_pyspark(
+    df_type, data, min_value, max_value, should_succeed, expected_message, spark
+):
+    """Test basic expectation scenarios for PySpark DataFrames."""
+    df = create_pyspark_dataframe(data, "col1", spark)
 
+    # Test through registry
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationColumnMinBetween",
+        column_name="col1",
+        min_value=min_value,
+        max_value=max_value,
+    )
+    result = expectation.validate(data_frame=df)
+
+    if should_succeed:
+        assert isinstance(result, DataFrameExpectationSuccessMessage), (
+            f"Expected success but got: {result}"
+        )
+    else:
+        assert isinstance(result, DataFrameExpectationFailureMessage), (
+            f"Expected failure but got: {result}"
+        )
+        assert expected_message in str(result), (
+            f"Expected message '{expected_message}' in result: {result}"
+        )
+
+    # Test through suite
+    suite = DataFrameExpectationsSuite().expect_column_min_between(
+        column_name="col1", min_value=min_value, max_value=max_value
+    )
+
+    if should_succeed:
+        suite_result = suite.build().run(data_frame=df)
+        assert suite_result is not None, "Expected SuiteExecutionResult"
+        assert suite_result.success, "Expected all expectations to pass"
+    else:
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            suite.build().run(data_frame=df)
+
+
+def test_column_missing_error_pandas():
+    """Test missing column error for pandas DataFrames."""
+    df = pd.DataFrame({"col1": [20, 25, 30, 35]})
     expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
 
     # Test through registry
@@ -307,7 +373,36 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=df)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure)
+
+    # Test through suite
+    suite = DataFrameExpectationsSuite().expect_column_min_between(
+        column_name="nonexistent_col", min_value=15, max_value=25
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        suite.build().run(data_frame=df)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test missing column error for PySpark DataFrames."""
+    df = spark.createDataFrame([(20,), (25,), (30,), (35,)], ["col1"])
+    expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
+
+    # Test through registry
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationColumnMinBetween",
+        column_name="nonexistent_col",
+        min_value=15,
+        max_value=25,
+    )
+    result = expectation.validate(data_frame=df)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message=expected_message,
     )
     assert str(result) == str(expected_failure)

--- a/tests/expectations/aggregation/numerical_expectations/test_expect_column_min_between.py
+++ b/tests/expectations/aggregation/numerical_expectations/test_expect_column_min_between.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 import pandas as pd
 
 from dataframe_expectations.registry import (
@@ -417,8 +418,6 @@ def test_column_missing_error_pyspark(spark):
 
 def test_large_dataset_performance():
     """Test the expectation with a larger dataset to ensure performance."""
-    import numpy as np
-
     # Create a larger dataset with minimum around 10
     large_data = np.random.uniform(10, 60, 1000).tolist()
     data_frame = pd.DataFrame({"col1": large_data})

--- a/tests/expectations/aggregation/numerical_expectations/test_expect_column_quantile_between.py
+++ b/tests/expectations/aggregation/numerical_expectations/test_expect_column_quantile_between.py
@@ -15,21 +15,18 @@ from dataframe_expectations.result_message import (
 )
 
 
-def create_dataframe(df_type, data, column_name, spark):
-    """Helper function to create pandas or pyspark DataFrame."""
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        from pyspark.sql.types import DoubleType, StructField, StructType
+def create_pyspark_dataframe(data, column_name, spark):
+    """Helper function to create a PySpark DataFrame."""
+    from pyspark.sql.types import DoubleType, StructField, StructType
 
-        if not data:  # Empty DataFrame
-            schema = StructType([StructField(column_name, DoubleType(), True)])
-            return spark.createDataFrame([], schema)
-        # Handle all nulls case with explicit schema
-        if all(val is None for val in data):
-            schema = StructType([StructField(column_name, DoubleType(), True)])
-            return spark.createDataFrame([{column_name: None} for _ in data], schema)
-        return spark.createDataFrame([(val,) for val in data], [column_name])
+    if not data:  # Empty DataFrame
+        schema = StructType([StructField(column_name, DoubleType(), True)])
+        return spark.createDataFrame([], schema)
+    # Handle all nulls case with explicit schema
+    if all(val is None for val in data):
+        schema = StructType([StructField(column_name, DoubleType(), True)])
+        return spark.createDataFrame([{column_name: None} for _ in data], schema)
+    return spark.createDataFrame([(val,) for val in data], [column_name])
 
 
 def test_expectation_name():
@@ -78,37 +75,21 @@ def test_expectation_description():
     [
         # Quantile 0.0 (minimum) scenarios
         ("pandas", [20, 25, 30, 35], 0.0, 15, 25, True, None),  # min = 20
-        ("pyspark", [20, 25, 30, 35], 0.0, 15, 25, True, None),  # min = 20
         # Quantile 1.0 (maximum) scenarios
         ("pandas", [20, 25, 30, 35], 1.0, 30, 40, True, None),  # max = 35
-        ("pyspark", [20, 25, 30, 35], 1.0, 30, 40, True, None),  # max = 35
         # Quantile 0.5 (median) scenarios
         ("pandas", [20, 25, 30, 35], 0.5, 25, 30, True, None),  # median = 27.5
-        ("pyspark", [20, 25, 30, 35], 0.5, 25, 30, True, None),  # median ≈ 27.5
         # Quantile 0.25 (25th percentile) scenarios
         ("pandas", [20, 25, 30, 35], 0.25, 20, 25, True, None),  # 25th percentile = 22.5
-        ("pyspark", [20, 25, 30, 35], 0.25, 20, 25, True, None),  # 25th percentile ≈ 22.5
         # Other quantile scenarios
         ("pandas", [10, 20, 30, 40, 50], 0.33, 20, 30, True, None),  # 33rd percentile ≈ 23.2
-        ("pyspark", [20, 25, 30, 35], 0.9, 30, 40, True, None),  # 90th percentile ≈ 34
         # Single row scenarios
         ("pandas", [25], 0.5, 20, 30, True, None),  # median = 25
-        ("pyspark", [25], 0.5, 20, 30, True, None),  # median = 25
         # Null scenarios
         ("pandas", [20, None, 25, None, 30], 0.5, 20, 30, True, None),  # median = 25
-        ("pyspark", [20, None, 25, None, 30], 0.5, 20, 30, True, None),  # median ≈ 25
         # Failure scenarios - minimum (quantile 0.0)
         (
             "pandas",
-            [20, 25, 30, 35],
-            0.0,
-            25,
-            35,
-            False,
-            "Column 'col1' minimum value 20 is not between 25 and 35.",
-        ),
-        (
-            "pyspark",
             [20, 25, 30, 35],
             0.0,
             25,
@@ -126,15 +107,6 @@ def test_expectation_description():
             False,
             "Column 'col1' maximum value 35 is not between 40 and 50.",
         ),
-        (
-            "pyspark",
-            [20, 25, 30, 35],
-            1.0,
-            40,
-            50,
-            False,
-            "Column 'col1' maximum value 35 is not between 40 and 50.",
-        ),
         # Failure scenarios - median (quantile 0.5)
         (
             "pandas",
@@ -144,15 +116,6 @@ def test_expectation_description():
             35,
             False,
             "Column 'col1' median value 27.5 is not between 30 and 35.",
-        ),
-        (
-            "pyspark",
-            [20, 25, 30, 35],
-            0.5,
-            30,
-            35,
-            False,
-            f"Column 'col1' median value {np.median([20, 25, 30, 35])} is not between 30 and 35.",
         ),
         # Failure scenarios - 75th percentile
         (
@@ -164,15 +127,6 @@ def test_expectation_description():
             False,
             f"Column 'col1' 75th percentile value {np.quantile([20, 25, 30, 35], 0.75)} is not between 25 and 30.",
         ),
-        (
-            "pyspark",
-            [20, 25, 30, 35],
-            0.75,
-            32,
-            40,
-            False,
-            "Column 'col1' 75th percentile value 30 is not between 32 and 40.",
-        ),
         # Failure scenarios - all nulls
         (
             "pandas",
@@ -183,53 +137,30 @@ def test_expectation_description():
             False,
             "Column 'col1' contains only null values.",
         ),
-        (
-            "pyspark",
-            [None, None, None],
-            0.5,
-            20,
-            30,
-            False,
-            "Column 'col1' contains only null values.",
-        ),
         # Failure scenarios - empty
         ("pandas", [], 0.5, 20, 30, False, "Column 'col1' contains only null values."),
-        ("pyspark", [], 0.5, 20, 30, False, "Column 'col1' contains only null values."),
     ],
     ids=[
         "pandas_quantile_0_min",
-        "pyspark_quantile_0_min",
         "pandas_quantile_1_max",
-        "pyspark_quantile_1_max",
         "pandas_quantile_0_5_median",
-        "pyspark_quantile_0_5_median",
         "pandas_quantile_0_25",
-        "pyspark_quantile_0_25",
         "pandas_quantile_0_33",
-        "pyspark_quantile_0_9",
         "pandas_single_row",
-        "pyspark_single_row",
         "pandas_with_nulls",
-        "pyspark_with_nulls",
         "pandas_fail_min_too_low",
-        "pyspark_fail_min_too_low",
         "pandas_fail_max_too_low",
-        "pyspark_fail_max_too_low",
         "pandas_fail_median_too_low",
-        "pyspark_fail_median_too_low",
         "pandas_fail_75th_percentile",
-        "pyspark_fail_75th_percentile",
         "pandas_all_nulls",
-        "pyspark_all_nulls",
         "pandas_empty",
-        "pyspark_empty",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, data, quantile, min_value, max_value, should_succeed, expected_message, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, data, quantile, min_value, max_value, should_succeed, expected_message
 ):
-    """Test basic expectation scenarios for both pandas and PySpark DataFrames."""
-    df = create_dataframe(df_type, data, "col1", spark)
+    """Test basic expectation scenarios for pandas DataFrames."""
+    df = pd.DataFrame({"col1": data})
 
     # Test through registry
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -267,18 +198,138 @@ def test_expectation_basic_scenarios(
             suite.build().run(data_frame=df)
 
 
+@pytest.mark.pyspark
 @pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
+    "df_type, data, quantile, min_value, max_value, should_succeed, expected_message",
+    [
+        # Quantile 0.0 (minimum) scenarios
+        ("pyspark", [20, 25, 30, 35], 0.0, 15, 25, True, None),  # min = 20
+        # Quantile 1.0 (maximum) scenarios
+        ("pyspark", [20, 25, 30, 35], 1.0, 30, 40, True, None),  # max = 35
+        # Quantile 0.5 (median) scenarios
+        ("pyspark", [20, 25, 30, 35], 0.5, 25, 30, True, None),  # median ≈ 27.5
+        # Quantile 0.25 (25th percentile) scenarios
+        ("pyspark", [20, 25, 30, 35], 0.25, 20, 25, True, None),  # 25th percentile ≈ 22.5
+        # Other quantile scenarios
+        ("pyspark", [20, 25, 30, 35], 0.9, 30, 40, True, None),  # 90th percentile ≈ 34
+        # Single row scenarios
+        ("pyspark", [25], 0.5, 20, 30, True, None),  # median = 25
+        # Null scenarios
+        ("pyspark", [20, None, 25, None, 30], 0.5, 20, 30, True, None),  # median ≈ 25
+        # Failure scenarios - minimum (quantile 0.0)
+        (
+            "pyspark",
+            [20, 25, 30, 35],
+            0.0,
+            25,
+            35,
+            False,
+            "Column 'col1' minimum value 20 is not between 25 and 35.",
+        ),
+        # Failure scenarios - maximum (quantile 1.0)
+        (
+            "pyspark",
+            [20, 25, 30, 35],
+            1.0,
+            40,
+            50,
+            False,
+            "Column 'col1' maximum value 35 is not between 40 and 50.",
+        ),
+        # Failure scenarios - median (quantile 0.5)
+        (
+            "pyspark",
+            [20, 25, 30, 35],
+            0.5,
+            30,
+            35,
+            False,
+            f"Column 'col1' median value {np.median([20, 25, 30, 35])} is not between 30 and 35.",
+        ),
+        # Failure scenarios - 75th percentile
+        (
+            "pyspark",
+            [20, 25, 30, 35],
+            0.75,
+            32,
+            40,
+            False,
+            "Column 'col1' 75th percentile value 30 is not between 32 and 40.",
+        ),
+        # Failure scenarios - all nulls
+        (
+            "pyspark",
+            [None, None, None],
+            0.5,
+            20,
+            30,
+            False,
+            "Column 'col1' contains only null values.",
+        ),
+        # Failure scenarios - empty
+        ("pyspark", [], 0.5, 20, 30, False, "Column 'col1' contains only null values."),
+    ],
+    ids=[
+        "pyspark_quantile_0_min",
+        "pyspark_quantile_1_max",
+        "pyspark_quantile_0_5_median",
+        "pyspark_quantile_0_25",
+        "pyspark_quantile_0_9",
+        "pyspark_single_row",
+        "pyspark_with_nulls",
+        "pyspark_fail_min_too_low",
+        "pyspark_fail_max_too_low",
+        "pyspark_fail_median_too_low",
+        "pyspark_fail_75th_percentile",
+        "pyspark_all_nulls",
+        "pyspark_empty",
+    ],
 )
-def test_column_missing_error(df_type, spark):
-    """Test missing column error for both pandas and PySpark DataFrames."""
-    if df_type == "pandas":
-        df = pd.DataFrame({"col1": [20, 25, 30, 35]})
-    else:
-        df = spark.createDataFrame([(20,), (25,), (30,), (35,)], ["col1"])
+def test_expectation_basic_scenarios_pyspark(
+    df_type, data, quantile, min_value, max_value, should_succeed, expected_message, spark
+):
+    """Test basic expectation scenarios for PySpark DataFrames."""
+    df = create_pyspark_dataframe(data, "col1", spark)
 
+    # Test through registry
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationColumnQuantileBetween",
+        column_name="col1",
+        quantile=quantile,
+        min_value=min_value,
+        max_value=max_value,
+    )
+    result = expectation.validate(data_frame=df)
+
+    if should_succeed:
+        assert isinstance(result, DataFrameExpectationSuccessMessage), (
+            f"Expected success but got: {result}"
+        )
+    else:
+        assert isinstance(result, DataFrameExpectationFailureMessage), (
+            f"Expected failure but got: {result}"
+        )
+        assert expected_message in str(result), (
+            f"Expected message '{expected_message}' in result: {result}"
+        )
+
+    # Test through suite
+    suite = DataFrameExpectationsSuite().expect_column_quantile_between(
+        column_name="col1", quantile=quantile, min_value=min_value, max_value=max_value
+    )
+
+    if should_succeed:
+        suite_result = suite.build().run(data_frame=df)
+        assert suite_result is not None, "Expected SuiteExecutionResult"
+        assert suite_result.success, "Expected all expectations to pass"
+    else:
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            suite.build().run(data_frame=df)
+
+
+def test_column_missing_error_pandas():
+    """Test missing column error for pandas DataFrames."""
+    df = pd.DataFrame({"col1": [20, 25, 30, 35]})
     expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
 
     # Test through registry
@@ -292,7 +343,37 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=df)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure)
+
+    # Test through suite
+    suite = DataFrameExpectationsSuite().expect_column_quantile_between(
+        column_name="nonexistent_col", quantile=0.5, min_value=25, max_value=30
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        suite.build().run(data_frame=df)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test missing column error for PySpark DataFrames."""
+    df = spark.createDataFrame([(20,), (25,), (30,), (35,)], ["col1"])
+    expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
+
+    # Test through registry
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationColumnQuantileBetween",
+        column_name="nonexistent_col",
+        quantile=0.5,
+        min_value=25,
+        max_value=30,
+    )
+    result = expectation.validate(data_frame=df)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message=expected_message,
     )
     assert str(result) == str(expected_failure)

--- a/tests/expectations/column/any_value_expectations/test_expect_value_equals.py
+++ b/tests/expectations/column/any_value_expectations/test_expect_value_equals.py
@@ -8,47 +8,36 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark, data_type="long"):
-    """Helper function to create pandas or pyspark DataFrame.
+def create_pyspark_dataframe(data, column_name, spark, data_type="long"):
+    """Helper function to create a PySpark DataFrame."""
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        LongType,
+        StringType,
+        DoubleType,
+        BooleanType,
+        TimestampType,
+    )
 
-    Args:
-        df_type: "pandas" or "pyspark"
-        data: List of values for the column
-        column_name: Name of the column
-        spark: Spark session (required for pyspark)
-        data_type: Data type for the column - "long", "string", "double", "boolean", "timestamp"
-    """
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        from pyspark.sql.types import (
-            StructType,
-            StructField,
-            LongType,
-            StringType,
-            DoubleType,
-            BooleanType,
-            TimestampType,
-        )
+    type_mapping = {
+        "long": LongType(),
+        "string": StringType(),
+        "double": DoubleType(),
+        "boolean": BooleanType(),
+        "timestamp": TimestampType(),
+    }
 
-        type_mapping = {
-            "long": LongType(),
-            "string": StringType(),
-            "double": DoubleType(),
-            "boolean": BooleanType(),
-            "timestamp": TimestampType(),
-        }
-
-        schema = StructType([StructField(column_name, type_mapping[data_type], True)])
-        return spark.createDataFrame([(val,) for val in data], schema)
+    schema = StructType([StructField(column_name, type_mapping[data_type], True)])
+    return spark.createDataFrame([(val,) for val in data], schema)
 
 
 def test_expectation_name():
@@ -68,9 +57,7 @@ def test_expectation_name():
     [
         # Basic integer success scenarios
         ("pandas", [5, 5, 5], 5, True, None, None, "long"),
-        ("pyspark", [5, 5, 5], 5, True, None, None, "long"),
         ("pandas", [10, 10], 10, True, None, None, "long"),
-        ("pyspark", [10, 10], 10, True, None, None, "long"),
         # Integer failure scenarios with violations
         (
             "pandas",
@@ -81,30 +68,11 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is not equal to 5.",
             "long",
         ),
-        (
-            "pyspark",
-            [3, 4, 5],
-            5,
-            False,
-            [3, 4],
-            "Found 2 row(s) where 'col1' is not equal to 5.",
-            "long",
-        ),
         # String success scenarios
         ("pandas", ["apple", "apple", "apple"], "apple", True, None, None, "string"),
-        ("pyspark", ["apple", "apple", "apple"], "apple", True, None, None, "string"),
         # String failure scenarios
         (
             "pandas",
-            ["apple", "banana", "apple"],
-            "apple",
-            False,
-            ["banana"],
-            "Found 1 row(s) where 'col1' is not equal to apple.",
-            "string",
-        ),
-        (
-            "pyspark",
             ["apple", "banana", "apple"],
             "apple",
             False,
@@ -122,18 +90,8 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is not equal to apple.",
             "string",
         ),
-        (
-            "pyspark",
-            ["Apple", "APPLE", "apple"],
-            "apple",
-            False,
-            ["Apple", "APPLE"],
-            "Found 2 row(s) where 'col1' is not equal to apple.",
-            "string",
-        ),
         # Float/Double success scenarios
         ("pandas", [3.14, 3.14, 3.14], 3.14, True, None, None, "double"),
-        ("pyspark", [3.14, 3.14, 3.14], 3.14, True, None, None, "double"),
         # Float/Double failure scenarios
         (
             "pandas",
@@ -144,29 +102,10 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not equal to 3.14.",
             "double",
         ),
-        (
-            "pyspark",
-            [3.14, 2.71, 3.14],
-            3.14,
-            False,
-            [2.71],
-            "Found 1 row(s) where 'col1' is not equal to 3.14.",
-            "double",
-        ),
         # Float precision edge cases
         ("pandas", [1.0, 1.0, 1.0], 1.0, True, None, None, "double"),
-        ("pyspark", [1.0, 1.0, 1.0], 1.0, True, None, None, "double"),
         (
             "pandas",
-            [1.0, 1.1, 1.0],
-            1.0,
-            False,
-            [1.1],
-            "Found 1 row(s) where 'col1' is not equal to 1.0.",
-            "double",
-        ),
-        (
-            "pyspark",
             [1.0, 1.1, 1.0],
             1.0,
             False,
@@ -176,22 +115,11 @@ def test_expectation_name():
         ),
         # Boolean success scenarios - True
         ("pandas", [True, True, True], True, True, None, None, "boolean"),
-        ("pyspark", [True, True, True], True, True, None, None, "boolean"),
         # Boolean success scenarios - False
         ("pandas", [False, False, False], False, True, None, None, "boolean"),
-        ("pyspark", [False, False, False], False, True, None, None, "boolean"),
         # Boolean failure scenarios
         (
             "pandas",
-            [True, False, True],
-            True,
-            False,
-            [False],
-            "Found 1 row(s) where 'col1' is not equal to True.",
-            "boolean",
-        ),
-        (
-            "pyspark",
             [True, False, True],
             True,
             False,
@@ -209,27 +137,9 @@ def test_expectation_name():
             None,
             "timestamp",
         ),
-        (
-            "pyspark",
-            [datetime(2023, 1, 1), datetime(2023, 1, 1), datetime(2023, 1, 1)],
-            datetime(2023, 1, 1),
-            True,
-            None,
-            None,
-            "timestamp",
-        ),
         # Timestamp failure scenarios
         (
             "pandas",
-            [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 1)],
-            datetime(2023, 1, 1),
-            False,
-            [datetime(2023, 1, 2)],
-            "Found 1 row(s) where 'col1' is not equal to 2023-01-01 00:00:00.",
-            "timestamp",
-        ),
-        (
-            "pyspark",
             [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 1)],
             datetime(2023, 1, 1),
             False,
@@ -250,32 +160,10 @@ def test_expectation_name():
             None,
             "timestamp",
         ),
-        (
-            "pyspark",
-            [
-                datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
-                datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
-            ],
-            datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
-            True,
-            None,
-            None,
-            "timestamp",
-        ),
         # Empty string scenarios
         ("pandas", ["", "", ""], "", True, None, None, "string"),
-        ("pyspark", ["", "", ""], "", True, None, None, "string"),
         (
             "pandas",
-            ["", "text", ""],
-            "",
-            False,
-            ["text"],
-            "Found 1 row(s) where 'col1' is not equal to .",
-            "string",
-        ),
-        (
-            "pyspark",
             ["", "text", ""],
             "",
             False,
@@ -293,83 +181,45 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not equal to test.",
             "string",
         ),
-        (
-            "pyspark",
-            ["test", " test", "test"],
-            "test",
-            False,
-            [" test"],
-            "Found 1 row(s) where 'col1' is not equal to test.",
-            "string",
-        ),
         # Zero value scenarios - integer
         ("pandas", [0, 0, 0], 0, True, None, None, "long"),
-        ("pyspark", [0, 0, 0], 0, True, None, None, "long"),
         # Zero value scenarios - double
         ("pandas", [0.0, 0.0, 0.0], 0.0, True, None, None, "double"),
-        ("pyspark", [0.0, 0.0, 0.0], 0.0, True, None, None, "double"),
         # Negative integer scenarios
         ("pandas", [-5, -5, -5], -5, True, None, None, "long"),
-        ("pyspark", [-5, -5, -5], -5, True, None, None, "long"),
         # Negative double scenarios
         ("pandas", [-3.14, -3.14, -3.14], -3.14, True, None, None, "double"),
-        ("pyspark", [-3.14, -3.14, -3.14], -3.14, True, None, None, "double"),
         # Large numbers
         ("pandas", [1000000, 1000000], 1000000, True, None, None, "long"),
-        ("pyspark", [1000000, 1000000], 1000000, True, None, None, "long"),
     ],
     ids=[
         "pandas_int_basic_success",
-        "pyspark_int_basic_success",
         "pandas_int_success_two_rows",
-        "pyspark_int_success_two_rows",
         "pandas_int_failure_violations",
-        "pyspark_int_failure_violations",
         "pandas_string_success",
-        "pyspark_string_success",
         "pandas_string_failure",
-        "pyspark_string_failure",
         "pandas_string_case_sensitive",
-        "pyspark_string_case_sensitive",
         "pandas_double_success",
-        "pyspark_double_success",
         "pandas_double_failure",
-        "pyspark_double_failure",
         "pandas_double_precision_success",
-        "pyspark_double_precision_success",
         "pandas_double_precision_failure",
-        "pyspark_double_precision_failure",
         "pandas_boolean_true_success",
-        "pyspark_boolean_true_success",
         "pandas_boolean_false_success",
-        "pyspark_boolean_false_success",
         "pandas_boolean_failure",
-        "pyspark_boolean_failure",
         "pandas_timestamp_success",
-        "pyspark_timestamp_success",
         "pandas_timestamp_failure",
-        "pyspark_timestamp_failure",
         "pandas_timestamp_with_timezone",
-        "pyspark_timestamp_with_timezone",
         "pandas_empty_string_success",
-        "pyspark_empty_string_success",
         "pandas_empty_string_failure",
-        "pyspark_empty_string_failure",
         "pandas_string_whitespace",
-        "pyspark_string_whitespace",
         "pandas_zero_int",
-        "pyspark_zero_int",
         "pandas_zero_double",
-        "pyspark_zero_double",
         "pandas_negative_int",
-        "pyspark_negative_int",
         "pandas_negative_double",
-        "pyspark_negative_double",
         "pandas_large_numbers",
-        "pyspark_large_numbers",
     ],
 )
-def test_expectation_basic_scenarios(
+def test_expectation_basic_scenarios_pandas(
     df_type,
     data,
     value,
@@ -377,9 +227,8 @@ def test_expectation_basic_scenarios(
     expected_violations,
     expected_message,
     data_type,
-    spark,
 ):
-    """Test basic expectation scenarios for both pandas and PySpark DataFrames.
+    """Test basic expectation scenarios for pandas DataFrames.
 
     Tests various data types including:
     - Integers (long): positive, negative, zero, large numbers
@@ -388,7 +237,7 @@ def test_expectation_basic_scenarios(
     - Booleans: True/False
     - Timestamps: with and without timezone
     """
-    df = create_dataframe(df_type, data, "col1", spark, data_type)
+    df = pd.DataFrame({"col1": data})
 
     # Test through registry
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -412,12 +261,10 @@ def test_expectation_basic_scenarios(
 
         # Verify violations if present
         if expected_violations is not None:
-            expected_violations_df = create_dataframe(
-                df_type, expected_violations, "col1", spark, data_type
-            )
+            expected_violations_df = pd.DataFrame({"col1": expected_violations})
             expected_failure = DataFrameExpectationFailureMessage(
                 expectation_str=str(expectation),
-                data_frame_type=str(df_type),
+                data_frame_type="pandas",
                 violations_data_frame=expected_violations_df,
                 message=expected_message,
                 limit_violations=5,
@@ -443,17 +290,251 @@ def test_expectation_basic_scenarios(
             suite.build().run(data_frame=df)
 
 
+@pytest.mark.pyspark
 @pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
+    "df_type, data, value, should_succeed, expected_violations, expected_message, data_type",
+    [
+        # Basic integer success scenarios
+        ("pyspark", [5, 5, 5], 5, True, None, None, "long"),
+        ("pyspark", [10, 10], 10, True, None, None, "long"),
+        # Integer failure scenarios with violations
+        (
+            "pyspark",
+            [3, 4, 5],
+            5,
+            False,
+            [3, 4],
+            "Found 2 row(s) where 'col1' is not equal to 5.",
+            "long",
+        ),
+        # String success scenarios
+        ("pyspark", ["apple", "apple", "apple"], "apple", True, None, None, "string"),
+        # String failure scenarios
+        (
+            "pyspark",
+            ["apple", "banana", "apple"],
+            "apple",
+            False,
+            ["banana"],
+            "Found 1 row(s) where 'col1' is not equal to apple.",
+            "string",
+        ),
+        # String case sensitivity
+        (
+            "pyspark",
+            ["Apple", "APPLE", "apple"],
+            "apple",
+            False,
+            ["Apple", "APPLE"],
+            "Found 2 row(s) where 'col1' is not equal to apple.",
+            "string",
+        ),
+        # Float/Double success scenarios
+        ("pyspark", [3.14, 3.14, 3.14], 3.14, True, None, None, "double"),
+        # Float/Double failure scenarios
+        (
+            "pyspark",
+            [3.14, 2.71, 3.14],
+            3.14,
+            False,
+            [2.71],
+            "Found 1 row(s) where 'col1' is not equal to 3.14.",
+            "double",
+        ),
+        # Float precision edge cases
+        ("pyspark", [1.0, 1.0, 1.0], 1.0, True, None, None, "double"),
+        (
+            "pyspark",
+            [1.0, 1.1, 1.0],
+            1.0,
+            False,
+            [1.1],
+            "Found 1 row(s) where 'col1' is not equal to 1.0.",
+            "double",
+        ),
+        # Boolean success scenarios - True
+        ("pyspark", [True, True, True], True, True, None, None, "boolean"),
+        # Boolean success scenarios - False
+        ("pyspark", [False, False, False], False, True, None, None, "boolean"),
+        # Boolean failure scenarios
+        (
+            "pyspark",
+            [True, False, True],
+            True,
+            False,
+            [False],
+            "Found 1 row(s) where 'col1' is not equal to True.",
+            "boolean",
+        ),
+        # Timestamp success scenarios
+        (
+            "pyspark",
+            [datetime(2023, 1, 1), datetime(2023, 1, 1), datetime(2023, 1, 1)],
+            datetime(2023, 1, 1),
+            True,
+            None,
+            None,
+            "timestamp",
+        ),
+        # Timestamp failure scenarios
+        (
+            "pyspark",
+            [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 1)],
+            datetime(2023, 1, 1),
+            False,
+            [datetime(2023, 1, 2)],
+            "Found 1 row(s) where 'col1' is not equal to 2023-01-01 00:00:00.",
+            "timestamp",
+        ),
+        # Datetime with timezone
+        (
+            "pyspark",
+            [
+                datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+                datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            ],
+            datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            True,
+            None,
+            None,
+            "timestamp",
+        ),
+        # Empty string scenarios
+        ("pyspark", ["", "", ""], "", True, None, None, "string"),
+        (
+            "pyspark",
+            ["", "text", ""],
+            "",
+            False,
+            ["text"],
+            "Found 1 row(s) where 'col1' is not equal to .",
+            "string",
+        ),
+        # Whitespace in strings
+        (
+            "pyspark",
+            ["test", " test", "test"],
+            "test",
+            False,
+            [" test"],
+            "Found 1 row(s) where 'col1' is not equal to test.",
+            "string",
+        ),
+        # Zero value scenarios - integer
+        ("pyspark", [0, 0, 0], 0, True, None, None, "long"),
+        # Zero value scenarios - double
+        ("pyspark", [0.0, 0.0, 0.0], 0.0, True, None, None, "double"),
+        # Negative integer scenarios
+        ("pyspark", [-5, -5, -5], -5, True, None, None, "long"),
+        # Negative double scenarios
+        ("pyspark", [-3.14, -3.14, -3.14], -3.14, True, None, None, "double"),
+        # Large numbers
+        ("pyspark", [1000000, 1000000], 1000000, True, None, None, "long"),
+    ],
+    ids=[
+        "pyspark_int_basic_success",
+        "pyspark_int_success_two_rows",
+        "pyspark_int_failure_violations",
+        "pyspark_string_success",
+        "pyspark_string_failure",
+        "pyspark_string_case_sensitive",
+        "pyspark_double_success",
+        "pyspark_double_failure",
+        "pyspark_double_precision_success",
+        "pyspark_double_precision_failure",
+        "pyspark_boolean_true_success",
+        "pyspark_boolean_false_success",
+        "pyspark_boolean_failure",
+        "pyspark_timestamp_success",
+        "pyspark_timestamp_failure",
+        "pyspark_timestamp_with_timezone",
+        "pyspark_empty_string_success",
+        "pyspark_empty_string_failure",
+        "pyspark_string_whitespace",
+        "pyspark_zero_int",
+        "pyspark_zero_double",
+        "pyspark_negative_int",
+        "pyspark_negative_double",
+        "pyspark_large_numbers",
+    ],
 )
-def test_column_missing_error(df_type, spark):
-    """Test missing column error for both pandas and PySpark DataFrames."""
-    if df_type == "pandas":
-        df = pd.DataFrame({"col1": [5, 5, 5]})
+def test_expectation_basic_scenarios_pyspark(
+    df_type,
+    data,
+    value,
+    should_succeed,
+    expected_violations,
+    expected_message,
+    data_type,
+    spark,
+):
+    """Test basic expectation scenarios for PySpark DataFrames.
+
+    Tests various data types including:
+    - Integers (long): positive, negative, zero, large numbers
+    - Strings: case sensitivity, empty strings, whitespace
+    - Floats (double): precision, zero, negative
+    - Booleans: True/False
+    - Timestamps: with and without timezone
+    """
+    df = create_pyspark_dataframe(data, "col1", spark, data_type)
+
+    # Test through registry
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueEquals",
+        column_name="col1",
+        value=value,
+    )
+    result = expectation.validate(data_frame=df)
+
+    if should_succeed:
+        assert isinstance(result, DataFrameExpectationSuccessMessage), (
+            f"Expected success but got: {result}"
+        )
     else:
-        df = spark.createDataFrame([(5,), (5,), (5,)], ["col1"])
+        assert isinstance(result, DataFrameExpectationFailureMessage), (
+            f"Expected failure but got: {result}"
+        )
+        assert expected_message in str(result), (
+            f"Expected message '{expected_message}' in result: {result}"
+        )
+
+        # Verify violations if present
+        if expected_violations is not None:
+            expected_violations_df = create_pyspark_dataframe(
+                expected_violations, "col1", spark, data_type
+            )
+            expected_failure = DataFrameExpectationFailureMessage(
+                expectation_str=str(expectation),
+                data_frame_type="pyspark",
+                violations_data_frame=expected_violations_df,
+                message=expected_message,
+                limit_violations=5,
+            )
+            assert str(result) == str(expected_failure), (
+                f"Expected failure details don't match. Got: {result}"
+            )
+
+    # Test through suite
+    suite = DataFrameExpectationsSuite().expect_value_equals(column_name="col1", value=value)
+
+    if should_succeed:
+        suite_result = suite.build().run(data_frame=df)
+        assert suite_result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(suite_result, SuiteExecutionResult), (
+            "Result should be SuiteExecutionResult"
+        )
+        assert suite_result.success, "Expected all expectations to pass"
+        assert suite_result.total_passed == 1, "Expected 1 passed expectation"
+        assert suite_result.total_failed == 0, "Expected 0 failed expectations"
+    else:
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            suite.build().run(data_frame=df)
+
+
+def test_column_missing_error_pandas():
+    """Test missing column error for pandas DataFrames."""
+    df = pd.DataFrame({"col1": [5, 5, 5]})
 
     expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
 
@@ -466,7 +547,34 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=df)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure)
+
+    # Test through suite
+    suite = DataFrameExpectationsSuite().expect_value_equals(column_name="nonexistent_col", value=5)
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        suite.build().run(data_frame=df)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test missing column error for PySpark DataFrames."""
+    df = spark.createDataFrame([(5,), (5,), (5,)], ["col1"])
+
+    expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
+
+    # Test through registry
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueEquals",
+        column_name="nonexistent_col",
+        value=5,
+    )
+    result = expectation.validate(data_frame=df)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message=expected_message,
     )
     assert str(result) == str(expected_failure)

--- a/tests/expectations/column/any_value_expectations/test_expect_value_in.py
+++ b/tests/expectations/column/any_value_expectations/test_expect_value_in.py
@@ -8,47 +8,36 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark, data_type="long"):
-    """Helper function to create pandas or pyspark DataFrame.
+def create_pyspark_dataframe(data, column_name, spark, data_type="long"):
+    """Helper function to create a PySpark DataFrame."""
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        LongType,
+        StringType,
+        DoubleType,
+        BooleanType,
+        TimestampType,
+    )
 
-    Args:
-        df_type: "pandas" or "pyspark"
-        data: List of values for the column
-        column_name: Name of the column
-        spark: Spark session (required for pyspark)
-        data_type: Data type for the column - "long", "string", "double", "boolean", "timestamp"
-    """
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        from pyspark.sql.types import (
-            StructType,
-            StructField,
-            LongType,
-            StringType,
-            DoubleType,
-            BooleanType,
-            TimestampType,
-        )
+    type_mapping = {
+        "long": LongType(),
+        "string": StringType(),
+        "double": DoubleType(),
+        "boolean": BooleanType(),
+        "timestamp": TimestampType(),
+    }
 
-        type_mapping = {
-            "long": LongType(),
-            "string": StringType(),
-            "double": DoubleType(),
-            "boolean": BooleanType(),
-            "timestamp": TimestampType(),
-        }
-
-        schema = StructType([StructField(column_name, type_mapping[data_type], True)])
-        return spark.createDataFrame([(val,) for val in data], schema)
+    schema = StructType([StructField(column_name, type_mapping[data_type], True)])
+    return spark.createDataFrame([(val,) for val in data], schema)
 
 
 def test_expectation_name():
@@ -68,19 +57,9 @@ def test_expectation_name():
     [
         # Basic integer scenarios - success
         ("pandas", [1, 2, 3, 2, 1], [1, 2, 3], True, None, None, "long"),
-        ("pyspark", [1, 2, 3, 2, 1], [1, 2, 3], True, None, None, "long"),
         # Integer scenarios - violations
         (
             "pandas",
-            [1, 4, 5, 2, 3],
-            [1, 2, 3],
-            False,
-            [4, 5],
-            "Found 2 row(s) where 'col1' is not in [1, 2, 3].",
-            "long",
-        ),
-        (
-            "pyspark",
             [1, 4, 5, 2, 3],
             [1, 2, 3],
             False,
@@ -99,25 +78,7 @@ def test_expectation_name():
             "string",
         ),
         (
-            "pyspark",
-            ["apple", "banana", "cherry"],
-            ["apple", "banana", "cherry"],
-            True,
-            None,
-            None,
-            "string",
-        ),
-        (
             "pandas",
-            ["apple", "orange", "banana"],
-            ["apple", "banana"],
-            False,
-            ["orange"],
-            "Found 1 row(s) where 'col1' is not in ['apple', 'banana'].",
-            "string",
-        ),
-        (
-            "pyspark",
             ["apple", "orange", "banana"],
             ["apple", "banana"],
             False,
@@ -135,29 +96,10 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is not in ['apple'].",
             "string",
         ),
-        (
-            "pyspark",
-            ["Apple", "apple", "APPLE"],
-            ["apple"],
-            False,
-            ["Apple", "APPLE"],
-            "Found 2 row(s) where 'col1' is not in ['apple'].",
-            "string",
-        ),
         # Float/Double data type scenarios
         ("pandas", [1.5, 2.5, 3.5], [1.5, 2.5, 3.5], True, None, None, "double"),
-        ("pyspark", [1.5, 2.5, 3.5], [1.5, 2.5, 3.5], True, None, None, "double"),
         (
             "pandas",
-            [1.5, 4.5, 2.5],
-            [1.5, 2.5],
-            False,
-            [4.5],
-            "Found 1 row(s) where 'col1' is not in [1.5, 2.5].",
-            "double",
-        ),
-        (
-            "pyspark",
             [1.5, 4.5, 2.5],
             [1.5, 2.5],
             False,
@@ -167,20 +109,9 @@ def test_expectation_name():
         ),
         # Boolean data type scenarios
         ("pandas", [True, False, True], [True, False], True, None, None, "boolean"),
-        ("pyspark", [True, False, True], [True, False], True, None, None, "boolean"),
         ("pandas", [True, True, True], [True], True, None, None, "boolean"),
-        ("pyspark", [True, True, True], [True], True, None, None, "boolean"),
         (
             "pandas",
-            [True, False, True],
-            [True],
-            False,
-            [False],
-            "Found 1 row(s) where 'col1' is not in [True].",
-            "boolean",
-        ),
-        (
-            "pyspark",
             [True, False, True],
             [True],
             False,
@@ -199,25 +130,7 @@ def test_expectation_name():
             "timestamp",
         ),
         (
-            "pyspark",
-            [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 3)],
-            [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 3)],
-            True,
-            None,
-            None,
-            "timestamp",
-        ),
-        (
             "pandas",
-            [datetime(2023, 1, 1), datetime(2023, 1, 4), datetime(2023, 1, 2)],
-            [datetime(2023, 1, 1), datetime(2023, 1, 2)],
-            False,
-            [datetime(2023, 1, 4)],
-            "Found 1 row(s) where 'col1' is not in [datetime.datetime(2023, 1, 1, 0, 0), datetime.datetime(2023, 1, 2, 0, 0)].",
-            "timestamp",
-        ),
-        (
-            "pyspark",
             [datetime(2023, 1, 1), datetime(2023, 1, 4), datetime(2023, 1, 2)],
             [datetime(2023, 1, 1), datetime(2023, 1, 2)],
             False,
@@ -227,15 +140,11 @@ def test_expectation_name():
         ),
         # Empty string scenarios
         ("pandas", ["", "text", ""], ["", "text"], True, None, None, "string"),
-        ("pyspark", ["", "text", ""], ["", "text"], True, None, None, "string"),
         # Zero value scenarios
         ("pandas", [0, 1, 2, 0], [0, 1, 2], True, None, None, "long"),
-        ("pyspark", [0, 1, 2, 0], [0, 1, 2], True, None, None, "long"),
         ("pandas", [0.0, 1.0, 2.0], [0.0, 1.0, 2.0], True, None, None, "double"),
-        ("pyspark", [0.0, 1.0, 2.0], [0.0, 1.0, 2.0], True, None, None, "double"),
         # Negative numbers
         ("pandas", [-1, -2, -3], [-1, -2, -3], True, None, None, "long"),
-        ("pyspark", [-1, -2, -3], [-1, -2, -3], True, None, None, "long"),
         (
             "pandas",
             [-1, 5, -2],
@@ -245,21 +154,10 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not in [-1, -2].",
             "long",
         ),
-        (
-            "pyspark",
-            [-1, 5, -2],
-            [-1, -2],
-            False,
-            [5],
-            "Found 1 row(s) where 'col1' is not in [-1, -2].",
-            "long",
-        ),
         # Large numbers
         ("pandas", [1000000, 2000000], [1000000, 2000000], True, None, None, "long"),
-        ("pyspark", [1000000, 2000000], [1000000, 2000000], True, None, None, "long"),
         # Single value in list
         ("pandas", [5, 5, 5], [5], True, None, None, "long"),
-        ("pyspark", [5, 5, 5], [5], True, None, None, "long"),
         # Multiple values with single violation
         (
             "pandas",
@@ -270,60 +168,31 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not in [1, 2, 3, 4].",
             "long",
         ),
-        (
-            "pyspark",
-            [1, 2, 3, 4, 5],
-            [1, 2, 3, 4],
-            False,
-            [5],
-            "Found 1 row(s) where 'col1' is not in [1, 2, 3, 4].",
-            "long",
-        ),
     ],
     ids=[
         "pandas_int_basic_success",
-        "pyspark_int_basic_success",
         "pandas_int_violations",
-        "pyspark_int_violations",
         "pandas_string_success",
-        "pyspark_string_success",
         "pandas_string_violations",
-        "pyspark_string_violations",
         "pandas_string_case_sensitive",
-        "pyspark_string_case_sensitive",
         "pandas_double_success",
-        "pyspark_double_success",
         "pandas_double_violations",
-        "pyspark_double_violations",
         "pandas_boolean_both_values",
-        "pyspark_boolean_both_values",
         "pandas_boolean_single_value",
-        "pyspark_boolean_single_value",
         "pandas_boolean_violation",
-        "pyspark_boolean_violation",
         "pandas_timestamp_success",
-        "pyspark_timestamp_success",
         "pandas_timestamp_violation",
-        "pyspark_timestamp_violation",
         "pandas_empty_string",
-        "pyspark_empty_string",
         "pandas_zero_int",
-        "pyspark_zero_int",
         "pandas_zero_double",
-        "pyspark_zero_double",
         "pandas_negative_int_success",
-        "pyspark_negative_int_success",
         "pandas_negative_int_violation",
-        "pyspark_negative_int_violation",
         "pandas_large_numbers",
-        "pyspark_large_numbers",
         "pandas_single_value_list",
-        "pyspark_single_value_list",
         "pandas_multiple_values_single_violation",
-        "pyspark_multiple_values_single_violation",
     ],
 )
-def test_expectation_basic_scenarios(
+def test_expectation_basic_scenarios_pandas(
     df_type,
     data,
     values,
@@ -331,9 +200,8 @@ def test_expectation_basic_scenarios(
     expected_violations,
     expected_message,
     data_type,
-    spark,
 ):
-    """Test basic expectation scenarios for both pandas and PySpark DataFrames.
+    """Test basic expectation scenarios for pandas DataFrames.
 
     Tests various data types including:
     - Integers (long): positive, negative, zero, large numbers, single/multiple values
@@ -343,7 +211,7 @@ def test_expectation_basic_scenarios(
     - Timestamps: datetime objects
     - Edge cases: single value lists
     """
-    df = create_dataframe(df_type, data, "col1", spark, data_type)
+    df = pd.DataFrame({"col1": data})
 
     # Test through registry
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -367,8 +235,222 @@ def test_expectation_basic_scenarios(
 
         # Verify violations if present
         if expected_violations is not None:
-            expected_violations_df = create_dataframe(
-                df_type, expected_violations, "col1", spark, data_type
+            expected_violations_df = pd.DataFrame({"col1": expected_violations})
+            expected_failure = DataFrameExpectationFailureMessage(
+                expectation_str=str(expectation),
+                data_frame_type=str(df_type),
+                violations_data_frame=expected_violations_df,
+                message=expected_message,
+                limit_violations=5,
+            )
+            assert str(result) == str(expected_failure), (
+                f"Expected failure details don't match. Got: {result}"
+            )
+
+    # Test through suite
+    suite = DataFrameExpectationsSuite().expect_value_in(column_name="col1", values=values)
+
+    if should_succeed:
+        suite_result = suite.build().run(data_frame=df)
+        assert suite_result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(suite_result, SuiteExecutionResult), (
+            "Result should be SuiteExecutionResult"
+        )
+        assert suite_result.success, "Expected all expectations to pass"
+        assert suite_result.total_passed == 1, "Expected 1 passed expectation"
+        assert suite_result.total_failed == 0, "Expected 0 failed expectations"
+    else:
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            suite.build().run(data_frame=df)
+
+
+@pytest.mark.pyspark
+@pytest.mark.parametrize(
+    "df_type, data, values, should_succeed, expected_violations, expected_message, data_type",
+    [
+        # Basic integer scenarios - success
+        ("pyspark", [1, 2, 3, 2, 1], [1, 2, 3], True, None, None, "long"),
+        # Integer scenarios - violations
+        (
+            "pyspark",
+            [1, 4, 5, 2, 3],
+            [1, 2, 3],
+            False,
+            [4, 5],
+            "Found 2 row(s) where 'col1' is not in [1, 2, 3].",
+            "long",
+        ),
+        # String data type scenarios
+        (
+            "pyspark",
+            ["apple", "banana", "cherry"],
+            ["apple", "banana", "cherry"],
+            True,
+            None,
+            None,
+            "string",
+        ),
+        (
+            "pyspark",
+            ["apple", "orange", "banana"],
+            ["apple", "banana"],
+            False,
+            ["orange"],
+            "Found 1 row(s) where 'col1' is not in ['apple', 'banana'].",
+            "string",
+        ),
+        # String case sensitivity
+        (
+            "pyspark",
+            ["Apple", "apple", "APPLE"],
+            ["apple"],
+            False,
+            ["Apple", "APPLE"],
+            "Found 2 row(s) where 'col1' is not in ['apple'].",
+            "string",
+        ),
+        # Float/Double data type scenarios
+        ("pyspark", [1.5, 2.5, 3.5], [1.5, 2.5, 3.5], True, None, None, "double"),
+        (
+            "pyspark",
+            [1.5, 4.5, 2.5],
+            [1.5, 2.5],
+            False,
+            [4.5],
+            "Found 1 row(s) where 'col1' is not in [1.5, 2.5].",
+            "double",
+        ),
+        # Boolean data type scenarios
+        ("pyspark", [True, False, True], [True, False], True, None, None, "boolean"),
+        ("pyspark", [True, True, True], [True], True, None, None, "boolean"),
+        (
+            "pyspark",
+            [True, False, True],
+            [True],
+            False,
+            [False],
+            "Found 1 row(s) where 'col1' is not in [True].",
+            "boolean",
+        ),
+        # Timestamp/Datetime scenarios
+        (
+            "pyspark",
+            [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 3)],
+            [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 3)],
+            True,
+            None,
+            None,
+            "timestamp",
+        ),
+        (
+            "pyspark",
+            [datetime(2023, 1, 1), datetime(2023, 1, 4), datetime(2023, 1, 2)],
+            [datetime(2023, 1, 1), datetime(2023, 1, 2)],
+            False,
+            [datetime(2023, 1, 4)],
+            "Found 1 row(s) where 'col1' is not in [datetime.datetime(2023, 1, 1, 0, 0), datetime.datetime(2023, 1, 2, 0, 0)].",
+            "timestamp",
+        ),
+        # Empty string scenarios
+        ("pyspark", ["", "text", ""], ["", "text"], True, None, None, "string"),
+        # Zero value scenarios
+        ("pyspark", [0, 1, 2, 0], [0, 1, 2], True, None, None, "long"),
+        ("pyspark", [0.0, 1.0, 2.0], [0.0, 1.0, 2.0], True, None, None, "double"),
+        # Negative numbers
+        ("pyspark", [-1, -2, -3], [-1, -2, -3], True, None, None, "long"),
+        (
+            "pyspark",
+            [-1, 5, -2],
+            [-1, -2],
+            False,
+            [5],
+            "Found 1 row(s) where 'col1' is not in [-1, -2].",
+            "long",
+        ),
+        # Large numbers
+        ("pyspark", [1000000, 2000000], [1000000, 2000000], True, None, None, "long"),
+        # Single value in list
+        ("pyspark", [5, 5, 5], [5], True, None, None, "long"),
+        # Multiple values with single violation
+        (
+            "pyspark",
+            [1, 2, 3, 4, 5],
+            [1, 2, 3, 4],
+            False,
+            [5],
+            "Found 1 row(s) where 'col1' is not in [1, 2, 3, 4].",
+            "long",
+        ),
+    ],
+    ids=[
+        "pyspark_int_basic_success",
+        "pyspark_int_violations",
+        "pyspark_string_success",
+        "pyspark_string_violations",
+        "pyspark_string_case_sensitive",
+        "pyspark_double_success",
+        "pyspark_double_violations",
+        "pyspark_boolean_both_values",
+        "pyspark_boolean_single_value",
+        "pyspark_boolean_violation",
+        "pyspark_timestamp_success",
+        "pyspark_timestamp_violation",
+        "pyspark_empty_string",
+        "pyspark_zero_int",
+        "pyspark_zero_double",
+        "pyspark_negative_int_success",
+        "pyspark_negative_int_violation",
+        "pyspark_large_numbers",
+        "pyspark_single_value_list",
+        "pyspark_multiple_values_single_violation",
+    ],
+)
+def test_expectation_basic_scenarios_pyspark(
+    df_type,
+    data,
+    values,
+    should_succeed,
+    expected_violations,
+    expected_message,
+    data_type,
+    spark,
+):
+    """Test basic expectation scenarios for PySpark DataFrames.
+
+    Tests various data types including:
+    - Integers (long): positive, negative, zero, large numbers, single/multiple values
+    - Strings: case sensitivity, empty strings
+    - Floats (double): precision, zero values
+    - Booleans: True/False combinations
+    - Timestamps: datetime objects
+    - Edge cases: single value lists
+    """
+    df = create_pyspark_dataframe(data, "col1", spark, data_type)
+
+    # Test through registry
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueIn",
+        column_name="col1",
+        values=values,
+    )
+    result = expectation.validate(data_frame=df)
+
+    if should_succeed:
+        assert isinstance(result, DataFrameExpectationSuccessMessage), (
+            f"Expected success but got: {result}"
+        )
+    else:
+        assert isinstance(result, DataFrameExpectationFailureMessage), (
+            f"Expected failure but got: {result}"
+        )
+        assert expected_message in str(result), (
+            f"Expected message '{expected_message}' in result: {result}"
+        )
+
+        # Verify violations if present
+        if expected_violations is not None:
+            expected_violations_df = create_pyspark_dataframe(
+                expected_violations, "col1", spark, data_type
             )
             expected_failure = DataFrameExpectationFailureMessage(
                 expectation_str=str(expectation),
@@ -398,18 +480,9 @@ def test_expectation_basic_scenarios(
             suite.build().run(data_frame=df)
 
 
-@pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
-)
-def test_column_missing_error(df_type, spark):
-    """Test missing column error for both pandas and PySpark DataFrames."""
-    if df_type == "pandas":
-        df = pd.DataFrame({"col1": [1, 2, 3]})
-    else:
-        df = spark.createDataFrame([(1,), (2,), (3,)], ["col1"])
-
+def test_column_missing_error_pandas():
+    """Test missing column error for pandas DataFrames."""
+    df = pd.DataFrame({"col1": [1, 2, 3]})
     expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
 
     # Test through registry
@@ -421,7 +494,35 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=df)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure)
+
+    # Test through suite
+    suite = DataFrameExpectationsSuite().expect_value_in(
+        column_name="nonexistent_col", values=[1, 2, 3]
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        suite.build().run(data_frame=df)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test missing column error for PySpark DataFrames."""
+    df = spark.createDataFrame([(1,), (2,), (3,)], ["col1"])
+    expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
+
+    # Test through registry
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueIn",
+        column_name="nonexistent_col",
+        values=[1, 2, 3],
+    )
+    result = expectation.validate(data_frame=df)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message=expected_message,
     )
     assert str(result) == str(expected_failure)

--- a/tests/expectations/column/any_value_expectations/test_expect_value_not_equals.py
+++ b/tests/expectations/column/any_value_expectations/test_expect_value_not_equals.py
@@ -8,47 +8,36 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark, data_type="long"):
-    """Helper function to create pandas or pyspark DataFrame.
+def create_pyspark_dataframe(data, column_name, spark, data_type="long"):
+    """Helper function to create a PySpark DataFrame."""
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        LongType,
+        StringType,
+        DoubleType,
+        BooleanType,
+        TimestampType,
+    )
 
-    Args:
-        df_type: "pandas" or "pyspark"
-        data: List of values for the column
-        column_name: Name of the column
-        spark: Spark session (required for pyspark)
-        data_type: Data type for the column - "long", "string", "double", "boolean", "timestamp"
-    """
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        from pyspark.sql.types import (
-            StructType,
-            StructField,
-            LongType,
-            StringType,
-            DoubleType,
-            BooleanType,
-            TimestampType,
-        )
+    type_mapping = {
+        "long": LongType(),
+        "string": StringType(),
+        "double": DoubleType(),
+        "boolean": BooleanType(),
+        "timestamp": TimestampType(),
+    }
 
-        type_mapping = {
-            "long": LongType(),
-            "string": StringType(),
-            "double": DoubleType(),
-            "boolean": BooleanType(),
-            "timestamp": TimestampType(),
-        }
-
-        schema = StructType([StructField(column_name, type_mapping[data_type], True)])
-        return spark.createDataFrame([(val,) for val in data], schema)
+    schema = StructType([StructField(column_name, type_mapping[data_type], True)])
+    return spark.createDataFrame([(val,) for val in data], schema)
 
 
 def test_expectation_name():
@@ -68,9 +57,7 @@ def test_expectation_name():
     [
         # Basic integer scenarios - success (values NOT equal to 5)
         ("pandas", [3, 4, 6], 5, True, None, None, "long"),
-        ("pyspark", [3, 4, 6], 5, True, None, None, "long"),
         ("pandas", [1, 2, 3], 5, True, None, None, "long"),
-        ("pyspark", [1, 2, 3], 5, True, None, None, "long"),
         # Integer scenarios - violations (values equal to 5)
         (
             "pandas",
@@ -82,25 +69,7 @@ def test_expectation_name():
             "long",
         ),
         (
-            "pyspark",
-            [3, 5, 5],
-            5,
-            False,
-            [5, 5],
-            "Found 2 row(s) where 'col1' is equal to 5.",
-            "long",
-        ),
-        (
             "pandas",
-            [5, 5, 5],
-            5,
-            False,
-            [5, 5, 5],
-            "Found 3 row(s) where 'col1' is equal to 5.",
-            "long",
-        ),
-        (
-            "pyspark",
             [5, 5, 5],
             5,
             False,
@@ -110,7 +79,6 @@ def test_expectation_name():
         ),
         # String data type scenarios - success
         ("pandas", ["banana", "cherry", "orange"], "apple", True, None, None, "string"),
-        ("pyspark", ["banana", "cherry", "orange"], "apple", True, None, None, "string"),
         # String scenarios - violations
         (
             "pandas",
@@ -121,18 +89,8 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is equal to apple.",
             "string",
         ),
-        (
-            "pyspark",
-            ["apple", "banana", "apple"],
-            "apple",
-            False,
-            ["apple", "apple"],
-            "Found 2 row(s) where 'col1' is equal to apple.",
-            "string",
-        ),
         # String case sensitivity - success (case matters)
         ("pandas", ["Apple", "APPLE", "aPpLe"], "apple", True, None, None, "string"),
-        ("pyspark", ["Apple", "APPLE", "aPpLe"], "apple", True, None, None, "string"),
         # String case sensitivity - violations (exact match)
         (
             "pandas",
@@ -143,18 +101,8 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is equal to apple.",
             "string",
         ),
-        (
-            "pyspark",
-            ["apple", "Apple", "apple"],
-            "apple",
-            False,
-            ["apple", "apple"],
-            "Found 2 row(s) where 'col1' is equal to apple.",
-            "string",
-        ),
         # Float/Double data type scenarios - success
         ("pandas", [1.5, 2.5, 4.5], 3.14, True, None, None, "double"),
-        ("pyspark", [1.5, 2.5, 4.5], 3.14, True, None, None, "double"),
         # Float scenarios - violations
         (
             "pandas",
@@ -165,18 +113,8 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is equal to 3.14.",
             "double",
         ),
-        (
-            "pyspark",
-            [3.14, 2.71, 3.14],
-            3.14,
-            False,
-            [3.14, 3.14],
-            "Found 2 row(s) where 'col1' is equal to 3.14.",
-            "double",
-        ),
         # Float precision edge cases - success
         ("pandas", [1.1, 1.2, 1.3], 1.0, True, None, None, "double"),
-        ("pyspark", [1.1, 1.2, 1.3], 1.0, True, None, None, "double"),
         # Float precision - violations
         (
             "pandas",
@@ -187,20 +125,9 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is equal to 1.0.",
             "double",
         ),
-        (
-            "pyspark",
-            [1.0, 1.1, 1.0],
-            1.0,
-            False,
-            [1.0, 1.0],
-            "Found 2 row(s) where 'col1' is equal to 1.0.",
-            "double",
-        ),
         # Boolean data type scenarios - success
         ("pandas", [False, False, False], True, True, None, None, "boolean"),
-        ("pyspark", [False, False, False], True, True, None, None, "boolean"),
         ("pandas", [True, True, True], False, True, None, None, "boolean"),
-        ("pyspark", [True, True, True], False, True, None, None, "boolean"),
         # Boolean scenarios - violations
         (
             "pandas",
@@ -212,25 +139,7 @@ def test_expectation_name():
             "boolean",
         ),
         (
-            "pyspark",
-            [True, False, True],
-            True,
-            False,
-            [True, True],
-            "Found 2 row(s) where 'col1' is equal to True.",
-            "boolean",
-        ),
-        (
             "pandas",
-            [False, True, False],
-            False,
-            False,
-            [False, False],
-            "Found 2 row(s) where 'col1' is equal to False.",
-            "boolean",
-        ),
-        (
-            "pyspark",
             [False, True, False],
             False,
             False,
@@ -248,27 +157,9 @@ def test_expectation_name():
             None,
             "timestamp",
         ),
-        (
-            "pyspark",
-            [datetime(2023, 1, 2), datetime(2023, 1, 3), datetime(2023, 1, 4)],
-            datetime(2023, 1, 1),
-            True,
-            None,
-            None,
-            "timestamp",
-        ),
         # Timestamp scenarios - violations
         (
             "pandas",
-            [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 1)],
-            datetime(2023, 1, 1),
-            False,
-            [datetime(2023, 1, 1), datetime(2023, 1, 1)],
-            "Found 2 row(s) where 'col1' is equal to 2023-01-01 00:00:00.",
-            "timestamp",
-        ),
-        (
-            "pyspark",
             [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 1)],
             datetime(2023, 1, 1),
             False,
@@ -289,21 +180,8 @@ def test_expectation_name():
             None,
             "timestamp",
         ),
-        (
-            "pyspark",
-            [
-                datetime(2023, 1, 2, 12, 0, 0, tzinfo=timezone.utc),
-                datetime(2023, 1, 3, 12, 0, 0, tzinfo=timezone.utc),
-            ],
-            datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
-            True,
-            None,
-            None,
-            "timestamp",
-        ),
         # Empty string scenarios - success
         ("pandas", ["text", "data", "value"], "", True, None, None, "string"),
-        ("pyspark", ["text", "data", "value"], "", True, None, None, "string"),
         # Empty string - violations
         (
             "pandas",
@@ -314,23 +192,11 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is equal to .",
             "string",
         ),
-        (
-            "pyspark",
-            ["", "text", ""],
-            "",
-            False,
-            ["", ""],
-            "Found 2 row(s) where 'col1' is equal to .",
-            "string",
-        ),
         # Whitespace in strings - success
         ("pandas", [" test", "test ", " test "], "test", True, None, None, "string"),
-        ("pyspark", [" test", "test ", " test "], "test", True, None, None, "string"),
         # Zero value scenarios - success
         ("pandas", [1, 2, 3], 0, True, None, None, "long"),
-        ("pyspark", [1, 2, 3], 0, True, None, None, "long"),
         ("pandas", [1.5, 2.5, 3.5], 0.0, True, None, None, "double"),
-        ("pyspark", [1.5, 2.5, 3.5], 0.0, True, None, None, "double"),
         # Zero value - violations
         (
             "pandas",
@@ -341,20 +207,9 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is equal to 0.",
             "long",
         ),
-        (
-            "pyspark",
-            [0, 1, 0],
-            0,
-            False,
-            [0, 0],
-            "Found 2 row(s) where 'col1' is equal to 0.",
-            "long",
-        ),
         # Negative numbers - success
         ("pandas", [1, 2, 3], -5, True, None, None, "long"),
-        ("pyspark", [1, 2, 3], -5, True, None, None, "long"),
         ("pandas", [1.5, 2.5, 3.5], -3.14, True, None, None, "double"),
-        ("pyspark", [1.5, 2.5, 3.5], -3.14, True, None, None, "double"),
         # Negative numbers - violations
         (
             "pandas",
@@ -365,18 +220,8 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is equal to -5.",
             "long",
         ),
-        (
-            "pyspark",
-            [-5, 1, -5],
-            -5,
-            False,
-            [-5, -5],
-            "Found 2 row(s) where 'col1' is equal to -5.",
-            "long",
-        ),
         # Large numbers - success
         ("pandas", [999999, 1000001], 1000000, True, None, None, "long"),
-        ("pyspark", [999999, 1000001], 1000000, True, None, None, "long"),
         # Large numbers - violations
         (
             "pandas",
@@ -387,80 +232,41 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is equal to 1000000.",
             "long",
         ),
-        (
-            "pyspark",
-            [1000000, 999999, 1000000],
-            1000000,
-            False,
-            [1000000, 1000000],
-            "Found 2 row(s) where 'col1' is equal to 1000000.",
-            "long",
-        ),
     ],
     ids=[
         "pandas_int_basic_success",
-        "pyspark_int_basic_success",
         "pandas_int_success_different_values",
-        "pyspark_int_success_different_values",
         "pandas_int_violations_two",
-        "pyspark_int_violations_two",
         "pandas_int_violations_all",
-        "pyspark_int_violations_all",
         "pandas_string_success",
-        "pyspark_string_success",
         "pandas_string_violations",
-        "pyspark_string_violations",
         "pandas_string_case_sensitive_success",
-        "pyspark_string_case_sensitive_success",
         "pandas_string_case_sensitive_violations",
-        "pyspark_string_case_sensitive_violations",
         "pandas_double_success",
-        "pyspark_double_success",
         "pandas_double_violations",
-        "pyspark_double_violations",
         "pandas_double_precision_success",
-        "pyspark_double_precision_success",
         "pandas_double_precision_violations",
-        "pyspark_double_precision_violations",
         "pandas_boolean_false_success",
-        "pyspark_boolean_false_success",
         "pandas_boolean_true_success",
-        "pyspark_boolean_true_success",
         "pandas_boolean_true_violations",
-        "pyspark_boolean_true_violations",
         "pandas_boolean_false_violations",
-        "pyspark_boolean_false_violations",
         "pandas_timestamp_success",
-        "pyspark_timestamp_success",
         "pandas_timestamp_violations",
-        "pyspark_timestamp_violations",
         "pandas_timestamp_with_timezone_success",
-        "pyspark_timestamp_with_timezone_success",
         "pandas_empty_string_success",
-        "pyspark_empty_string_success",
         "pandas_empty_string_violations",
-        "pyspark_empty_string_violations",
         "pandas_string_whitespace_success",
-        "pyspark_string_whitespace_success",
         "pandas_zero_int_success",
-        "pyspark_zero_int_success",
         "pandas_zero_double_success",
-        "pyspark_zero_double_success",
         "pandas_zero_int_violations",
-        "pyspark_zero_int_violations",
         "pandas_negative_int_success",
-        "pyspark_negative_int_success",
         "pandas_negative_double_success",
-        "pyspark_negative_double_success",
         "pandas_negative_int_violations",
-        "pyspark_negative_int_violations",
         "pandas_large_numbers_success",
-        "pyspark_large_numbers_success",
         "pandas_large_numbers_violations",
-        "pyspark_large_numbers_violations",
     ],
 )
-def test_expectation_basic_scenarios(
+def test_expectation_basic_scenarios_pandas(
     df_type,
     data,
     value,
@@ -468,21 +274,9 @@ def test_expectation_basic_scenarios(
     expected_violations,
     expected_message,
     data_type,
-    spark,
 ):
-    """Test basic expectation scenarios for both pandas and PySpark DataFrames.
-
-    Tests various data types including:
-    - Integers (long): positive, negative, zero, large numbers
-    - Strings: case sensitivity, empty strings, whitespace
-    - Floats (double): precision, zero, negative
-    - Booleans: True/False
-    - Timestamps: with and without timezone
-
-    Note: ExpectationValueNotEquals checks that values are NOT equal to the target.
-    Success = all values differ from target, Violations = values that equal target.
-    """
-    df = create_dataframe(df_type, data, "col1", spark, data_type)
+    """Test basic expectation scenarios for pandas DataFrames."""
+    df = pd.DataFrame({"col1": data})
 
     # Test through registry
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -506,8 +300,287 @@ def test_expectation_basic_scenarios(
 
         # Verify violations if present
         if expected_violations is not None:
-            expected_violations_df = create_dataframe(
-                df_type, expected_violations, "col1", spark, data_type
+            expected_violations_df = pd.DataFrame({"col1": expected_violations})
+            expected_failure = DataFrameExpectationFailureMessage(
+                expectation_str=str(expectation),
+                data_frame_type=str(df_type),
+                violations_data_frame=expected_violations_df,
+                message=expected_message,
+                limit_violations=5,
+            )
+            assert str(result) == str(expected_failure), (
+                f"Expected failure details don't match. Got: {result}"
+            )
+
+    # Test through suite
+    suite = DataFrameExpectationsSuite().expect_value_not_equals(column_name="col1", value=value)
+
+    if should_succeed:
+        suite_result = suite.build().run(data_frame=df)
+        assert suite_result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(suite_result, SuiteExecutionResult), (
+            "Result should be SuiteExecutionResult"
+        )
+        assert suite_result.success, "Expected all expectations to pass"
+        assert suite_result.total_passed == 1, "Expected 1 passed expectation"
+        assert suite_result.total_failed == 0, "Expected 0 failed expectations"
+    else:
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            suite.build().run(data_frame=df)
+
+
+@pytest.mark.pyspark
+@pytest.mark.parametrize(
+    "df_type, data, value, should_succeed, expected_violations, expected_message, data_type",
+    [
+        # Basic integer scenarios - success (values NOT equal to 5)
+        ("pyspark", [3, 4, 6], 5, True, None, None, "long"),
+        ("pyspark", [1, 2, 3], 5, True, None, None, "long"),
+        # Integer scenarios - violations (values equal to 5)
+        (
+            "pyspark",
+            [3, 5, 5],
+            5,
+            False,
+            [5, 5],
+            "Found 2 row(s) where 'col1' is equal to 5.",
+            "long",
+        ),
+        (
+            "pyspark",
+            [5, 5, 5],
+            5,
+            False,
+            [5, 5, 5],
+            "Found 3 row(s) where 'col1' is equal to 5.",
+            "long",
+        ),
+        # String data type scenarios - success
+        ("pyspark", ["banana", "cherry", "orange"], "apple", True, None, None, "string"),
+        # String scenarios - violations
+        (
+            "pyspark",
+            ["apple", "banana", "apple"],
+            "apple",
+            False,
+            ["apple", "apple"],
+            "Found 2 row(s) where 'col1' is equal to apple.",
+            "string",
+        ),
+        # String case sensitivity - success (case matters)
+        ("pyspark", ["Apple", "APPLE", "aPpLe"], "apple", True, None, None, "string"),
+        # String case sensitivity - violations (exact match)
+        (
+            "pyspark",
+            ["apple", "Apple", "apple"],
+            "apple",
+            False,
+            ["apple", "apple"],
+            "Found 2 row(s) where 'col1' is equal to apple.",
+            "string",
+        ),
+        # Float/Double data type scenarios - success
+        ("pyspark", [1.5, 2.5, 4.5], 3.14, True, None, None, "double"),
+        # Float scenarios - violations
+        (
+            "pyspark",
+            [3.14, 2.71, 3.14],
+            3.14,
+            False,
+            [3.14, 3.14],
+            "Found 2 row(s) where 'col1' is equal to 3.14.",
+            "double",
+        ),
+        # Float precision edge cases - success
+        ("pyspark", [1.1, 1.2, 1.3], 1.0, True, None, None, "double"),
+        # Float precision - violations
+        (
+            "pyspark",
+            [1.0, 1.1, 1.0],
+            1.0,
+            False,
+            [1.0, 1.0],
+            "Found 2 row(s) where 'col1' is equal to 1.0.",
+            "double",
+        ),
+        # Boolean data type scenarios - success
+        ("pyspark", [False, False, False], True, True, None, None, "boolean"),
+        ("pyspark", [True, True, True], False, True, None, None, "boolean"),
+        # Boolean scenarios - violations
+        (
+            "pyspark",
+            [True, False, True],
+            True,
+            False,
+            [True, True],
+            "Found 2 row(s) where 'col1' is equal to True.",
+            "boolean",
+        ),
+        (
+            "pyspark",
+            [False, True, False],
+            False,
+            False,
+            [False, False],
+            "Found 2 row(s) where 'col1' is equal to False.",
+            "boolean",
+        ),
+        # Timestamp/Datetime scenarios - success
+        (
+            "pyspark",
+            [datetime(2023, 1, 2), datetime(2023, 1, 3), datetime(2023, 1, 4)],
+            datetime(2023, 1, 1),
+            True,
+            None,
+            None,
+            "timestamp",
+        ),
+        # Timestamp scenarios - violations
+        (
+            "pyspark",
+            [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 1)],
+            datetime(2023, 1, 1),
+            False,
+            [datetime(2023, 1, 1), datetime(2023, 1, 1)],
+            "Found 2 row(s) where 'col1' is equal to 2023-01-01 00:00:00.",
+            "timestamp",
+        ),
+        # Datetime with timezone - success
+        (
+            "pyspark",
+            [
+                datetime(2023, 1, 2, 12, 0, 0, tzinfo=timezone.utc),
+                datetime(2023, 1, 3, 12, 0, 0, tzinfo=timezone.utc),
+            ],
+            datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            True,
+            None,
+            None,
+            "timestamp",
+        ),
+        # Empty string scenarios - success
+        ("pyspark", ["text", "data", "value"], "", True, None, None, "string"),
+        # Empty string - violations
+        (
+            "pyspark",
+            ["", "text", ""],
+            "",
+            False,
+            ["", ""],
+            "Found 2 row(s) where 'col1' is equal to .",
+            "string",
+        ),
+        # Whitespace in strings - success
+        ("pyspark", [" test", "test ", " test "], "test", True, None, None, "string"),
+        # Zero value scenarios - success
+        ("pyspark", [1, 2, 3], 0, True, None, None, "long"),
+        ("pyspark", [1.5, 2.5, 3.5], 0.0, True, None, None, "double"),
+        # Zero value - violations
+        (
+            "pyspark",
+            [0, 1, 0],
+            0,
+            False,
+            [0, 0],
+            "Found 2 row(s) where 'col1' is equal to 0.",
+            "long",
+        ),
+        # Negative numbers - success
+        ("pyspark", [1, 2, 3], -5, True, None, None, "long"),
+        ("pyspark", [1.5, 2.5, 3.5], -3.14, True, None, None, "double"),
+        # Negative numbers - violations
+        (
+            "pyspark",
+            [-5, 1, -5],
+            -5,
+            False,
+            [-5, -5],
+            "Found 2 row(s) where 'col1' is equal to -5.",
+            "long",
+        ),
+        # Large numbers - success
+        ("pyspark", [999999, 1000001], 1000000, True, None, None, "long"),
+        # Large numbers - violations
+        (
+            "pyspark",
+            [1000000, 999999, 1000000],
+            1000000,
+            False,
+            [1000000, 1000000],
+            "Found 2 row(s) where 'col1' is equal to 1000000.",
+            "long",
+        ),
+    ],
+    ids=[
+        "pyspark_int_basic_success",
+        "pyspark_int_success_different_values",
+        "pyspark_int_violations_two",
+        "pyspark_int_violations_all",
+        "pyspark_string_success",
+        "pyspark_string_violations",
+        "pyspark_string_case_sensitive_success",
+        "pyspark_string_case_sensitive_violations",
+        "pyspark_double_success",
+        "pyspark_double_violations",
+        "pyspark_double_precision_success",
+        "pyspark_double_precision_violations",
+        "pyspark_boolean_false_success",
+        "pyspark_boolean_true_success",
+        "pyspark_boolean_true_violations",
+        "pyspark_boolean_false_violations",
+        "pyspark_timestamp_success",
+        "pyspark_timestamp_violations",
+        "pyspark_timestamp_with_timezone_success",
+        "pyspark_empty_string_success",
+        "pyspark_empty_string_violations",
+        "pyspark_string_whitespace_success",
+        "pyspark_zero_int_success",
+        "pyspark_zero_double_success",
+        "pyspark_zero_int_violations",
+        "pyspark_negative_int_success",
+        "pyspark_negative_double_success",
+        "pyspark_negative_int_violations",
+        "pyspark_large_numbers_success",
+        "pyspark_large_numbers_violations",
+    ],
+)
+def test_expectation_basic_scenarios_pyspark(
+    df_type,
+    data,
+    value,
+    should_succeed,
+    expected_violations,
+    expected_message,
+    data_type,
+    spark,
+):
+    """Test basic expectation scenarios for PySpark DataFrames."""
+    df = create_pyspark_dataframe(data, "col1", spark, data_type)
+
+    # Test through registry
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueNotEquals",
+        column_name="col1",
+        value=value,
+    )
+    result = expectation.validate(data_frame=df)
+
+    if should_succeed:
+        assert isinstance(result, DataFrameExpectationSuccessMessage), (
+            f"Expected success but got: {result}"
+        )
+    else:
+        assert isinstance(result, DataFrameExpectationFailureMessage), (
+            f"Expected failure but got: {result}"
+        )
+        assert expected_message in str(result), (
+            f"Expected message '{expected_message}' in result: {result}"
+        )
+
+        # Verify violations if present
+        if expected_violations is not None:
+            expected_violations_df = create_pyspark_dataframe(
+                expected_violations, "col1", spark, data_type
             )
             expected_failure = DataFrameExpectationFailureMessage(
                 expectation_str=str(expectation),
@@ -537,18 +610,9 @@ def test_expectation_basic_scenarios(
             suite.build().run(data_frame=df)
 
 
-@pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
-)
-def test_column_missing_error(df_type, spark):
-    """Test missing column error for both pandas and PySpark DataFrames."""
-    if df_type == "pandas":
-        df = pd.DataFrame({"col1": [3, 4, 5]})
-    else:
-        df = spark.createDataFrame([(3,), (4,), (5,)], ["col1"])
-
+def test_column_missing_error_pandas():
+    """Test missing column error for pandas DataFrames."""
+    df = pd.DataFrame({"col1": [3, 4, 5]})
     expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
 
     # Test through registry
@@ -560,7 +624,35 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=df)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure)
+
+    # Test through suite
+    suite = DataFrameExpectationsSuite().expect_value_not_equals(
+        column_name="nonexistent_col", value=5
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        suite.build().run(data_frame=df)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test missing column error for PySpark DataFrames."""
+    df = spark.createDataFrame([(3,), (4,), (5,)], ["col1"])
+    expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
+
+    # Test through registry
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueNotEquals",
+        column_name="nonexistent_col",
+        value=5,
+    )
+    result = expectation.validate(data_frame=df)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message=expected_message,
     )
     assert str(result) == str(expected_failure)

--- a/tests/expectations/column/any_value_expectations/test_expect_value_not_in.py
+++ b/tests/expectations/column/any_value_expectations/test_expect_value_not_in.py
@@ -718,7 +718,7 @@ def test_column_missing_error_pandas():
 @pytest.mark.pyspark
 def test_column_missing_error_pyspark(spark):
     """Test missing column error for both pandas and PySpark DataFrames."""
-    df = create_pyspark_dataframe([(4,), (5,), (6,)], "col1", spark)
+    df = create_pyspark_dataframe([4, 5, 6], "col1", spark)
 
     expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
 

--- a/tests/expectations/column/any_value_expectations/test_expect_value_not_in.py
+++ b/tests/expectations/column/any_value_expectations/test_expect_value_not_in.py
@@ -8,47 +8,44 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark, data_type="long"):
-    """Helper function to create pandas or pyspark DataFrame.
+def create_pyspark_dataframe(data, column_name, spark, data_type="long"):
+    """Helper function to create a PySpark DataFrame.
 
     Args:
-        df_type: "pandas" or "pyspark"
         data: List of values for the column
         column_name: Name of the column
         spark: Spark session (required for pyspark)
         data_type: Data type for the column - "long", "string", "double", "boolean", "timestamp"
     """
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        from pyspark.sql.types import (
-            StructType,
-            StructField,
-            LongType,
-            StringType,
-            DoubleType,
-            BooleanType,
-            TimestampType,
-        )
 
-        type_mapping = {
-            "long": LongType(),
-            "string": StringType(),
-            "double": DoubleType(),
-            "boolean": BooleanType(),
-            "timestamp": TimestampType(),
-        }
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        LongType,
+        StringType,
+        DoubleType,
+        BooleanType,
+        TimestampType,
+    )
 
-        schema = StructType([StructField(column_name, type_mapping[data_type], True)])
-        return spark.createDataFrame([(val,) for val in data], schema)
+    type_mapping = {
+        "long": LongType(),
+        "string": StringType(),
+        "double": DoubleType(),
+        "boolean": BooleanType(),
+        "timestamp": TimestampType(),
+    }
+
+    schema = StructType([StructField(column_name, type_mapping[data_type], True)])
+    return spark.createDataFrame([(val,) for val in data], schema)
 
 
 def test_expectation_name():
@@ -68,9 +65,7 @@ def test_expectation_name():
     [
         # Basic integer scenarios - success (values NOT in [1,2,3])
         ("pandas", [4, 5, 6, 7], [1, 2, 3], True, None, None, "long"),
-        ("pyspark", [4, 5, 6, 7], [1, 2, 3], True, None, None, "long"),
         ("pandas", [10, 20, 30], [1, 2, 3], True, None, None, "long"),
-        ("pyspark", [10, 20, 30], [1, 2, 3], True, None, None, "long"),
         # Integer scenarios - violations (values in [1,2,3])
         (
             "pandas",
@@ -82,25 +77,7 @@ def test_expectation_name():
             "long",
         ),
         (
-            "pyspark",
-            [1, 2, 4, 5],
-            [1, 2, 3],
-            False,
-            [1, 2],
-            "Found 2 row(s) where 'col1' is in [1, 2, 3].",
-            "long",
-        ),
-        (
             "pandas",
-            [1, 2, 3],
-            [1, 2, 3],
-            False,
-            [1, 2, 3],
-            "Found 3 row(s) where 'col1' is in [1, 2, 3].",
-            "long",
-        ),
-        (
-            "pyspark",
             [1, 2, 3],
             [1, 2, 3],
             False,
@@ -118,15 +95,6 @@ def test_expectation_name():
             None,
             "string",
         ),
-        (
-            "pyspark",
-            ["orange", "grape", "melon"],
-            ["apple", "banana"],
-            True,
-            None,
-            None,
-            "string",
-        ),
         # String scenarios - violations
         (
             "pandas",
@@ -137,18 +105,8 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is in ['apple', 'banana'].",
             "string",
         ),
-        (
-            "pyspark",
-            ["apple", "orange", "banana"],
-            ["apple", "banana"],
-            False,
-            ["apple", "banana"],
-            "Found 2 row(s) where 'col1' is in ['apple', 'banana'].",
-            "string",
-        ),
         # String case sensitivity - success (case matters)
         ("pandas", ["Apple", "APPLE", "aPpLe"], ["apple"], True, None, None, "string"),
-        ("pyspark", ["Apple", "APPLE", "aPpLe"], ["apple"], True, None, None, "string"),
         # String case sensitivity - violations (exact match)
         (
             "pandas",
@@ -159,18 +117,8 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is in ['apple', 'banana'].",
             "string",
         ),
-        (
-            "pyspark",
-            ["apple", "Apple", "banana"],
-            ["apple", "banana"],
-            False,
-            ["apple", "banana"],
-            "Found 2 row(s) where 'col1' is in ['apple', 'banana'].",
-            "string",
-        ),
         # Float/Double data type scenarios - success
         ("pandas", [5.5, 6.5, 7.5], [1.5, 2.5, 3.5], True, None, None, "double"),
-        ("pyspark", [5.5, 6.5, 7.5], [1.5, 2.5, 3.5], True, None, None, "double"),
         # Float scenarios - violations
         (
             "pandas",
@@ -181,18 +129,8 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is in [1.5, 2.5].",
             "double",
         ),
-        (
-            "pyspark",
-            [1.5, 2.5, 5.5],
-            [1.5, 2.5],
-            False,
-            [1.5, 2.5],
-            "Found 2 row(s) where 'col1' is in [1.5, 2.5].",
-            "double",
-        ),
         # Float precision edge cases - success
         ("pandas", [1.1, 1.2, 1.3], [1.0, 2.0], True, None, None, "double"),
-        ("pyspark", [1.1, 1.2, 1.3], [1.0, 2.0], True, None, None, "double"),
         # Float precision - violations
         (
             "pandas",
@@ -203,20 +141,9 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is in [1.0, 2.0].",
             "double",
         ),
-        (
-            "pyspark",
-            [1.0, 1.5, 2.0],
-            [1.0, 2.0],
-            False,
-            [1.0, 2.0],
-            "Found 2 row(s) where 'col1' is in [1.0, 2.0].",
-            "double",
-        ),
         # Boolean data type scenarios - success
         ("pandas", [False, False, False], [True], True, None, None, "boolean"),
-        ("pyspark", [False, False, False], [True], True, None, None, "boolean"),
         ("pandas", [True, True, True], [False], True, None, None, "boolean"),
-        ("pyspark", [True, True, True], [False], True, None, None, "boolean"),
         # Boolean scenarios - violations
         (
             "pandas",
@@ -228,25 +155,7 @@ def test_expectation_name():
             "boolean",
         ),
         (
-            "pyspark",
-            [True, False, True],
-            [True],
-            False,
-            [True, True],
-            "Found 2 row(s) where 'col1' is in [True].",
-            "boolean",
-        ),
-        (
             "pandas",
-            [True, False, False],
-            [True, False],
-            False,
-            [True, False, False],
-            "Found 3 row(s) where 'col1' is in [True, False].",
-            "boolean",
-        ),
-        (
-            "pyspark",
             [True, False, False],
             [True, False],
             False,
@@ -264,27 +173,9 @@ def test_expectation_name():
             None,
             "timestamp",
         ),
-        (
-            "pyspark",
-            [datetime(2023, 1, 5), datetime(2023, 1, 6), datetime(2023, 1, 7)],
-            [datetime(2023, 1, 1), datetime(2023, 1, 2)],
-            True,
-            None,
-            None,
-            "timestamp",
-        ),
         # Timestamp scenarios - violations
         (
             "pandas",
-            [datetime(2023, 1, 1), datetime(2023, 1, 5), datetime(2023, 1, 2)],
-            [datetime(2023, 1, 1), datetime(2023, 1, 2)],
-            False,
-            [datetime(2023, 1, 1), datetime(2023, 1, 2)],
-            "Found 2 row(s) where 'col1' is in [datetime.datetime(2023, 1, 1, 0, 0), datetime.datetime(2023, 1, 2, 0, 0)].",
-            "timestamp",
-        ),
-        (
-            "pyspark",
             [datetime(2023, 1, 1), datetime(2023, 1, 5), datetime(2023, 1, 2)],
             [datetime(2023, 1, 1), datetime(2023, 1, 2)],
             False,
@@ -305,21 +196,8 @@ def test_expectation_name():
             None,
             "timestamp",
         ),
-        (
-            "pyspark",
-            [
-                datetime(2023, 1, 5, 12, 0, 0, tzinfo=timezone.utc),
-                datetime(2023, 1, 6, 12, 0, 0, tzinfo=timezone.utc),
-            ],
-            [datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)],
-            True,
-            None,
-            None,
-            "timestamp",
-        ),
         # Empty string scenarios - success
         ("pandas", ["text", "data", "value"], [""], True, None, None, "string"),
-        ("pyspark", ["text", "data", "value"], [""], True, None, None, "string"),
         # Empty string - violations
         (
             "pandas",
@@ -330,23 +208,11 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is in [''].",
             "string",
         ),
-        (
-            "pyspark",
-            ["", "text", ""],
-            [""],
-            False,
-            ["", ""],
-            "Found 2 row(s) where 'col1' is in [''].",
-            "string",
-        ),
         # Whitespace in strings - success
         ("pandas", [" test", "test ", " test "], ["test"], True, None, None, "string"),
-        ("pyspark", [" test", "test ", " test "], ["test"], True, None, None, "string"),
         # Zero value scenarios - success
         ("pandas", [1, 2, 3], [0], True, None, None, "long"),
-        ("pyspark", [1, 2, 3], [0], True, None, None, "long"),
         ("pandas", [1.5, 2.5, 3.5], [0.0], True, None, None, "double"),
-        ("pyspark", [1.5, 2.5, 3.5], [0.0], True, None, None, "double"),
         # Zero value - violations
         (
             "pandas",
@@ -357,20 +223,9 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is in [0].",
             "long",
         ),
-        (
-            "pyspark",
-            [0, 1, 0],
-            [0],
-            False,
-            [0, 0],
-            "Found 2 row(s) where 'col1' is in [0].",
-            "long",
-        ),
         # Negative numbers - success
         ("pandas", [1, 2, 3], [-5, -10], True, None, None, "long"),
-        ("pyspark", [1, 2, 3], [-5, -10], True, None, None, "long"),
         ("pandas", [1.5, 2.5, 3.5], [-3.14], True, None, None, "double"),
-        ("pyspark", [1.5, 2.5, 3.5], [-3.14], True, None, None, "double"),
         # Negative numbers - violations
         (
             "pandas",
@@ -381,18 +236,8 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is in [-5].",
             "long",
         ),
-        (
-            "pyspark",
-            [-5, 1, -5],
-            [-5],
-            False,
-            [-5, -5],
-            "Found 2 row(s) where 'col1' is in [-5].",
-            "long",
-        ),
         # Large numbers - success
         ("pandas", [999999, 1000001], [1000000], True, None, None, "long"),
-        ("pyspark", [999999, 1000001], [1000000], True, None, None, "long"),
         # Large numbers - violations
         (
             "pandas",
@@ -403,18 +248,8 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is in [1000000].",
             "long",
         ),
-        (
-            "pyspark",
-            [1000000, 999999, 1000000],
-            [1000000],
-            False,
-            [1000000, 1000000],
-            "Found 2 row(s) where 'col1' is in [1000000].",
-            "long",
-        ),
         # Single value in list - success
         ("pandas", [10, 20, 30], [5], True, None, None, "long"),
-        ("pyspark", [10, 20, 30], [5], True, None, None, "long"),
         # Multiple values with partial match
         (
             "pandas",
@@ -425,84 +260,43 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is in [1, 2, 3, 4].",
             "long",
         ),
-        (
-            "pyspark",
-            [1, 5, 6],
-            [1, 2, 3, 4],
-            False,
-            [1],
-            "Found 1 row(s) where 'col1' is in [1, 2, 3, 4].",
-            "long",
-        ),
     ],
     ids=[
         "pandas_int_basic_success",
-        "pyspark_int_basic_success",
         "pandas_int_success_different_range",
-        "pyspark_int_success_different_range",
         "pandas_int_violations_two",
-        "pyspark_int_violations_two",
         "pandas_int_violations_all",
-        "pyspark_int_violations_all",
         "pandas_string_success",
-        "pyspark_string_success",
         "pandas_string_violations",
-        "pyspark_string_violations",
         "pandas_string_case_sensitive_success",
-        "pyspark_string_case_sensitive_success",
         "pandas_string_case_sensitive_violations",
-        "pyspark_string_case_sensitive_violations",
         "pandas_double_success",
-        "pyspark_double_success",
         "pandas_double_violations",
-        "pyspark_double_violations",
         "pandas_double_precision_success",
-        "pyspark_double_precision_success",
         "pandas_double_precision_violations",
-        "pyspark_double_precision_violations",
         "pandas_boolean_false_success",
-        "pyspark_boolean_false_success",
         "pandas_boolean_true_success",
-        "pyspark_boolean_true_success",
         "pandas_boolean_true_violations",
-        "pyspark_boolean_true_violations",
         "pandas_boolean_both_violations",
-        "pyspark_boolean_both_violations",
         "pandas_timestamp_success",
-        "pyspark_timestamp_success",
         "pandas_timestamp_violations",
-        "pyspark_timestamp_violations",
         "pandas_timestamp_with_timezone_success",
-        "pyspark_timestamp_with_timezone_success",
         "pandas_empty_string_success",
-        "pyspark_empty_string_success",
         "pandas_empty_string_violations",
-        "pyspark_empty_string_violations",
         "pandas_string_whitespace_success",
-        "pyspark_string_whitespace_success",
         "pandas_zero_int_success",
-        "pyspark_zero_int_success",
         "pandas_zero_double_success",
-        "pyspark_zero_double_success",
         "pandas_zero_int_violations",
-        "pyspark_zero_int_violations",
         "pandas_negative_int_success",
-        "pyspark_negative_int_success",
         "pandas_negative_double_success",
-        "pyspark_negative_double_success",
         "pandas_negative_int_violations",
-        "pyspark_negative_int_violations",
         "pandas_large_numbers_success",
-        "pyspark_large_numbers_success",
         "pandas_large_numbers_violations",
-        "pyspark_large_numbers_violations",
         "pandas_single_value_list_success",
-        "pyspark_single_value_list_success",
         "pandas_multiple_values_partial_match",
-        "pyspark_multiple_values_partial_match",
     ],
 )
-def test_expectation_basic_scenarios(
+def test_expectation_basic_scenarios_pandas(
     df_type,
     data,
     values,
@@ -510,9 +304,8 @@ def test_expectation_basic_scenarios(
     expected_violations,
     expected_message,
     data_type,
-    spark,
 ):
-    """Test basic expectation scenarios for both pandas and PySpark DataFrames.
+    """Test basic expectation scenarios for pandas DataFrames.
 
     Tests various data types including:
     - Integers (long): positive, negative, zero, large numbers, single/multiple values
@@ -525,7 +318,7 @@ def test_expectation_basic_scenarios(
     Note: ExpectationValueNotIn checks that values are NOT in the target list.
     Success = all values outside target list, Violations = values that are in target list.
     """
-    df = create_dataframe(df_type, data, "col1", spark, data_type)
+    df = pd.DataFrame(data, columns=["col1"])
 
     # Test through registry
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -549,8 +342,321 @@ def test_expectation_basic_scenarios(
 
         # Verify violations if present
         if expected_violations is not None:
-            expected_violations_df = create_dataframe(
-                df_type, expected_violations, "col1", spark, data_type
+            expected_violations_df = pd.DataFrame(expected_violations, columns=["col1"])
+            expected_failure = DataFrameExpectationFailureMessage(
+                expectation_str=str(expectation),
+                data_frame_type=str(df_type),
+                violations_data_frame=expected_violations_df,
+                message=expected_message,
+                limit_violations=5,
+            )
+            assert str(result) == str(expected_failure), (
+                f"Expected failure details don't match. Got: {result}"
+            )
+
+    # Test through suite
+    suite = DataFrameExpectationsSuite().expect_value_not_in(column_name="col1", values=values)
+
+    if should_succeed:
+        suite_result = suite.build().run(data_frame=df)
+        assert suite_result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(suite_result, SuiteExecutionResult), (
+            "Result should be SuiteExecutionResult"
+        )
+        assert suite_result.success, "Expected all expectations to pass"
+        assert suite_result.total_passed == 1, "Expected 1 passed expectation"
+        assert suite_result.total_failed == 0, "Expected 0 failed expectations"
+    else:
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            suite.build().run(data_frame=df)
+
+
+@pytest.mark.pyspark
+@pytest.mark.parametrize(
+    "df_type, data, values, should_succeed, expected_violations, expected_message, data_type",
+    [
+        # Basic integer scenarios - success (values NOT in [1,2,3])
+        ("pyspark", [4, 5, 6, 7], [1, 2, 3], True, None, None, "long"),
+        ("pyspark", [10, 20, 30], [1, 2, 3], True, None, None, "long"),
+        # Integer scenarios - violations (values in [1,2,3])
+        (
+            "pyspark",
+            [1, 2, 4, 5],
+            [1, 2, 3],
+            False,
+            [1, 2],
+            "Found 2 row(s) where 'col1' is in [1, 2, 3].",
+            "long",
+        ),
+        (
+            "pyspark",
+            [1, 2, 3],
+            [1, 2, 3],
+            False,
+            [1, 2, 3],
+            "Found 3 row(s) where 'col1' is in [1, 2, 3].",
+            "long",
+        ),
+        # String data type scenarios - success
+        (
+            "pyspark",
+            ["orange", "grape", "melon"],
+            ["apple", "banana"],
+            True,
+            None,
+            None,
+            "string",
+        ),
+        # String scenarios - violations
+        (
+            "pyspark",
+            ["apple", "orange", "banana"],
+            ["apple", "banana"],
+            False,
+            ["apple", "banana"],
+            "Found 2 row(s) where 'col1' is in ['apple', 'banana'].",
+            "string",
+        ),
+        # String case sensitivity - success (case matters)
+        ("pyspark", ["Apple", "APPLE", "aPpLe"], ["apple"], True, None, None, "string"),
+        # String case sensitivity - violations (exact match)
+        (
+            "pyspark",
+            ["apple", "Apple", "banana"],
+            ["apple", "banana"],
+            False,
+            ["apple", "banana"],
+            "Found 2 row(s) where 'col1' is in ['apple', 'banana'].",
+            "string",
+        ),
+        # Float/Double data type scenarios - success
+        ("pyspark", [5.5, 6.5, 7.5], [1.5, 2.5, 3.5], True, None, None, "double"),
+        # Float scenarios - violations
+        (
+            "pyspark",
+            [1.5, 2.5, 5.5],
+            [1.5, 2.5],
+            False,
+            [1.5, 2.5],
+            "Found 2 row(s) where 'col1' is in [1.5, 2.5].",
+            "double",
+        ),
+        # Float precision edge cases - success
+        ("pyspark", [1.1, 1.2, 1.3], [1.0, 2.0], True, None, None, "double"),
+        # Float precision - violations
+        (
+            "pyspark",
+            [1.0, 1.5, 2.0],
+            [1.0, 2.0],
+            False,
+            [1.0, 2.0],
+            "Found 2 row(s) where 'col1' is in [1.0, 2.0].",
+            "double",
+        ),
+        # Boolean data type scenarios - success
+        ("pyspark", [False, False, False], [True], True, None, None, "boolean"),
+        ("pyspark", [True, True, True], [False], True, None, None, "boolean"),
+        # Boolean scenarios - violations
+        (
+            "pyspark",
+            [True, False, True],
+            [True],
+            False,
+            [True, True],
+            "Found 2 row(s) where 'col1' is in [True].",
+            "boolean",
+        ),
+        (
+            "pyspark",
+            [True, False, False],
+            [True, False],
+            False,
+            [True, False, False],
+            "Found 3 row(s) where 'col1' is in [True, False].",
+            "boolean",
+        ),
+        # Timestamp/Datetime scenarios - success
+        (
+            "pyspark",
+            [datetime(2023, 1, 5), datetime(2023, 1, 6), datetime(2023, 1, 7)],
+            [datetime(2023, 1, 1), datetime(2023, 1, 2)],
+            True,
+            None,
+            None,
+            "timestamp",
+        ),
+        # Timestamp scenarios - violations
+        (
+            "pyspark",
+            [datetime(2023, 1, 1), datetime(2023, 1, 5), datetime(2023, 1, 2)],
+            [datetime(2023, 1, 1), datetime(2023, 1, 2)],
+            False,
+            [datetime(2023, 1, 1), datetime(2023, 1, 2)],
+            "Found 2 row(s) where 'col1' is in [datetime.datetime(2023, 1, 1, 0, 0), datetime.datetime(2023, 1, 2, 0, 0)].",
+            "timestamp",
+        ),
+        # Datetime with timezone - success
+        (
+            "pyspark",
+            [
+                datetime(2023, 1, 5, 12, 0, 0, tzinfo=timezone.utc),
+                datetime(2023, 1, 6, 12, 0, 0, tzinfo=timezone.utc),
+            ],
+            [datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)],
+            True,
+            None,
+            None,
+            "timestamp",
+        ),
+        # Empty string scenarios - success
+        ("pyspark", ["text", "data", "value"], [""], True, None, None, "string"),
+        # Empty string - violations
+        (
+            "pyspark",
+            ["", "text", ""],
+            [""],
+            False,
+            ["", ""],
+            "Found 2 row(s) where 'col1' is in [''].",
+            "string",
+        ),
+        # Whitespace in strings - success
+        ("pyspark", [" test", "test ", " test "], ["test"], True, None, None, "string"),
+        # Zero value scenarios - success
+        ("pyspark", [1, 2, 3], [0], True, None, None, "long"),
+        ("pyspark", [1.5, 2.5, 3.5], [0.0], True, None, None, "double"),
+        # Zero value - violations
+        (
+            "pyspark",
+            [0, 1, 0],
+            [0],
+            False,
+            [0, 0],
+            "Found 2 row(s) where 'col1' is in [0].",
+            "long",
+        ),
+        # Negative numbers - success
+        ("pyspark", [1, 2, 3], [-5, -10], True, None, None, "long"),
+        ("pyspark", [1.5, 2.5, 3.5], [-3.14], True, None, None, "double"),
+        # Negative numbers - violations
+        (
+            "pyspark",
+            [-5, 1, -5],
+            [-5],
+            False,
+            [-5, -5],
+            "Found 2 row(s) where 'col1' is in [-5].",
+            "long",
+        ),
+        # Large numbers - success
+        ("pyspark", [999999, 1000001], [1000000], True, None, None, "long"),
+        # Large numbers - violations
+        (
+            "pyspark",
+            [1000000, 999999, 1000000],
+            [1000000],
+            False,
+            [1000000, 1000000],
+            "Found 2 row(s) where 'col1' is in [1000000].",
+            "long",
+        ),
+        # Single value in list - success
+        ("pyspark", [10, 20, 30], [5], True, None, None, "long"),
+        # Multiple values with partial match
+        (
+            "pyspark",
+            [1, 5, 6],
+            [1, 2, 3, 4],
+            False,
+            [1],
+            "Found 1 row(s) where 'col1' is in [1, 2, 3, 4].",
+            "long",
+        ),
+    ],
+    ids=[
+        "pyspark_int_basic_success",
+        "pyspark_int_success_different_range",
+        "pyspark_int_violations_two",
+        "pyspark_int_violations_all",
+        "pyspark_string_success",
+        "pyspark_string_violations",
+        "pyspark_string_case_sensitive_success",
+        "pyspark_string_case_sensitive_violations",
+        "pyspark_double_success",
+        "pyspark_double_violations",
+        "pyspark_double_precision_success",
+        "pyspark_double_precision_violations",
+        "pyspark_boolean_false_success",
+        "pyspark_boolean_true_success",
+        "pyspark_boolean_true_violations",
+        "pyspark_boolean_both_violations",
+        "pyspark_timestamp_success",
+        "pyspark_timestamp_violations",
+        "pyspark_timestamp_with_timezone_success",
+        "pyspark_empty_string_success",
+        "pyspark_empty_string_violations",
+        "pyspark_string_whitespace_success",
+        "pyspark_zero_int_success",
+        "pyspark_zero_double_success",
+        "pyspark_zero_int_violations",
+        "pyspark_negative_int_success",
+        "pyspark_negative_double_success",
+        "pyspark_negative_int_violations",
+        "pyspark_large_numbers_success",
+        "pyspark_large_numbers_violations",
+        "pyspark_single_value_list_success",
+        "pyspark_multiple_values_partial_match",
+    ],
+)
+def test_expectation_basic_scenarios_pyspark(
+    df_type,
+    data,
+    values,
+    should_succeed,
+    expected_violations,
+    expected_message,
+    data_type,
+    spark,
+):
+    """Test basic expectation scenarios for both pandas and PySpark DataFrames.
+
+    Tests various data types including:
+    - Integers (long): positive, negative, zero, large numbers, single/multiple values
+    - Strings: case sensitivity, empty strings, whitespace
+    - Floats (double): precision, zero values
+    - Booleans: True/False combinations
+    - Timestamps: with and without timezone
+    - Edge cases: single value lists
+
+    Note: ExpectationValueNotIn checks that values are NOT in the target list.
+    Success = all values outside target list, Violations = values that are in target list.
+    """
+    df = create_pyspark_dataframe(data, "col1", spark, data_type)
+
+    # Test through registry
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueNotIn",
+        column_name="col1",
+        values=values,
+    )
+    result = expectation.validate(data_frame=df)
+
+    if should_succeed:
+        assert isinstance(result, DataFrameExpectationSuccessMessage), (
+            f"Expected success but got: {result}"
+        )
+    else:
+        assert isinstance(result, DataFrameExpectationFailureMessage), (
+            f"Expected failure but got: {result}"
+        )
+        assert expected_message in str(result), (
+            f"Expected message '{expected_message}' in result: {result}"
+        )
+
+        # Verify violations if present
+        if expected_violations is not None:
+            expected_violations_df = create_pyspark_dataframe(
+                expected_violations, "col1", spark, data_type
             )
             expected_failure = DataFrameExpectationFailureMessage(
                 expectation_str=str(expectation),
@@ -580,17 +686,10 @@ def test_expectation_basic_scenarios(
             suite.build().run(data_frame=df)
 
 
-@pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
-)
-def test_column_missing_error(df_type, spark):
+def test_column_missing_error_pandas():
     """Test missing column error for both pandas and PySpark DataFrames."""
-    if df_type == "pandas":
-        df = pd.DataFrame({"col1": [4, 5, 6]})
-    else:
-        df = spark.createDataFrame([(4,), (5,), (6,)], ["col1"])
+
+    df = pd.DataFrame({"col1": [4, 5, 6]})
 
     expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
 
@@ -603,7 +702,36 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=df)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure)
+
+    # Test through suite
+    suite = DataFrameExpectationsSuite().expect_value_not_in(
+        column_name="nonexistent_col", values=[1, 2, 3]
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        suite.build().run(data_frame=df)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test missing column error for both pandas and PySpark DataFrames."""
+    df = create_pyspark_dataframe([(4,), (5,), (6,)], "col1", spark)
+
+    expected_message = "Column 'nonexistent_col' does not exist in the DataFrame."
+
+    # Test through registry
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueNotIn",
+        column_name="nonexistent_col",
+        values=[1, 2, 3],
+    )
+    result = expectation.validate(data_frame=df)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message=expected_message,
     )
     assert str(result) == str(expected_failure)

--- a/tests/expectations/column/any_value_expectations/test_expect_value_not_null.py
+++ b/tests/expectations/column/any_value_expectations/test_expect_value_not_null.py
@@ -9,47 +9,36 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark, data_type="long"):
-    """Helper function to create pandas or pyspark DataFrame.
+def create_pyspark_dataframe(data, column_name, spark, data_type="long"):
+    """Helper function to create a PySpark DataFrame."""
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        LongType,
+        StringType,
+        DoubleType,
+        BooleanType,
+        TimestampType,
+    )
 
-    Args:
-        df_type: "pandas" or "pyspark"
-        data: List of values for the column
-        column_name: Name of the column
-        spark: Spark session (required for pyspark)
-        data_type: Data type for the column - "long", "string", "double", "boolean", "timestamp"
-    """
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        from pyspark.sql.types import (
-            StructType,
-            StructField,
-            LongType,
-            StringType,
-            DoubleType,
-            BooleanType,
-            TimestampType,
-        )
+    type_mapping = {
+        "long": LongType(),
+        "string": StringType(),
+        "double": DoubleType(),
+        "boolean": BooleanType(),
+        "timestamp": TimestampType(),
+    }
 
-        type_mapping = {
-            "long": LongType(),
-            "string": StringType(),
-            "double": DoubleType(),
-            "boolean": BooleanType(),
-            "timestamp": TimestampType(),
-        }
-
-        schema = StructType([StructField(column_name, type_mapping[data_type], True)])
-        return spark.createDataFrame([(val,) for val in data], schema)
+    schema = StructType([StructField(column_name, type_mapping[data_type], True)])
+    return spark.createDataFrame([(val,) for val in data], schema)
 
 
 def test_expectation_name():
@@ -68,9 +57,7 @@ def test_expectation_name():
     [
         # Basic integer scenarios - success (no nulls)
         ("pandas", [1, 2, 3], True, None, None, "long"),
-        ("pyspark", [1, 2, 3], True, None, None, "long"),
         ("pandas", [10, 20, 30, 40], True, None, None, "long"),
-        ("pyspark", [10, 20, 30, 40], True, None, None, "long"),
         # Integer scenarios - violations (with None)
         (
             "pandas",
@@ -80,25 +67,9 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is null.",
             "long",
         ),
-        (
-            "pyspark",
-            [1, None, None],
-            False,
-            [None, None],
-            "Found 2 row(s) where 'col1' is null.",
-            "long",
-        ),
         # All nulls scenario
         (
             "pandas",
-            [None, None, None],
-            False,
-            [None, None, None],
-            "Found 3 row(s) where 'col1' is null.",
-            "long",
-        ),
-        (
-            "pyspark",
             [None, None, None],
             False,
             [None, None, None],
@@ -114,19 +85,9 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is null.",
             "long",
         ),
-        (
-            "pyspark",
-            [1, 2, None],
-            False,
-            [None],
-            "Found 1 row(s) where 'col1' is null.",
-            "long",
-        ),
         # String data type scenarios - success (no nulls)
         ("pandas", ["apple", "banana", "cherry"], True, None, None, "string"),
-        ("pyspark", ["apple", "banana", "cherry"], True, None, None, "string"),
         ("pandas", ["test", "data", "values"], True, None, None, "string"),
-        ("pyspark", ["test", "data", "values"], True, None, None, "string"),
         # String scenarios - violations (with None)
         (
             "pandas",
@@ -136,20 +97,10 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is null.",
             "string",
         ),
-        (
-            "pyspark",
-            ["apple", None, "banana"],
-            False,
-            [None],
-            "Found 1 row(s) where 'col1' is null.",
-            "string",
-        ),
         # Empty string is NOT null - should succeed
         ("pandas", ["", "test", "data"], True, None, None, "string"),
-        ("pyspark", ["", "test", "data"], True, None, None, "string"),
         # Whitespace is NOT null - should succeed
         ("pandas", [" ", "  ", "   "], True, None, None, "string"),
-        ("pyspark", [" ", "  ", "   "], True, None, None, "string"),
         # Mixed empty strings and nulls - only nulls are violations
         (
             "pandas",
@@ -159,30 +110,12 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is null.",
             "string",
         ),
-        (
-            "pyspark",
-            ["", None, "test"],
-            False,
-            [None],
-            "Found 1 row(s) where 'col1' is null.",
-            "string",
-        ),
         # Float/Double data type scenarios - success (no nulls)
         ("pandas", [1.5, 2.5, 3.5], True, None, None, "double"),
-        ("pyspark", [1.5, 2.5, 3.5], True, None, None, "double"),
         ("pandas", [0.0, 1.1, 2.2], True, None, None, "double"),
-        ("pyspark", [0.0, 1.1, 2.2], True, None, None, "double"),
         # Float scenarios - violations (with None/NaN)
         (
             "pandas",
-            [1.5, None, 2.5],
-            False,
-            [None],
-            "Found 1 row(s) where 'col1' is null.",
-            "double",
-        ),
-        (
-            "pyspark",
             [1.5, None, 2.5],
             False,
             [None],
@@ -199,19 +132,13 @@ def test_expectation_name():
         ),
         # Zero is NOT null - should succeed
         ("pandas", [0.0, 0.0, 0.0], True, None, None, "double"),
-        ("pyspark", [0.0, 0.0, 0.0], True, None, None, "double"),
         ("pandas", [0, 0, 0], True, None, None, "long"),
-        ("pyspark", [0, 0, 0], True, None, None, "long"),
         # Negative numbers are NOT null - should succeed
         ("pandas", [-1, -2, -3], True, None, None, "long"),
-        ("pyspark", [-1, -2, -3], True, None, None, "long"),
         ("pandas", [-1.5, -2.5, -3.5], True, None, None, "double"),
-        ("pyspark", [-1.5, -2.5, -3.5], True, None, None, "double"),
         # Boolean data type scenarios - success (no nulls)
         ("pandas", [True, False, True], True, None, None, "boolean"),
-        ("pyspark", [True, False, True], True, None, None, "boolean"),
         ("pandas", [False, False, False], True, None, None, "boolean"),
-        ("pyspark", [False, False, False], True, None, None, "boolean"),
         # Boolean scenarios - violations (with None)
         (
             "pandas",
@@ -221,17 +148,8 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is null.",
             "boolean",
         ),
-        (
-            "pyspark",
-            [True, None, False],
-            False,
-            [None],
-            "Found 1 row(s) where 'col1' is null.",
-            "boolean",
-        ),
         # False is NOT null - should succeed
         ("pandas", [False], True, None, None, "boolean"),
-        ("pyspark", [False], True, None, None, "boolean"),
         # Timestamp/Datetime scenarios - success (no nulls)
         (
             "pandas",
@@ -241,25 +159,9 @@ def test_expectation_name():
             None,
             "timestamp",
         ),
-        (
-            "pyspark",
-            [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 3)],
-            True,
-            None,
-            None,
-            "timestamp",
-        ),
         # Timestamp scenarios - violations (with None)
         (
             "pandas",
-            [datetime(2023, 1, 1), None, datetime(2023, 1, 3)],
-            False,
-            [None],
-            "Found 1 row(s) where 'col1' is null.",
-            "timestamp",
-        ),
-        (
-            "pyspark",
             [datetime(2023, 1, 1), None, datetime(2023, 1, 3)],
             False,
             [None],
@@ -278,17 +180,6 @@ def test_expectation_name():
             None,
             "timestamp",
         ),
-        (
-            "pyspark",
-            [
-                datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
-                datetime(2023, 1, 2, 12, 0, 0, tzinfo=timezone.utc),
-            ],
-            True,
-            None,
-            None,
-            "timestamp",
-        ),
         # Multiple nulls in different positions
         (
             "pandas",
@@ -298,20 +189,10 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is null.",
             "long",
         ),
-        (
-            "pyspark",
-            [1, None, 3, None, 5],
-            False,
-            [None, None],
-            "Found 2 row(s) where 'col1' is null.",
-            "long",
-        ),
         # Large numbers - success (not null)
         ("pandas", [1000000, 2000000, 3000000], True, None, None, "long"),
-        ("pyspark", [1000000, 2000000, 3000000], True, None, None, "long"),
         # Single value - success
         ("pandas", [42], True, None, None, "long"),
-        ("pyspark", [42], True, None, None, "long"),
         # Single null
         (
             "pandas",
@@ -321,87 +202,49 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is null.",
             "long",
         ),
-        (
-            "pyspark",
-            [None],
-            False,
-            [None],
-            "Found 1 row(s) where 'col1' is null.",
-            "long",
-        ),
     ],
     ids=[
         "pandas_int_basic_success",
-        "pyspark_int_basic_success",
         "pandas_int_multi_value_success",
-        "pyspark_int_multi_value_success",
         "pandas_int_with_none_nan_violations",
-        "pyspark_int_with_none_violations",
         "pandas_all_nulls_violations",
-        "pyspark_all_nulls_violations",
         "pandas_single_null_violation",
-        "pyspark_single_null_violation",
         "pandas_string_basic_success",
-        "pyspark_string_basic_success",
         "pandas_string_multi_value_success",
-        "pyspark_string_multi_value_success",
         "pandas_string_with_none_violation",
-        "pyspark_string_with_none_violation",
         "pandas_empty_string_not_null_success",
-        "pyspark_empty_string_not_null_success",
         "pandas_whitespace_not_null_success",
-        "pyspark_whitespace_not_null_success",
         "pandas_mixed_empty_string_null_violation",
-        "pyspark_mixed_empty_string_null_violation",
         "pandas_double_basic_success",
-        "pyspark_double_basic_success",
         "pandas_double_with_zero_success",
-        "pyspark_double_with_zero_success",
         "pandas_double_with_none_violation",
-        "pyspark_double_with_none_violation",
         "pandas_double_with_nan_violation",
         "pandas_double_all_zeros_success",
-        "pyspark_double_all_zeros_success",
         "pandas_int_all_zeros_success",
-        "pyspark_int_all_zeros_success",
         "pandas_int_negative_values_success",
-        "pyspark_int_negative_values_success",
         "pandas_double_negative_values_success",
-        "pyspark_double_negative_values_success",
         "pandas_boolean_mixed_success",
-        "pyspark_boolean_mixed_success",
         "pandas_boolean_all_false_success",
-        "pyspark_boolean_all_false_success",
         "pandas_boolean_with_none_violation",
-        "pyspark_boolean_with_none_violation",
         "pandas_boolean_false_not_null_success",
-        "pyspark_boolean_false_not_null_success",
         "pandas_timestamp_basic_success",
-        "pyspark_timestamp_basic_success",
         "pandas_timestamp_with_none_violation",
-        "pyspark_timestamp_with_none_violation",
         "pandas_timestamp_with_tz_success",
-        "pyspark_timestamp_with_tz_success",
         "pandas_multiple_nulls_violations",
-        "pyspark_multiple_nulls_violations",
         "pandas_large_numbers_success",
-        "pyspark_large_numbers_success",
         "pandas_single_value_success",
-        "pyspark_single_value_success",
         "pandas_single_null_only_violation",
-        "pyspark_single_null_only_violation",
     ],
 )
-def test_expectation_basic_scenarios(
+def test_expectation_basic_scenarios_pandas(
     df_type,
     data,
     should_succeed,
     expected_violations,
     expected_message,
     data_type,
-    spark,
 ):
-    """Test basic expectation scenarios for both pandas and PySpark DataFrames.
+    """Test basic expectation scenarios for pandas DataFrames.
 
     Tests various data types including:
     - Integers (long): positive, negative, zero, large numbers, with/without nulls
@@ -415,7 +258,7 @@ def test_expectation_basic_scenarios(
     Success = no null values, Violations = null/None/NaN values.
     Empty strings, zeros, and False are NOT considered null.
     """
-    df = create_dataframe(df_type, data, "col1", spark, data_type)
+    df = pd.DataFrame({"col1": data})
 
     # Test through registry
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -436,15 +279,251 @@ def test_expectation_basic_scenarios(
             f"Expected message '{expected_message}' in result: {result}"
         )
 
-        # Verify violations if present (skip detailed DataFrame comparison for pandas None values
-        # as representation differs between None and np.nan in display)
-        if expected_violations is not None and df_type == "pyspark":
-            expected_violations_df = create_dataframe(
-                df_type, expected_violations, "col1", spark, data_type
+    # Test through suite
+    suite = DataFrameExpectationsSuite().expect_value_not_null(column_name="col1")
+
+    if should_succeed:
+        suite_result = suite.build().run(data_frame=df)
+        assert suite_result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(suite_result, SuiteExecutionResult), (
+            "Result should be SuiteExecutionResult"
+        )
+        assert suite_result.success, "Expected all expectations to pass"
+        assert suite_result.total_passed == 1, "Expected 1 passed expectation"
+        assert suite_result.total_failed == 0, "Expected 0 failed expectations"
+    else:
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            suite.build().run(data_frame=df)
+
+
+@pytest.mark.pyspark
+@pytest.mark.parametrize(
+    "df_type, data, should_succeed, expected_violations, expected_message, data_type",
+    [
+        # Basic integer scenarios - success (no nulls)
+        ("pyspark", [1, 2, 3], True, None, None, "long"),
+        ("pyspark", [10, 20, 30, 40], True, None, None, "long"),
+        # Integer scenarios - violations (with None)
+        (
+            "pyspark",
+            [1, None, None],
+            False,
+            [None, None],
+            "Found 2 row(s) where 'col1' is null.",
+            "long",
+        ),
+        # All nulls scenario
+        (
+            "pyspark",
+            [None, None, None],
+            False,
+            [None, None, None],
+            "Found 3 row(s) where 'col1' is null.",
+            "long",
+        ),
+        # Single null scenario
+        (
+            "pyspark",
+            [1, 2, None],
+            False,
+            [None],
+            "Found 1 row(s) where 'col1' is null.",
+            "long",
+        ),
+        # String data type scenarios - success (no nulls)
+        ("pyspark", ["apple", "banana", "cherry"], True, None, None, "string"),
+        ("pyspark", ["test", "data", "values"], True, None, None, "string"),
+        # String scenarios - violations (with None)
+        (
+            "pyspark",
+            ["apple", None, "banana"],
+            False,
+            [None],
+            "Found 1 row(s) where 'col1' is null.",
+            "string",
+        ),
+        # Empty string is NOT null - should succeed
+        ("pyspark", ["", "test", "data"], True, None, None, "string"),
+        # Whitespace is NOT null - should succeed
+        ("pyspark", [" ", "  ", "   "], True, None, None, "string"),
+        # Mixed empty strings and nulls - only nulls are violations
+        (
+            "pyspark",
+            ["", None, "test"],
+            False,
+            [None],
+            "Found 1 row(s) where 'col1' is null.",
+            "string",
+        ),
+        # Float/Double data type scenarios - success (no nulls)
+        ("pyspark", [1.5, 2.5, 3.5], True, None, None, "double"),
+        ("pyspark", [0.0, 1.1, 2.2], True, None, None, "double"),
+        # Float scenarios - violations (with None)
+        (
+            "pyspark",
+            [1.5, None, 2.5],
+            False,
+            [None],
+            "Found 1 row(s) where 'col1' is null.",
+            "double",
+        ),
+        # Zero is NOT null - should succeed
+        ("pyspark", [0.0, 0.0, 0.0], True, None, None, "double"),
+        ("pyspark", [0, 0, 0], True, None, None, "long"),
+        # Negative numbers are NOT null - should succeed
+        ("pyspark", [-1, -2, -3], True, None, None, "long"),
+        ("pyspark", [-1.5, -2.5, -3.5], True, None, None, "double"),
+        # Boolean data type scenarios - success (no nulls)
+        ("pyspark", [True, False, True], True, None, None, "boolean"),
+        ("pyspark", [False, False, False], True, None, None, "boolean"),
+        # Boolean scenarios - violations (with None)
+        (
+            "pyspark",
+            [True, None, False],
+            False,
+            [None],
+            "Found 1 row(s) where 'col1' is null.",
+            "boolean",
+        ),
+        # False is NOT null - should succeed
+        ("pyspark", [False], True, None, None, "boolean"),
+        # Timestamp/Datetime scenarios - success (no nulls)
+        (
+            "pyspark",
+            [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 3)],
+            True,
+            None,
+            None,
+            "timestamp",
+        ),
+        # Timestamp scenarios - violations (with None)
+        (
+            "pyspark",
+            [datetime(2023, 1, 1), None, datetime(2023, 1, 3)],
+            False,
+            [None],
+            "Found 1 row(s) where 'col1' is null.",
+            "timestamp",
+        ),
+        # Datetime with timezone - success (no nulls)
+        (
+            "pyspark",
+            [
+                datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+                datetime(2023, 1, 2, 12, 0, 0, tzinfo=timezone.utc),
+            ],
+            True,
+            None,
+            None,
+            "timestamp",
+        ),
+        # Multiple nulls in different positions
+        (
+            "pyspark",
+            [1, None, 3, None, 5],
+            False,
+            [None, None],
+            "Found 2 row(s) where 'col1' is null.",
+            "long",
+        ),
+        # Large numbers - success (not null)
+        ("pyspark", [1000000, 2000000, 3000000], True, None, None, "long"),
+        # Single value - success
+        ("pyspark", [42], True, None, None, "long"),
+        # Single null
+        (
+            "pyspark",
+            [None],
+            False,
+            [None],
+            "Found 1 row(s) where 'col1' is null.",
+            "long",
+        ),
+    ],
+    ids=[
+        "pyspark_int_basic_success",
+        "pyspark_int_multi_value_success",
+        "pyspark_int_with_none_violations",
+        "pyspark_all_nulls_violations",
+        "pyspark_single_null_violation",
+        "pyspark_string_basic_success",
+        "pyspark_string_multi_value_success",
+        "pyspark_string_with_none_violation",
+        "pyspark_empty_string_not_null_success",
+        "pyspark_whitespace_not_null_success",
+        "pyspark_mixed_empty_string_null_violation",
+        "pyspark_double_basic_success",
+        "pyspark_double_with_zero_success",
+        "pyspark_double_with_none_violation",
+        "pyspark_double_all_zeros_success",
+        "pyspark_int_all_zeros_success",
+        "pyspark_int_negative_values_success",
+        "pyspark_double_negative_values_success",
+        "pyspark_boolean_mixed_success",
+        "pyspark_boolean_all_false_success",
+        "pyspark_boolean_with_none_violation",
+        "pyspark_boolean_false_not_null_success",
+        "pyspark_timestamp_basic_success",
+        "pyspark_timestamp_with_none_violation",
+        "pyspark_timestamp_with_tz_success",
+        "pyspark_multiple_nulls_violations",
+        "pyspark_large_numbers_success",
+        "pyspark_single_value_success",
+        "pyspark_single_null_only_violation",
+    ],
+)
+def test_expectation_basic_scenarios_pyspark(
+    df_type,
+    data,
+    should_succeed,
+    expected_violations,
+    expected_message,
+    data_type,
+    spark,
+):
+    """Test basic expectation scenarios for PySpark DataFrames.
+
+    Tests various data types including:
+    - Integers (long): positive, negative, zero, large numbers, with/without nulls
+    - Strings: with nulls, empty strings (NOT null), whitespace (NOT null)
+    - Floats (double): with None/NaN, zero values (NOT null), negative values (NOT null)
+    - Booleans: True/False (NOT null), with None
+    - Timestamps: with and without timezone, with None
+    - Edge cases: missing columns, all nulls, single null, multiple nulls
+
+    Note: ExpectationValueNotNull checks that values are NOT null.
+    Success = no null values, Violations = null/None/NaN values.
+    Empty strings, zeros, and False are NOT considered null.
+    """
+    df = create_pyspark_dataframe(data, "col1", spark, data_type)
+
+    # Test through registry
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueNotNull",
+        column_name="col1",
+    )
+    result = expectation.validate(data_frame=df)
+
+    if should_succeed:
+        assert isinstance(result, DataFrameExpectationSuccessMessage), (
+            f"Expected success but got: {result}"
+        )
+    else:
+        assert isinstance(result, DataFrameExpectationFailureMessage), (
+            f"Expected failure but got: {result}"
+        )
+        assert expected_message in str(result), (
+            f"Expected message '{expected_message}' in result: {result}"
+        )
+
+        # Verify violations if present
+        if expected_violations is not None:
+            expected_violations_df = create_pyspark_dataframe(
+                expected_violations, "col1", spark, data_type
             )
             expected_failure = DataFrameExpectationFailureMessage(
                 expectation_str=str(expectation),
-                data_frame_type=str(df_type),
+                data_frame_type="pyspark",
                 violations_data_frame=expected_violations_df,
                 message=expected_message,
                 limit_violations=5,
@@ -470,15 +549,38 @@ def test_expectation_basic_scenarios(
             suite.build().run(data_frame=df)
 
 
-@pytest.mark.parametrize(
-    "df_type",
-    [("pandas"), ("pyspark")],
-    ids=["pandas", "pyspark"],
-)
-def test_column_missing_error(df_type, spark):
-    """Test that a missing column returns the appropriate error message."""
-    # Create DataFrame with a different column name (col2 instead of col1)
-    df = create_dataframe(df_type, [1, 2, 3], "col2", spark, "long")
+def test_column_missing_error_pandas():
+    """Test that a missing column returns the appropriate error message for pandas DataFrames."""
+    df = pd.DataFrame({"col2": [1, 2, 3]})
+
+    # Test through registry - should return failure message about missing column
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueNotNull",
+        column_name="col1",
+    )
+    result = expectation.validate(data_frame=df)
+
+    assert isinstance(result, DataFrameExpectationFailureMessage), (
+        f"Expected DataFrameExpectationFailureMessage but got: {type(result)}"
+    )
+    assert "Column 'col1' does not exist in the DataFrame" in str(result), (
+        f"Expected missing column message but got: {result}"
+    )
+
+    # Test through suite - should raise DataFrameExpectationsSuiteFailure
+    suite = DataFrameExpectationsSuite().expect_value_not_null(column_name="col1")
+    with pytest.raises(DataFrameExpectationsSuiteFailure) as exc_info:
+        suite.build().run(data_frame=df)
+
+    assert "Column 'col1' does not exist in the DataFrame" in str(exc_info.value), (
+        f"Expected missing column message in suite failure but got: {exc_info.value}"
+    )
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test that a missing column returns the appropriate error message for PySpark DataFrames."""
+    df = create_pyspark_dataframe([1, 2, 3], "col2", spark, "long")
 
     # Test through registry - should return failure message about missing column
     expectation = DataFrameExpectationRegistry.get_expectation(

--- a/tests/expectations/column/any_value_expectations/test_expect_value_null.py
+++ b/tests/expectations/column/any_value_expectations/test_expect_value_null.py
@@ -714,7 +714,7 @@ def test_column_missing_error_pandas():
 def test_column_missing_error_pyspark(spark):
     """Test that a missing column returns the appropriate error message."""
     # Create DataFrame with a different column name (col2 instead of col1)
-    df = create_pyspark_dataframe("pyspark", [None, None, None], "col2", spark, "long")
+    df = create_pyspark_dataframe([None, None, None], "col2", spark, "long")
 
     # Test through registry - should return failure message about missing column
     expectation = DataFrameExpectationRegistry.get_expectation(

--- a/tests/expectations/column/any_value_expectations/test_expect_value_null.py
+++ b/tests/expectations/column/any_value_expectations/test_expect_value_null.py
@@ -9,47 +9,43 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark, data_type="long"):
-    """Helper function to create pandas or pyspark DataFrame.
+def create_pyspark_dataframe(data, column_name, spark, data_type="long"):
+    """Helper function to create a PySpark DataFrame.
 
     Args:
-        df_type: "pandas" or "pyspark"
         data: List of values for the column
         column_name: Name of the column
         spark: Spark session (required for pyspark)
         data_type: Data type for the column - "long", "string", "double", "boolean", "timestamp"
     """
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        from pyspark.sql.types import (
-            StructType,
-            StructField,
-            LongType,
-            StringType,
-            DoubleType,
-            BooleanType,
-            TimestampType,
-        )
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        LongType,
+        StringType,
+        DoubleType,
+        BooleanType,
+        TimestampType,
+    )
 
-        type_mapping = {
-            "long": LongType(),
-            "string": StringType(),
-            "double": DoubleType(),
-            "boolean": BooleanType(),
-            "timestamp": TimestampType(),
-        }
+    type_mapping = {
+        "long": LongType(),
+        "string": StringType(),
+        "double": DoubleType(),
+        "boolean": BooleanType(),
+        "timestamp": TimestampType(),
+    }
 
-        schema = StructType([StructField(column_name, type_mapping[data_type], True)])
-        return spark.createDataFrame([(val,) for val in data], schema)
+    schema = StructType([StructField(column_name, type_mapping[data_type], True)])
+    return spark.createDataFrame([(val,) for val in data], schema)
 
 
 def test_expectation_name():
@@ -68,19 +64,10 @@ def test_expectation_name():
     [
         # Basic integer scenarios - success (all nulls)
         ("pandas", [None, None, None], True, None, None, "long"),
-        ("pyspark", [None, None, None], True, None, None, "long"),
         ("pandas", [None, np.nan, None], True, None, None, "long"),
         # Integer scenarios - violations (with non-null values)
         (
             "pandas",
-            [None, 1, 2],
-            False,
-            [1, 2],
-            "Found 2 row(s) where 'col1' is not null.",
-            "long",
-        ),
-        (
-            "pyspark",
             [None, 1, 2],
             False,
             [1, 2],
@@ -96,14 +83,6 @@ def test_expectation_name():
             "Found 3 row(s) where 'col1' is not null.",
             "long",
         ),
-        (
-            "pyspark",
-            [1, 2, 3],
-            False,
-            [1, 2, 3],
-            "Found 3 row(s) where 'col1' is not null.",
-            "long",
-        ),
         # Single non-null value - violation
         (
             "pandas",
@@ -113,28 +92,11 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not null.",
             "long",
         ),
-        (
-            "pyspark",
-            [None, None, 5],
-            False,
-            [5],
-            "Found 1 row(s) where 'col1' is not null.",
-            "long",
-        ),
         # String data type scenarios - success (all nulls)
         ("pandas", [None, None, None], True, None, None, "string"),
-        ("pyspark", [None, None, None], True, None, None, "string"),
         # String scenarios - violations (with non-null values)
         (
             "pandas",
-            [None, "apple", "banana"],
-            False,
-            ["apple", "banana"],
-            "Found 2 row(s) where 'col1' is not null.",
-            "string",
-        ),
-        (
-            "pyspark",
             [None, "apple", "banana"],
             False,
             ["apple", "banana"],
@@ -150,25 +112,9 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not null.",
             "string",
         ),
-        (
-            "pyspark",
-            [None, "", None],
-            False,
-            [""],
-            "Found 1 row(s) where 'col1' is not null.",
-            "string",
-        ),
         # Whitespace is NOT null - violation
         (
             "pandas",
-            [None, " ", None],
-            False,
-            [" "],
-            "Found 1 row(s) where 'col1' is not null.",
-            "string",
-        ),
-        (
-            "pyspark",
             [None, " ", None],
             False,
             [" "],
@@ -184,29 +130,12 @@ def test_expectation_name():
             "Found 3 row(s) where 'col1' is not null.",
             "string",
         ),
-        (
-            "pyspark",
-            ["", "", ""],
-            False,
-            ["", "", ""],
-            "Found 3 row(s) where 'col1' is not null.",
-            "string",
-        ),
         # Float/Double data type scenarios - success (all nulls)
         ("pandas", [None, None, None], True, None, None, "double"),
-        ("pyspark", [None, None, None], True, None, None, "double"),
         ("pandas", [None, np.nan, None], True, None, None, "double"),
         # Float scenarios - violations (with non-null values)
         (
             "pandas",
-            [None, 1.5, 2.5],
-            False,
-            [1.5, 2.5],
-            "Found 2 row(s) where 'col1' is not null.",
-            "double",
-        ),
-        (
-            "pyspark",
             [None, 1.5, 2.5],
             False,
             [1.5, 2.5],
@@ -223,23 +152,7 @@ def test_expectation_name():
             "double",
         ),
         (
-            "pyspark",
-            [None, 0.0, None],
-            False,
-            [0.0],
-            "Found 1 row(s) where 'col1' is not null.",
-            "double",
-        ),
-        (
             "pandas",
-            [None, 0, None],
-            False,
-            [0],
-            "Found 1 row(s) where 'col1' is not null.",
-            "long",
-        ),
-        (
-            "pyspark",
             [None, 0, None],
             False,
             [0],
@@ -256,23 +169,7 @@ def test_expectation_name():
             "long",
         ),
         (
-            "pyspark",
-            [None, -5, None],
-            False,
-            [-5],
-            "Found 1 row(s) where 'col1' is not null.",
-            "long",
-        ),
-        (
             "pandas",
-            [None, -3.14, None],
-            False,
-            [-3.14],
-            "Found 1 row(s) where 'col1' is not null.",
-            "double",
-        ),
-        (
-            "pyspark",
             [None, -3.14, None],
             False,
             [-3.14],
@@ -281,18 +178,9 @@ def test_expectation_name():
         ),
         # Boolean data type scenarios - success (all nulls)
         ("pandas", [None, None, None], True, None, None, "boolean"),
-        ("pyspark", [None, None, None], True, None, None, "boolean"),
         # Boolean scenarios - violations (with True/False)
         (
             "pandas",
-            [None, True, False],
-            False,
-            [True, False],
-            "Found 2 row(s) where 'col1' is not null.",
-            "boolean",
-        ),
-        (
-            "pyspark",
             [None, True, False],
             False,
             [True, False],
@@ -308,14 +196,6 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not null.",
             "boolean",
         ),
-        (
-            "pyspark",
-            [None, False, None],
-            False,
-            [False],
-            "Found 1 row(s) where 'col1' is not null.",
-            "boolean",
-        ),
         # True is NOT null - violation
         (
             "pandas",
@@ -325,28 +205,11 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not null.",
             "boolean",
         ),
-        (
-            "pyspark",
-            [None, True, None],
-            False,
-            [True],
-            "Found 1 row(s) where 'col1' is not null.",
-            "boolean",
-        ),
         # Timestamp/Datetime scenarios - success (all nulls)
         ("pandas", [None, None, None], True, None, None, "timestamp"),
-        ("pyspark", [None, None, None], True, None, None, "timestamp"),
         # Timestamp scenarios - violations (with datetime values)
         (
             "pandas",
-            [None, datetime(2023, 1, 1), datetime(2023, 1, 2)],
-            False,
-            [datetime(2023, 1, 1), datetime(2023, 1, 2)],
-            "Found 2 row(s) where 'col1' is not null.",
-            "timestamp",
-        ),
-        (
-            "pyspark",
             [None, datetime(2023, 1, 1), datetime(2023, 1, 2)],
             False,
             [datetime(2023, 1, 1), datetime(2023, 1, 2)],
@@ -362,25 +225,9 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not null.",
             "timestamp",
         ),
-        (
-            "pyspark",
-            [None, datetime(2023, 1, 1), None],
-            False,
-            [datetime(2023, 1, 1)],
-            "Found 1 row(s) where 'col1' is not null.",
-            "timestamp",
-        ),
         # Datetime with timezone - violation
         (
             "pandas",
-            [None, datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc), None],
-            False,
-            [datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)],
-            "Found 1 row(s) where 'col1' is not null.",
-            "timestamp",
-        ),
-        (
-            "pyspark",
             [None, datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc), None],
             False,
             [datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)],
@@ -396,14 +243,6 @@ def test_expectation_name():
             "Found 3 row(s) where 'col1' is not null.",
             "long",
         ),
-        (
-            "pyspark",
-            [1, None, 3, None, 5],
-            False,
-            [1, 3, 5],
-            "Found 3 row(s) where 'col1' is not null.",
-            "long",
-        ),
         # Large numbers - violations (NOT null)
         (
             "pandas",
@@ -413,17 +252,8 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not null.",
             "long",
         ),
-        (
-            "pyspark",
-            [None, 1000000, None],
-            False,
-            [1000000],
-            "Found 1 row(s) where 'col1' is not null.",
-            "long",
-        ),
         # Single null - success
         ("pandas", [None], True, None, None, "long"),
-        ("pyspark", [None], True, None, None, "long"),
         # Single non-null - violation
         (
             "pandas",
@@ -433,84 +263,48 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not null.",
             "long",
         ),
-        (
-            "pyspark",
-            [42],
-            False,
-            [42],
-            "Found 1 row(s) where 'col1' is not null.",
-            "long",
-        ),
     ],
     ids=[
         "pandas_int_all_nulls_success",
-        "pyspark_int_all_nulls_success",
         "pandas_int_with_nan_success",
         "pandas_int_with_non_null_violations",
-        "pyspark_int_with_non_null_violations",
         "pandas_int_all_non_null_violations",
-        "pyspark_int_all_non_null_violations",
         "pandas_int_single_non_null_violation",
-        "pyspark_int_single_non_null_violation",
         "pandas_string_all_nulls_success",
-        "pyspark_string_all_nulls_success",
         "pandas_string_with_non_null_violations",
-        "pyspark_string_with_non_null_violations",
         "pandas_string_empty_string_violation",
-        "pyspark_string_empty_string_violation",
         "pandas_string_whitespace_violation",
-        "pyspark_string_whitespace_violation",
         "pandas_string_all_empty_strings_violations",
-        "pyspark_string_all_empty_strings_violations",
         "pandas_double_all_nulls_success",
-        "pyspark_double_all_nulls_success",
         "pandas_double_with_nan_success",
         "pandas_double_with_non_null_violations",
-        "pyspark_double_with_non_null_violations",
         "pandas_double_zero_violation",
-        "pyspark_double_zero_violation",
         "pandas_int_zero_violation",
-        "pyspark_int_zero_violation",
         "pandas_int_negative_violation",
-        "pyspark_int_negative_violation",
         "pandas_double_negative_violation",
-        "pyspark_double_negative_violation",
         "pandas_boolean_all_nulls_success",
-        "pyspark_boolean_all_nulls_success",
         "pandas_boolean_true_false_violations",
-        "pyspark_boolean_true_false_violations",
         "pandas_boolean_false_violation",
-        "pyspark_boolean_false_violation",
         "pandas_boolean_true_violation",
-        "pyspark_boolean_true_violation",
         "pandas_timestamp_all_nulls_success",
-        "pyspark_timestamp_all_nulls_success",
         "pandas_timestamp_with_values_violations",
-        "pyspark_timestamp_with_values_violations",
         "pandas_timestamp_single_value_violation",
-        "pyspark_timestamp_single_value_violation",
         "pandas_timestamp_with_tz_violation",
-        "pyspark_timestamp_with_tz_violation",
         "pandas_multiple_non_nulls_violations",
-        "pyspark_multiple_non_nulls_violations",
         "pandas_large_number_violation",
-        "pyspark_large_number_violation",
         "pandas_single_null_success",
-        "pyspark_single_null_success",
         "pandas_single_non_null_violation",
-        "pyspark_single_non_null_violation",
     ],
 )
-def test_expectation_basic_scenarios(
+def test_expectation_basic_scenarios_pandas(
     df_type,
     data,
     should_succeed,
     expected_violations,
     expected_message,
     data_type,
-    spark,
 ):
-    """Test basic expectation scenarios for both pandas and PySpark DataFrames.
+    """Test basic expectation scenarios for pandas DataFrames.
 
     Tests various data types including:
     - Integers (long): all nulls (success), with non-null values (violations)
@@ -524,7 +318,7 @@ def test_expectation_basic_scenarios(
     Success = all null values, Violations = any non-null values.
     Empty strings, zeros, and False are NOT null and will be violations.
     """
-    df = create_dataframe(df_type, data, "col1", spark, data_type)
+    df = pd.DataFrame({"col1": data})
 
     # Test through registry
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -545,11 +339,319 @@ def test_expectation_basic_scenarios(
             f"Expected message '{expected_message}' in result: {result}"
         )
 
-        # Verify violations if present (skip detailed DataFrame comparison for pandas None values
-        # as representation differs between None and np.nan in display)
-        if expected_violations is not None and df_type == "pyspark":
-            expected_violations_df = create_dataframe(
-                df_type, expected_violations, "col1", spark, data_type
+        # Verify violations using the actual pandas DataFrame slice so dtype/display
+        # (e.g., int columns with None becoming float) matches the runtime message.
+        if expected_violations is not None:
+            expected_violations_df = df[df["col1"].notna()][["col1"]]
+            expected_failure = DataFrameExpectationFailureMessage(
+                expectation_str=str(expectation),
+                data_frame_type=str(df_type),
+                violations_data_frame=expected_violations_df,
+                message=expected_message,
+                limit_violations=5,
+            )
+            assert str(result) == str(expected_failure), (
+                f"Expected failure details don't match. Got: {result}"
+            )
+
+    # Test through suite
+    suite = DataFrameExpectationsSuite().expect_value_null(column_name="col1")
+
+    if should_succeed:
+        suite_result = suite.build().run(data_frame=df)
+        assert suite_result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(suite_result, SuiteExecutionResult), (
+            "Result should be SuiteExecutionResult"
+        )
+        assert suite_result.success, "Expected all expectations to pass"
+        assert suite_result.total_passed == 1, "Expected 1 passed expectation"
+        assert suite_result.total_failed == 0, "Expected 0 failed expectations"
+    else:
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            suite.build().run(data_frame=df)
+
+
+@pytest.mark.pyspark
+@pytest.mark.parametrize(
+    "df_type, data, should_succeed, expected_violations, expected_message, data_type",
+    [
+        # Basic integer scenarios - success (all nulls)
+        ("pyspark", [None, None, None], True, None, None, "long"),
+        # Integer scenarios - violations (with non-null values)
+        (
+            "pyspark",
+            [None, 1, 2],
+            False,
+            [1, 2],
+            "Found 2 row(s) where 'col1' is not null.",
+            "long",
+        ),
+        # All non-null values - violations
+        (
+            "pyspark",
+            [1, 2, 3],
+            False,
+            [1, 2, 3],
+            "Found 3 row(s) where 'col1' is not null.",
+            "long",
+        ),
+        # Single non-null value - violation
+        (
+            "pyspark",
+            [None, None, 5],
+            False,
+            [5],
+            "Found 1 row(s) where 'col1' is not null.",
+            "long",
+        ),
+        # String data type scenarios - success (all nulls)
+        ("pyspark", [None, None, None], True, None, None, "string"),
+        # String scenarios - violations (with non-null values)
+        (
+            "pyspark",
+            [None, "apple", "banana"],
+            False,
+            ["apple", "banana"],
+            "Found 2 row(s) where 'col1' is not null.",
+            "string",
+        ),
+        # Empty string is NOT null - violation
+        (
+            "pyspark",
+            [None, "", None],
+            False,
+            [""],
+            "Found 1 row(s) where 'col1' is not null.",
+            "string",
+        ),
+        # Whitespace is NOT null - violation
+        (
+            "pyspark",
+            [None, " ", None],
+            False,
+            [" "],
+            "Found 1 row(s) where 'col1' is not null.",
+            "string",
+        ),
+        # All empty strings - violations (empty strings are NOT null)
+        (
+            "pyspark",
+            ["", "", ""],
+            False,
+            ["", "", ""],
+            "Found 3 row(s) where 'col1' is not null.",
+            "string",
+        ),
+        # Float/Double data type scenarios - success (all nulls)
+        ("pyspark", [None, None, None], True, None, None, "double"),
+        # Float scenarios - violations (with non-null values)
+        (
+            "pyspark",
+            [None, 1.5, 2.5],
+            False,
+            [1.5, 2.5],
+            "Found 2 row(s) where 'col1' is not null.",
+            "double",
+        ),
+        # Zero is NOT null - violation
+        (
+            "pyspark",
+            [None, 0.0, None],
+            False,
+            [0.0],
+            "Found 1 row(s) where 'col1' is not null.",
+            "double",
+        ),
+        (
+            "pyspark",
+            [None, 0, None],
+            False,
+            [0],
+            "Found 1 row(s) where 'col1' is not null.",
+            "long",
+        ),
+        # Negative numbers are NOT null - violations
+        (
+            "pyspark",
+            [None, -5, None],
+            False,
+            [-5],
+            "Found 1 row(s) where 'col1' is not null.",
+            "long",
+        ),
+        (
+            "pyspark",
+            [None, -3.14, None],
+            False,
+            [-3.14],
+            "Found 1 row(s) where 'col1' is not null.",
+            "double",
+        ),
+        # Boolean data type scenarios - success (all nulls)
+        ("pyspark", [None, None, None], True, None, None, "boolean"),
+        # Boolean scenarios - violations (with True/False)
+        (
+            "pyspark",
+            [None, True, False],
+            False,
+            [True, False],
+            "Found 2 row(s) where 'col1' is not null.",
+            "boolean",
+        ),
+        # False is NOT null - violation
+        (
+            "pyspark",
+            [None, False, None],
+            False,
+            [False],
+            "Found 1 row(s) where 'col1' is not null.",
+            "boolean",
+        ),
+        # True is NOT null - violation
+        (
+            "pyspark",
+            [None, True, None],
+            False,
+            [True],
+            "Found 1 row(s) where 'col1' is not null.",
+            "boolean",
+        ),
+        # Timestamp/Datetime scenarios - success (all nulls)
+        ("pyspark", [None, None, None], True, None, None, "timestamp"),
+        # Timestamp scenarios - violations (with datetime values)
+        (
+            "pyspark",
+            [None, datetime(2023, 1, 1), datetime(2023, 1, 2)],
+            False,
+            [datetime(2023, 1, 1), datetime(2023, 1, 2)],
+            "Found 2 row(s) where 'col1' is not null.",
+            "timestamp",
+        ),
+        # Single datetime - violation
+        (
+            "pyspark",
+            [None, datetime(2023, 1, 1), None],
+            False,
+            [datetime(2023, 1, 1)],
+            "Found 1 row(s) where 'col1' is not null.",
+            "timestamp",
+        ),
+        # Datetime with timezone - violation
+        (
+            "pyspark",
+            [None, datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc), None],
+            False,
+            [datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)],
+            "Found 1 row(s) where 'col1' is not null.",
+            "timestamp",
+        ),
+        # Multiple non-nulls in different positions
+        (
+            "pyspark",
+            [1, None, 3, None, 5],
+            False,
+            [1, 3, 5],
+            "Found 3 row(s) where 'col1' is not null.",
+            "long",
+        ),
+        # Large numbers - violations (NOT null)
+        (
+            "pyspark",
+            [None, 1000000, None],
+            False,
+            [1000000],
+            "Found 1 row(s) where 'col1' is not null.",
+            "long",
+        ),
+        # Single null - success
+        ("pyspark", [None], True, None, None, "long"),
+        # Single non-null - violation
+        (
+            "pyspark",
+            [42],
+            False,
+            [42],
+            "Found 1 row(s) where 'col1' is not null.",
+            "long",
+        ),
+    ],
+    ids=[
+        "pyspark_int_all_nulls_success",
+        "pyspark_int_with_non_null_violations",
+        "pyspark_int_all_non_null_violations",
+        "pyspark_int_single_non_null_violation",
+        "pyspark_string_all_nulls_success",
+        "pyspark_string_with_non_null_violations",
+        "pyspark_string_empty_string_violation",
+        "pyspark_string_whitespace_violation",
+        "pyspark_string_all_empty_strings_violations",
+        "pyspark_double_all_nulls_success",
+        "pyspark_double_with_non_null_violations",
+        "pyspark_double_zero_violation",
+        "pyspark_int_zero_violation",
+        "pyspark_int_negative_violation",
+        "pyspark_double_negative_violation",
+        "pyspark_boolean_all_nulls_success",
+        "pyspark_boolean_true_false_violations",
+        "pyspark_boolean_false_violation",
+        "pyspark_boolean_true_violation",
+        "pyspark_timestamp_all_nulls_success",
+        "pyspark_timestamp_with_values_violations",
+        "pyspark_timestamp_single_value_violation",
+        "pyspark_timestamp_with_tz_violation",
+        "pyspark_multiple_non_nulls_violations",
+        "pyspark_large_number_violation",
+        "pyspark_single_null_success",
+        "pyspark_single_non_null_violation",
+    ],
+)
+def test_expectation_basic_scenarios_pyspark(
+    df_type,
+    data,
+    should_succeed,
+    expected_violations,
+    expected_message,
+    data_type,
+    spark,
+):
+    """Test basic expectation scenarios for PySpark DataFrames.
+
+    Tests various data types including:
+    - Integers (long): all nulls (success), with non-null values (violations)
+    - Strings: all nulls (success), empty strings (NOT null - violation), whitespace (NOT null - violation)
+    - Floats (double): all nulls (success), zero values (NOT null - violation), negative values (NOT null - violation)
+    - Booleans: all nulls (success), True/False (NOT null - violations)
+    - Timestamps: all nulls (success), with datetime values (violations)
+    - Edge cases: missing columns, single null, single non-null, multiple non-nulls
+
+    Note: ExpectationValueNull checks that ALL values ARE null.
+    Success = all null values, Violations = any non-null values.
+    Empty strings, zeros, and False are NOT null and will be violations.
+    """
+    df = create_pyspark_dataframe(data, "col1", spark, data_type)
+
+    # Test through registry
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueNull",
+        column_name="col1",
+    )
+    result = expectation.validate(data_frame=df)
+
+    if should_succeed:
+        assert isinstance(result, DataFrameExpectationSuccessMessage), (
+            f"Expected success but got: {result}"
+        )
+    else:
+        assert isinstance(result, DataFrameExpectationFailureMessage), (
+            f"Expected failure but got: {result}"
+        )
+        assert expected_message in str(result), (
+            f"Expected message '{expected_message}' in result: {result}"
+        )
+
+        if expected_violations is not None:
+            expected_violations_df = create_pyspark_dataframe(
+                expected_violations, "col1", spark, data_type
             )
             expected_failure = DataFrameExpectationFailureMessage(
                 expectation_str=str(expectation),
@@ -579,15 +681,40 @@ def test_expectation_basic_scenarios(
             suite.build().run(data_frame=df)
 
 
-@pytest.mark.parametrize(
-    "df_type",
-    [("pandas"), ("pyspark")],
-    ids=["pandas", "pyspark"],
-)
-def test_column_missing_error(df_type, spark):
+def test_column_missing_error_pandas():
     """Test that a missing column returns the appropriate error message."""
     # Create DataFrame with a different column name (col2 instead of col1)
-    df = create_dataframe(df_type, [None, None, None], "col2", spark, "long")
+    df = pd.DataFrame({"col2": [None, None, None]})
+
+    # Test through registry - should return failure message about missing column
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueNull",
+        column_name="col1",
+    )
+    result = expectation.validate(data_frame=df)
+
+    assert isinstance(result, DataFrameExpectationFailureMessage), (
+        f"Expected DataFrameExpectationFailureMessage but got: {type(result)}"
+    )
+    assert "Column 'col1' does not exist in the DataFrame" in str(result), (
+        f"Expected missing column message but got: {result}"
+    )
+
+    # Test through suite - should raise DataFrameExpectationsSuiteFailure
+    suite = DataFrameExpectationsSuite().expect_value_null(column_name="col1")
+    with pytest.raises(DataFrameExpectationsSuiteFailure) as exc_info:
+        suite.build().run(data_frame=df)
+
+    assert "Column 'col1' does not exist in the DataFrame" in str(exc_info.value), (
+        f"Expected missing column message in suite failure but got: {exc_info.value}"
+    )
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test that a missing column returns the appropriate error message."""
+    # Create DataFrame with a different column name (col2 instead of col1)
+    df = create_pyspark_dataframe("pyspark", [None, None, None], "col2", spark, "long")
 
     # Test through registry - should return failure message about missing column
     expectation = DataFrameExpectationRegistry.get_expectation(

--- a/tests/expectations/column/numerical_expectations/test_expect_value_between.py
+++ b/tests/expectations/column/numerical_expectations/test_expect_value_between.py
@@ -7,41 +7,37 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark, data_type="long"):
-    """Helper function to create pandas or pyspark DataFrame.
+def create_pyspark_dataframe(data, column_name, spark, data_type="long"):
+    """Helper function to create a PySpark DataFrame.
 
     Args:
-        df_type: "pandas" or "pyspark"
         data: List of values for the column
         column_name: Name of the column
         spark: Spark session (required for pyspark)
         data_type: Data type for the column - "long", "double"
     """
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        from pyspark.sql.types import (
-            StructType,
-            StructField,
-            LongType,
-            DoubleType,
-        )
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        LongType,
+        DoubleType,
+    )
 
-        type_mapping = {
-            "long": LongType(),
-            "double": DoubleType(),
-        }
+    type_mapping = {
+        "long": LongType(),
+        "double": DoubleType(),
+    }
 
-        schema = StructType([StructField(column_name, type_mapping[data_type], True)])
-        return spark.createDataFrame([(val,) for val in data], schema)
+    schema = StructType([StructField(column_name, type_mapping[data_type], True)])
+    return spark.createDataFrame([(val,) for val in data], schema)
 
 
 def test_expectation_name():
@@ -62,29 +58,13 @@ def test_expectation_name():
     [
         # Basic success - pandas
         ("pandas", [2, 3, 4, 5], 2, 5, "success", None, None),
-        # Basic success - pyspark
-        ("pyspark", [2, 3, 4, 5], 2, 5, "success", None, None),
         # Subset success - pandas
         ("pandas", [3, 4], 2, 5, "success", None, None),
-        # Subset success - pyspark
-        ("pyspark", [3, 4], 2, 5, "success", None, None),
         # Identical values - pandas
         ("pandas", [5, 5, 5, 5], 2, 5, "success", None, None),
-        # Identical values - pyspark
-        ("pyspark", [5, 5, 5, 5], 2, 5, "success", None, None),
         # Basic violations - pandas
         (
             "pandas",
-            [1, 2, 3, 6],
-            2,
-            5,
-            "failure",
-            [1, 6],
-            "Found 2 row(s) where 'col1' is not between 2 and 5.",
-        ),
-        # Basic violations - pyspark
-        (
-            "pyspark",
             [1, 2, 3, 6],
             2,
             5,
@@ -102,41 +82,15 @@ def test_expectation_name():
             [0, 1, 6, 7],
             "Found 4 row(s) where 'col1' is not between 2 and 5.",
         ),
-        # All violations - pyspark
-        (
-            "pyspark",
-            [0, 1, 6, 7],
-            2,
-            5,
-            "failure",
-            [0, 1, 6, 7],
-            "Found 4 row(s) where 'col1' is not between 2 and 5.",
-        ),
         # Boundary exact min - pandas
         ("pandas", [2, 2, 2], 2, 5, "success", None, None),
-        # Boundary exact min - pyspark
-        ("pyspark", [2, 2, 2], 2, 5, "success", None, None),
         # Boundary exact max - pandas
         ("pandas", [5, 5, 5], 2, 5, "success", None, None),
-        # Boundary exact max - pyspark
-        ("pyspark", [5, 5, 5], 2, 5, "success", None, None),
         # Boundary min max - pandas
         ("pandas", [2, 3, 4, 5], 2, 5, "success", None, None),
-        # Boundary min max - pyspark
-        ("pyspark", [2, 3, 4, 5], 2, 5, "success", None, None),
         # Boundary below min - pandas
         (
             "pandas",
-            [1, 2, 3],
-            2,
-            5,
-            "failure",
-            [1],
-            "Found 1 row(s) where 'col1' is not between 2 and 5.",
-        ),
-        # Boundary below min - pyspark
-        (
-            "pyspark",
             [1, 2, 3],
             2,
             5,
@@ -154,24 +108,10 @@ def test_expectation_name():
             [6],
             "Found 1 row(s) where 'col1' is not between 2 and 5.",
         ),
-        # Boundary above max - pyspark
-        (
-            "pyspark",
-            [3, 4, 6],
-            2,
-            5,
-            "failure",
-            [6],
-            "Found 1 row(s) where 'col1' is not between 2 and 5.",
-        ),
         # Negative success - pandas
         ("pandas", [-5, -3, -2, 0], -5, 0, "success", None, None),
-        # Negative success - pyspark
-        ("pyspark", [-5, -3, -2, 0], -5, 0, "success", None, None),
         # Negative range success - pandas
         ("pandas", [-10, -8, -6], -10, -5, "success", None, None),
-        # Negative range success - pyspark
-        ("pyspark", [-10, -8, -6], -10, -5, "success", None, None),
         # Negative violations - pandas
         (
             "pandas",
@@ -182,24 +122,10 @@ def test_expectation_name():
             [-6, 1],
             "Found 2 row(s) where 'col1' is not between -5 and 0.",
         ),
-        # Negative violations - pyspark
-        (
-            "pyspark",
-            [-6, -3, 1],
-            -5,
-            0,
-            "failure",
-            [-6, 1],
-            "Found 2 row(s) where 'col1' is not between -5 and 0.",
-        ),
         # Float success - pandas
         ("pandas", [2.5, 3.7, 4.2], 2.0, 5.0, "success", None, None),
-        # Float success - pyspark
-        ("pyspark", [2.5, 3.7, 4.2], 2.0, 5.0, "success", None, None),
         # Float mixed success - pandas
         ("pandas", [2.0, 2.5, 3.0, 4.5, 5.0], 2.0, 5.0, "success", None, None),
-        # Float mixed success - pyspark
-        ("pyspark", [2.0, 2.5, 3.0, 4.5, 5.0], 2.0, 5.0, "success", None, None),
         # Float violations - pandas
         (
             "pandas",
@@ -210,28 +136,12 @@ def test_expectation_name():
             [1.5, 5.5],
             "Found 2 row(s) where 'col1' is not between 2.0 and 5.0.",
         ),
-        # Float violations - pyspark
-        (
-            "pyspark",
-            [1.5, 2.5, 5.5],
-            2.0,
-            5.0,
-            "failure",
-            [1.5, 5.5],
-            "Found 2 row(s) where 'col1' is not between 2.0 and 5.0.",
-        ),
         # Zero in range - pandas
         ("pandas", [-2, -1, 0, 1, 2], -2, 2, "success", None, None),
-        # Zero in range - pyspark
-        ("pyspark", [-2, -1, 0, 1, 2], -2, 2, "success", None, None),
         # All zeros - pandas
         ("pandas", [0, 0, 0], 0, 1, "success", None, None),
-        # All zeros - pyspark
-        ("pyspark", [0, 0, 0], 0, 1, "success", None, None),
         # Single value success - pandas
         ("pandas", [3], 2, 5, "success", None, None),
-        # Single value success - pyspark
-        ("pyspark", [3], 2, 5, "success", None, None),
         # Single value violation - pandas
         (
             "pandas",
@@ -240,16 +150,6 @@ def test_expectation_name():
             5,
             "failure",
             [1],
-            "Found 1 row(s) where 'col1' is not between 2 and 5.",
-        ),
-        # Single value violation - pyspark
-        (
-            "pyspark",
-            [6],
-            2,
-            5,
-            "failure",
-            [6],
             "Found 1 row(s) where 'col1' is not between 2 and 5.",
         ),
         # Mixed integers and floats - pandas
@@ -265,21 +165,9 @@ def test_expectation_name():
         ),
         # Large range success - pandas
         ("pandas", [100, 500, 900], 0, 1000, "success", None, None),
-        # Large range success - pyspark
-        ("pyspark", [100, 500, 900], 0, 1000, "success", None, None),
         # Large range violations - pandas
         (
             "pandas",
-            [-100, 500, 1100],
-            0,
-            1000,
-            "failure",
-            [-100, 1100],
-            "Found 2 row(s) where 'col1' is not between 0 and 1000.",
-        ),
-        # Large range violations - pyspark
-        (
-            "pyspark",
             [-100, 500, 1100],
             0,
             1000,
@@ -297,16 +185,6 @@ def test_expectation_name():
             [0, 1, 1],
             "Found 3 row(s) where 'col1' is not between 2 and 5.",
         ),
-        # All below range - pyspark
-        (
-            "pyspark",
-            [0, 1, 1],
-            2,
-            5,
-            "failure",
-            [0, 1, 1],
-            "Found 3 row(s) where 'col1' is not between 2 and 5.",
-        ),
         # All above range - pandas
         (
             "pandas",
@@ -317,20 +195,8 @@ def test_expectation_name():
             [6, 7, 8],
             "Found 3 row(s) where 'col1' is not between 2 and 5.",
         ),
-        # All above range - pyspark
-        (
-            "pyspark",
-            [6, 7, 8],
-            2,
-            5,
-            "failure",
-            [6, 7, 8],
-            "Found 3 row(s) where 'col1' is not between 2 and 5.",
-        ),
         # With nulls success - pandas
         ("pandas", [2, None, 3, None, 4], 2, 5, "success", None, None),
-        # With nulls success - pyspark
-        ("pyspark", [2, None, 3, None, 4], 2, 5, "success", None, None),
         # With nulls violations - pandas
         (
             "pandas",
@@ -341,75 +207,50 @@ def test_expectation_name():
             [1.0, 6.0],
             "Found 2 row(s) where 'col1' is not between 2 and 5.",
         ),
-        # With nulls violations - pyspark
+        # With nulls violations (ints) - pandas
         (
-            "pyspark",
+            "pandas",
             [1, None, 3, 6],
             2,
             5,
             "failure",
-            [1, 6],
+            [1.0, 6.0],
             "Found 2 row(s) where 'col1' is not between 2 and 5.",
         ),
     ],
     ids=[
         "pandas_basic_success",
-        "pyspark_basic_success",
         "pandas_subset_success",
-        "pyspark_subset_success",
         "pandas_identical_values",
-        "pyspark_identical_values",
         "pandas_basic_violations",
-        "pyspark_basic_violations",
         "pandas_all_violations",
-        "pyspark_all_violations",
         "pandas_boundary_exact_min",
-        "pyspark_boundary_exact_min",
         "pandas_boundary_exact_max",
-        "pyspark_boundary_exact_max",
         "pandas_boundary_min_max",
-        "pyspark_boundary_min_max",
         "pandas_boundary_below_min",
-        "pyspark_boundary_below_min",
         "pandas_boundary_above_max",
-        "pyspark_boundary_above_max",
         "pandas_negative_success",
-        "pyspark_negative_success",
         "pandas_negative_range_success",
-        "pyspark_negative_range_success",
         "pandas_negative_violations",
-        "pyspark_negative_violations",
         "pandas_float_success",
-        "pyspark_float_success",
         "pandas_float_mixed_success",
-        "pyspark_float_mixed_success",
         "pandas_float_violations",
-        "pyspark_float_violations",
         "pandas_zero_in_range",
-        "pyspark_zero_in_range",
         "pandas_all_zeros",
-        "pyspark_all_zeros",
         "pandas_single_value_success",
-        "pyspark_single_value_success",
         "pandas_single_value_violation",
-        "pyspark_single_value_violation",
         "pandas_mixed_types_success",
         "pandas_mixed_types_violations",
         "pandas_large_range_success",
-        "pyspark_large_range_success",
         "pandas_large_range_violations",
-        "pyspark_large_range_violations",
         "pandas_all_below_range",
-        "pyspark_all_below_range",
         "pandas_all_above_range",
-        "pyspark_all_above_range",
         "pandas_with_nulls_success",
-        "pyspark_with_nulls_success",
         "pandas_with_nulls_violations",
-        "pyspark_with_nulls_violations",
+        "pandas_with_nulls_violations_int",
     ],
 )
-def test_expectation_basic_scenarios(
+def test_expectation_basic_scenarios_pandas(
     df_type,
     data,
     min_value,
@@ -417,7 +258,6 @@ def test_expectation_basic_scenarios(
     expected_result,
     expected_violations,
     expected_message,
-    spark,
 ):
     """
     Test the expectation for various scenarios across pandas and PySpark DataFrames.
@@ -425,10 +265,7 @@ def test_expectation_basic_scenarios(
     Covers: success cases, boundary conditions, violations, negative values, floats,
     zero values, single values, mixed types, large ranges, and nulls.
     """
-    # Determine data type based on whether we have float values (excluding None)
-    has_float = any(isinstance(val, float) for val in data if val is not None)
-    data_type = "double" if has_float else "long"
-    data_frame = create_dataframe(df_type, data, "col1", spark, data_type)
+    data_frame = pd.DataFrame({"col1": data})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -445,12 +282,10 @@ def test_expectation_basic_scenarios(
             DataFrameExpectationSuccessMessage(expectation_name="ExpectationValueBetween")
         ), f"Expected success message but got: {result}"
     else:  # failure
-        expected_violations_df = create_dataframe(
-            df_type, expected_violations, "col1", spark, data_type
-        )
+        expected_violations_df = pd.DataFrame({"col1": expected_violations})
         expected_failure_message = DataFrameExpectationFailureMessage(
             expectation_str=str(expectation),
-            data_frame_type=str(df_type),
+            data_frame_type=df_type,
             violations_data_frame=expected_violations_df,
             message=expected_message,
             limit_violations=5,
@@ -476,19 +311,247 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
+@pytest.mark.pyspark
 @pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
+    "df_type, data, min_value, max_value, expected_result, expected_violations, expected_message",
+    [
+        # Basic success - pyspark
+        ("pyspark", [2, 3, 4, 5], 2, 5, "success", None, None),
+        # Subset success - pyspark
+        ("pyspark", [3, 4], 2, 5, "success", None, None),
+        # Identical values - pyspark
+        ("pyspark", [5, 5, 5, 5], 2, 5, "success", None, None),
+        # Basic violations - pyspark
+        (
+            "pyspark",
+            [1, 2, 3, 6],
+            2,
+            5,
+            "failure",
+            [1, 6],
+            "Found 2 row(s) where 'col1' is not between 2 and 5.",
+        ),
+        # All violations - pyspark
+        (
+            "pyspark",
+            [0, 1, 6, 7],
+            2,
+            5,
+            "failure",
+            [0, 1, 6, 7],
+            "Found 4 row(s) where 'col1' is not between 2 and 5.",
+        ),
+        # Boundary exact min - pyspark
+        ("pyspark", [2, 2, 2], 2, 5, "success", None, None),
+        # Boundary exact max - pyspark
+        ("pyspark", [5, 5, 5], 2, 5, "success", None, None),
+        # Boundary min max - pyspark
+        ("pyspark", [2, 3, 4, 5], 2, 5, "success", None, None),
+        # Boundary below min - pyspark
+        (
+            "pyspark",
+            [1, 2, 3],
+            2,
+            5,
+            "failure",
+            [1],
+            "Found 1 row(s) where 'col1' is not between 2 and 5.",
+        ),
+        # Boundary above max - pyspark
+        (
+            "pyspark",
+            [3, 4, 6],
+            2,
+            5,
+            "failure",
+            [6],
+            "Found 1 row(s) where 'col1' is not between 2 and 5.",
+        ),
+        # Negative success - pyspark
+        ("pyspark", [-5, -3, -2, 0], -5, 0, "success", None, None),
+        # Negative range success - pyspark
+        ("pyspark", [-10, -8, -6], -10, -5, "success", None, None),
+        # Negative violations - pyspark
+        (
+            "pyspark",
+            [-6, -3, 1],
+            -5,
+            0,
+            "failure",
+            [-6, 1],
+            "Found 2 row(s) where 'col1' is not between -5 and 0.",
+        ),
+        # Float success - pyspark
+        ("pyspark", [2.5, 3.7, 4.2], 2.0, 5.0, "success", None, None),
+        # Float mixed success - pyspark
+        ("pyspark", [2.0, 2.5, 3.0, 4.5, 5.0], 2.0, 5.0, "success", None, None),
+        # Float violations - pyspark
+        (
+            "pyspark",
+            [1.5, 2.5, 5.5],
+            2.0,
+            5.0,
+            "failure",
+            [1.5, 5.5],
+            "Found 2 row(s) where 'col1' is not between 2.0 and 5.0.",
+        ),
+        # Zero in range - pyspark
+        ("pyspark", [-2, -1, 0, 1, 2], -2, 2, "success", None, None),
+        # All zeros - pyspark
+        ("pyspark", [0, 0, 0], 0, 1, "success", None, None),
+        # Single value success - pyspark
+        ("pyspark", [3], 2, 5, "success", None, None),
+        # Single value violation - pyspark
+        (
+            "pyspark",
+            [6],
+            2,
+            5,
+            "failure",
+            [6],
+            "Found 1 row(s) where 'col1' is not between 2 and 5.",
+        ),
+        # Large range success - pyspark
+        ("pyspark", [100, 500, 900], 0, 1000, "success", None, None),
+        # Large range violations - pyspark
+        (
+            "pyspark",
+            [-100, 500, 1100],
+            0,
+            1000,
+            "failure",
+            [-100, 1100],
+            "Found 2 row(s) where 'col1' is not between 0 and 1000.",
+        ),
+        # All below range - pyspark
+        (
+            "pyspark",
+            [0, 1, 1],
+            2,
+            5,
+            "failure",
+            [0, 1, 1],
+            "Found 3 row(s) where 'col1' is not between 2 and 5.",
+        ),
+        # All above range - pyspark
+        (
+            "pyspark",
+            [6, 7, 8],
+            2,
+            5,
+            "failure",
+            [6, 7, 8],
+            "Found 3 row(s) where 'col1' is not between 2 and 5.",
+        ),
+        # With nulls success - pyspark
+        ("pyspark", [2, None, 3, None, 4], 2, 5, "success", None, None),
+        # With nulls violations - pyspark
+        (
+            "pyspark",
+            [1, None, 3, 6],
+            2,
+            5,
+            "failure",
+            [1, 6],
+            "Found 2 row(s) where 'col1' is not between 2 and 5.",
+        ),
+    ],
+    ids=[
+        "pyspark_basic_success",
+        "pyspark_subset_success",
+        "pyspark_identical_values",
+        "pyspark_basic_violations",
+        "pyspark_all_violations",
+        "pyspark_boundary_exact_min",
+        "pyspark_boundary_exact_max",
+        "pyspark_boundary_min_max",
+        "pyspark_boundary_below_min",
+        "pyspark_boundary_above_max",
+        "pyspark_negative_success",
+        "pyspark_negative_range_success",
+        "pyspark_negative_violations",
+        "pyspark_float_success",
+        "pyspark_float_mixed_success",
+        "pyspark_float_violations",
+        "pyspark_zero_in_range",
+        "pyspark_all_zeros",
+        "pyspark_single_value_success",
+        "pyspark_single_value_violation",
+        "pyspark_large_range_success",
+        "pyspark_large_range_violations",
+        "pyspark_all_below_range",
+        "pyspark_all_above_range",
+        "pyspark_with_nulls_success",
+        "pyspark_with_nulls_violations",
+    ],
 )
-def test_column_missing_error(df_type, spark):
-    """Test that an error is raised when the specified column is missing in both pandas and PySpark."""
+def test_expectation_basic_scenarios_pyspark(
+    df_type,
+    data,
+    min_value,
+    max_value,
+    expected_result,
+    expected_violations,
+    expected_message,
+    spark,
+):
+    """
+    Test the expectation for various scenarios for PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    """
+    has_float = any(isinstance(val, float) for val in data if val is not None)
+    data_type = "double" if has_float else "long"
+    data_frame = create_pyspark_dataframe(data, "col1", spark, data_type)
+
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueBetween",
+        column_name="col1",
+        min_value=min_value,
+        max_value=max_value,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationValueBetween")
+        ), f"Expected success message but got: {result}"
+    else:
+        expected_violations_df = create_pyspark_dataframe(
+            expected_violations, "col1", spark, data_type
+        )
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=df_type,
+            violations_data_frame=expected_violations_df,
+            message=expected_message,
+            limit_violations=5,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    expectations_suite = DataFrameExpectationsSuite().expect_value_between(
+        column_name="col1", min_value=min_value, max_value=max_value
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+def test_column_missing_error_pandas():
+    """Test that an error is raised when the specified column is missing in pandas."""
     expected_message = "Column 'col1' does not exist in the DataFrame."
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col2": [2, 3, 4]})
-    else:  # pyspark
-        data_frame = spark.createDataFrame([(2,), (3,), (4,)], ["col2"])
+    data_frame = pd.DataFrame({"col2": [2, 3, 4]})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -500,12 +563,40 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=data_frame)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
         message=expected_message,
     )
     assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
 
     # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_value_between(
+        column_name="col1", min_value=2, max_value=5
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test that an error is raised when the specified column is missing in PySpark."""
+    expected_message = "Column 'col1' does not exist in the DataFrame."
+
+    data_frame = spark.createDataFrame([(2,), (3,), (4,)], ["col2"])
+
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueBetween",
+        column_name="col1",
+        min_value=2,
+        max_value=5,
+    )
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
+
     expectations_suite = DataFrameExpectationsSuite().expect_value_between(
         column_name="col1", min_value=2, max_value=5
     )

--- a/tests/expectations/column/numerical_expectations/test_expect_value_between.py
+++ b/tests/expectations/column/numerical_expectations/test_expect_value_between.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 import pandas as pd
 
 from dataframe_expectations.registry import (
@@ -606,8 +607,6 @@ def test_column_missing_error_pyspark(spark):
 
 def test_large_dataset_performance():
     """Test the expectation with a larger dataset to ensure performance."""
-    import numpy as np
-
     # Create a larger dataset with values between 10 and 100
     large_data = np.random.uniform(10, 100, 10000).tolist()
     data_frame = pd.DataFrame({"col1": large_data})

--- a/tests/expectations/column/numerical_expectations/test_expect_value_greater_than.py
+++ b/tests/expectations/column/numerical_expectations/test_expect_value_greater_than.py
@@ -7,45 +7,41 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark, data_type="long"):
-    """Helper function to create pandas or pyspark DataFrame.
+def create_pyspark_dataframe(data, column_name, spark, data_type="long"):
+    """Helper function to create a PySpark DataFrame.
 
     Args:
-        df_type: "pandas" or "pyspark"
         data: List of values for the column
         column_name: Name of the column
         spark: Spark session (required for pyspark)
         data_type: Data type for the column - "long", "double"
     """
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        from pyspark.sql.types import (
-            StructType,
-            StructField,
-            LongType,
-            DoubleType,
-        )
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        LongType,
+        DoubleType,
+    )
 
-        type_mapping = {
-            "long": LongType(),
-            "double": DoubleType(),
-        }
+    type_mapping = {
+        "long": LongType(),
+        "double": DoubleType(),
+    }
 
-        # Convert integers to floats when using double type to avoid type mismatch
-        if data_type == "double":
-            data = [float(val) if val is not None else None for val in data]
+    # Convert integers to floats when using double type to avoid type mismatch
+    if data_type == "double":
+        data = [float(val) if val is not None else None for val in data]
 
-        schema = StructType([StructField(column_name, type_mapping[data_type], True)])
-        return spark.createDataFrame([(val,) for val in data], schema)
+    schema = StructType([StructField(column_name, type_mapping[data_type], True)])
+    return spark.createDataFrame([(val,) for val in data], schema)
 
 
 def test_expectation_name():
@@ -65,11 +61,8 @@ def test_expectation_name():
     [
         # Basic success scenarios
         ("pandas", [3, 4, 5], 2, "success", None, None),
-        ("pyspark", [3, 4, 5], 2, "success", None, None),
         ("pandas", [4, 5, 6], 3, "success", None, None),
-        ("pyspark", [4, 5, 6], 3, "success", None, None),
         ("pandas", [10, 20, 30], 5, "success", None, None),
-        ("pyspark", [10, 20, 30], 5, "success", None, None),
         # Basic violation scenarios
         (
             "pandas",
@@ -80,14 +73,6 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not greater than 3.",
         ),
         (
-            "pyspark",
-            [3, 4, 5],
-            3,
-            "failure",
-            [3],
-            "Found 1 row(s) where 'col1' is not greater than 3.",
-        ),
-        (
             "pandas",
             [1, 2, 3],
             3,
@@ -96,23 +81,7 @@ def test_expectation_name():
             "Found 3 row(s) where 'col1' is not greater than 3.",
         ),
         (
-            "pyspark",
-            [1, 2, 3],
-            3,
-            "failure",
-            [1, 2, 3],
-            "Found 3 row(s) where 'col1' is not greater than 3.",
-        ),
-        (
             "pandas",
-            [2, 3, 4, 5],
-            4,
-            "failure",
-            [2, 3, 4],
-            "Found 3 row(s) where 'col1' is not greater than 4.",
-        ),
-        (
-            "pyspark",
             [2, 3, 4, 5],
             4,
             "failure",
@@ -121,9 +90,7 @@ def test_expectation_name():
         ),
         # Boundary conditions - just above threshold
         ("pandas", [3, 4, 5], 2, "success", None, None),
-        ("pyspark", [3, 4, 5], 2, "success", None, None),
         ("pandas", [2.1, 3, 4], 2, "success", None, None),
-        ("pyspark", [2.1, 3, 4], 2, "success", None, None),
         # Boundary conditions - at threshold (violation)
         (
             "pandas",
@@ -134,23 +101,7 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not greater than 2.",
         ),
         (
-            "pyspark",
-            [2, 3, 4],
-            2,
-            "failure",
-            [2],
-            "Found 1 row(s) where 'col1' is not greater than 2.",
-        ),
-        (
             "pandas",
-            [5, 5, 5],
-            5,
-            "failure",
-            [5, 5, 5],
-            "Found 3 row(s) where 'col1' is not greater than 5.",
-        ),
-        (
-            "pyspark",
             [5, 5, 5],
             5,
             "failure",
@@ -166,21 +117,10 @@ def test_expectation_name():
             [1, 2],
             "Found 2 row(s) where 'col1' is not greater than 2.",
         ),
-        (
-            "pyspark",
-            [1, 2, 3],
-            2,
-            "failure",
-            [1, 2],
-            "Found 2 row(s) where 'col1' is not greater than 2.",
-        ),
         # Negative values - success
         ("pandas", [0, 1, 2], -1, "success", None, None),
-        ("pyspark", [0, 1, 2], -1, "success", None, None),
         ("pandas", [-2, -1, 0], -3, "success", None, None),
-        ("pyspark", [-2, -1, 0], -3, "success", None, None),
         ("pandas", [-5, -3, 0], -10, "success", None, None),
-        ("pyspark", [-5, -3, 0], -10, "success", None, None),
         # Negative values - violations
         (
             "pandas",
@@ -191,23 +131,7 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is not greater than -2.",
         ),
         (
-            "pyspark",
-            [-3, -2, -1],
-            -2,
-            "failure",
-            [-3, -2],
-            "Found 2 row(s) where 'col1' is not greater than -2.",
-        ),
-        (
             "pandas",
-            [-5, -4, -3],
-            -3,
-            "failure",
-            [-5, -4, -3],
-            "Found 3 row(s) where 'col1' is not greater than -3.",
-        ),
-        (
-            "pyspark",
             [-5, -4, -3],
             -3,
             "failure",
@@ -216,11 +140,8 @@ def test_expectation_name():
         ),
         # Float values - success
         ("pandas", [2.5, 3.7, 4.2], 2.0, "success", None, None),
-        ("pyspark", [2.5, 3.7, 4.2], 2.0, "success", None, None),
         ("pandas", [3.1, 4.5, 5.9], 3.0, "success", None, None),
-        ("pyspark", [3.1, 4.5, 5.9], 3.0, "success", None, None),
         ("pandas", [10.1, 10.2, 10.3], 10.0, "success", None, None),
-        ("pyspark", [10.1, 10.2, 10.3], 10.0, "success", None, None),
         # Float values - violations
         (
             "pandas",
@@ -231,23 +152,7 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is not greater than 2.5.",
         ),
         (
-            "pyspark",
-            [2.0, 2.5, 3.0],
-            2.5,
-            "failure",
-            [2.0, 2.5],
-            "Found 2 row(s) where 'col1' is not greater than 2.5.",
-        ),
-        (
             "pandas",
-            [1.5, 2.5, 3.5],
-            3.0,
-            "failure",
-            [1.5, 2.5],
-            "Found 2 row(s) where 'col1' is not greater than 3.0.",
-        ),
-        (
-            "pyspark",
             [1.5, 2.5, 3.5],
             3.0,
             "failure",
@@ -256,9 +161,7 @@ def test_expectation_name():
         ),
         # Zero as threshold - success
         ("pandas", [1, 2, 3], 0, "success", None, None),
-        ("pyspark", [1, 2, 3], 0, "success", None, None),
         ("pandas", [0.1, 0.5, 1.0], 0, "success", None, None),
-        ("pyspark", [0.1, 0.5, 1.0], 0, "success", None, None),
         # Zero as threshold - violations
         (
             "pandas",
@@ -269,23 +172,7 @@ def test_expectation_name():
             "Found 3 row(s) where 'col1' is not greater than 0.",
         ),
         (
-            "pyspark",
-            [-2, -1, 0],
-            0,
-            "failure",
-            [-2, -1, 0],
-            "Found 3 row(s) where 'col1' is not greater than 0.",
-        ),
-        (
             "pandas",
-            [-1, 0, 1],
-            0,
-            "failure",
-            [-1, 0],
-            "Found 2 row(s) where 'col1' is not greater than 0.",
-        ),
-        (
-            "pyspark",
             [-1, 0, 1],
             0,
             "failure",
@@ -294,7 +181,6 @@ def test_expectation_name():
         ),
         # Zero in data - success
         ("pandas", [1, 2, 3], -1, "success", None, None),
-        ("pyspark", [1, 2, 3], -1, "success", None, None),
         # Zero in data - violations
         (
             "pandas",
@@ -304,19 +190,9 @@ def test_expectation_name():
             [0],
             "Found 1 row(s) where 'col1' is not greater than 0.",
         ),
-        (
-            "pyspark",
-            [0, 1, 2],
-            0,
-            "failure",
-            [0],
-            "Found 1 row(s) where 'col1' is not greater than 0.",
-        ),
         # Single value - success
         ("pandas", [5], 4, "success", None, None),
-        ("pyspark", [5], 4, "success", None, None),
         ("pandas", [10], 0, "success", None, None),
-        ("pyspark", [10], 0, "success", None, None),
         # Single value - violation
         (
             "pandas",
@@ -327,23 +203,7 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not greater than 3.",
         ),
         (
-            "pyspark",
-            [3],
-            3,
-            "failure",
-            [3],
-            "Found 1 row(s) where 'col1' is not greater than 3.",
-        ),
-        (
             "pandas",
-            [2],
-            5,
-            "failure",
-            [2],
-            "Found 1 row(s) where 'col1' is not greater than 5.",
-        ),
-        (
-            "pyspark",
             [2],
             5,
             "failure",
@@ -359,27 +219,10 @@ def test_expectation_name():
             [5, 5, 5, 5],
             "Found 4 row(s) where 'col1' is not greater than 5.",
         ),
-        (
-            "pyspark",
-            [5, 5, 5, 5],
-            5,
-            "failure",
-            [5, 5, 5, 5],
-            "Found 4 row(s) where 'col1' is not greater than 5.",
-        ),
         # Mixed integers and floats
         ("pandas", [3, 3.5, 4, 4.5], 2, "success", None, None),
-        ("pyspark", [3, 3.5, 4, 4.5], 2, "success", None, None),
         (
             "pandas",
-            [2, 2.5, 3, 3.5],
-            3,
-            "failure",
-            [2, 2.5, 3],
-            "Found 3 row(s) where 'col1' is not greater than 3.",
-        ),
-        (
-            "pyspark",
             [2, 2.5, 3, 3.5],
             3,
             "failure",
@@ -388,17 +231,8 @@ def test_expectation_name():
         ),
         # Large values
         ("pandas", [1000, 2000, 3000], 999, "success", None, None),
-        ("pyspark", [1000, 2000, 3000], 999, "success", None, None),
         (
             "pandas",
-            [1000, 1500, 2000],
-            2000,
-            "failure",
-            [1000, 1500, 2000],
-            "Found 3 row(s) where 'col1' is not greater than 2000.",
-        ),
-        (
-            "pyspark",
             [1000, 1500, 2000],
             2000,
             "failure",
@@ -414,19 +248,9 @@ def test_expectation_name():
             [1, 2, 3],
             "Found 3 row(s) where 'col1' is not greater than 5.",
         ),
-        (
-            "pyspark",
-            [1, 2, 3],
-            5,
-            "failure",
-            [1, 2, 3],
-            "Found 3 row(s) where 'col1' is not greater than 5.",
-        ),
         # With nulls - success (nulls are ignored)
         ("pandas", [3, None, 4, None, 5], 2, "success", None, None),
-        ("pyspark", [3, None, 4, None, 5], 2, "success", None, None),
         ("pandas", [10, None, 20, None], 5, "success", None, None),
-        ("pyspark", [10, None, 20, None], 5, "success", None, None),
         # With nulls - violations
         (
             "pandas",
@@ -436,111 +260,60 @@ def test_expectation_name():
             [2.0, 3.0],
             "Found 2 row(s) where 'col1' is not greater than 3.",
         ),
-        (
-            "pyspark",
-            [2, None, 3, 4],
-            3,
-            "failure",
-            [2, 3],
-            "Found 2 row(s) where 'col1' is not greater than 3.",
-        ),
     ],
     ids=[
         "pandas_basic_success",
-        "pyspark_basic_success",
         "pandas_success_different_data",
-        "pyspark_success_different_data",
         "pandas_success_large_values",
-        "pyspark_success_large_values",
         "pandas_basic_violations",
-        "pyspark_basic_violations",
         "pandas_all_violations",
-        "pyspark_all_violations",
         "pandas_partial_violations",
-        "pyspark_partial_violations",
         "pandas_boundary_just_above",
-        "pyspark_boundary_just_above",
         "pandas_boundary_just_above_float",
-        "pyspark_boundary_just_above_float",
         "pandas_boundary_at_threshold",
-        "pyspark_boundary_at_threshold",
         "pandas_boundary_all_at_threshold",
-        "pyspark_boundary_all_at_threshold",
         "pandas_boundary_below_threshold",
-        "pyspark_boundary_below_threshold",
         "pandas_negative_success",
-        "pyspark_negative_success",
         "pandas_negative_range_success",
-        "pyspark_negative_range_success",
         "pandas_negative_large_success",
-        "pyspark_negative_large_success",
         "pandas_negative_violations",
-        "pyspark_negative_violations",
         "pandas_negative_all_violations",
-        "pyspark_negative_all_violations",
         "pandas_float_success",
-        "pyspark_float_success",
         "pandas_float_different_success",
-        "pyspark_float_different_success",
         "pandas_float_precise_success",
-        "pyspark_float_precise_success",
         "pandas_float_violations",
-        "pyspark_float_violations",
         "pandas_float_mixed_violations",
-        "pyspark_float_mixed_violations",
         "pandas_zero_threshold_success",
-        "pyspark_zero_threshold_success",
         "pandas_zero_threshold_float_success",
-        "pyspark_zero_threshold_float_success",
         "pandas_zero_threshold_violations",
-        "pyspark_zero_threshold_violations",
         "pandas_zero_threshold_mixed_violations",
-        "pyspark_zero_threshold_mixed_violations",
         "pandas_zero_in_data_success",
-        "pyspark_zero_in_data_success",
         "pandas_zero_in_data_violation",
-        "pyspark_zero_in_data_violation",
         "pandas_single_value_success",
-        "pyspark_single_value_success",
         "pandas_single_value_large_success",
-        "pyspark_single_value_large_success",
         "pandas_single_value_violation",
-        "pyspark_single_value_violation",
         "pandas_single_value_below_violation",
-        "pyspark_single_value_below_violation",
         "pandas_all_equal_threshold",
-        "pyspark_all_equal_threshold",
         "pandas_mixed_types_success",
-        "pyspark_mixed_types_success",
         "pandas_mixed_types_violations",
-        "pyspark_mixed_types_violations",
         "pandas_large_values_success",
-        "pyspark_large_values_success",
         "pandas_large_values_violations",
-        "pyspark_large_values_violations",
         "pandas_all_below_threshold",
-        "pyspark_all_below_threshold",
         "pandas_with_nulls_success",
-        "pyspark_with_nulls_success",
         "pandas_with_nulls_large_success",
-        "pyspark_with_nulls_large_success",
         "pandas_with_nulls_violations",
-        "pyspark_with_nulls_violations",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, data, threshold, expected_result, expected_violations, expected_message, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, data, threshold, expected_result, expected_violations, expected_message
 ):
     """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
+    Test the expectation for various scenarios across pandas DataFrames.
     Tests both direct expectation validation and suite-based validation.
     Covers: success cases, boundary conditions, violations, negative values, floats,
     zero values, single values, mixed types, large values, and nulls.
     """
-    # Determine data type based on whether we have float values (excluding None)
-    has_float = any(isinstance(val, float) for val in data if val is not None)
-    data_type = "double" if has_float else "long"
-    data_frame = create_dataframe(df_type, data, "col1", spark, data_type)
+    data_frame = pd.DataFrame({"col1": data})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -556,8 +329,314 @@ def test_expectation_basic_scenarios(
             DataFrameExpectationSuccessMessage(expectation_name="ExpectationValueGreaterThan")
         ), f"Expected success message but got: {result}"
     else:  # failure
-        expected_violations_df = create_dataframe(
-            df_type, expected_violations, "col1", spark, data_type
+        expected_violations_df = pd.DataFrame({"col1": expected_violations})
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            violations_data_frame=expected_violations_df,
+            message=expected_message,
+            limit_violations=5,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_value_greater_than(
+        column_name="col1", value=threshold
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+@pytest.mark.parametrize(
+    "df_type, data, threshold, expected_result, expected_violations, expected_message",
+    [
+        # Basic success scenarios
+        ("pyspark", [3, 4, 5], 2, "success", None, None),
+        ("pyspark", [4, 5, 6], 3, "success", None, None),
+        ("pyspark", [10, 20, 30], 5, "success", None, None),
+        # Basic violation scenarios
+        (
+            "pyspark",
+            [3, 4, 5],
+            3,
+            "failure",
+            [3],
+            "Found 1 row(s) where 'col1' is not greater than 3.",
+        ),
+        (
+            "pyspark",
+            [1, 2, 3],
+            3,
+            "failure",
+            [1, 2, 3],
+            "Found 3 row(s) where 'col1' is not greater than 3.",
+        ),
+        (
+            "pyspark",
+            [2, 3, 4, 5],
+            4,
+            "failure",
+            [2, 3, 4],
+            "Found 3 row(s) where 'col1' is not greater than 4.",
+        ),
+        # Boundary conditions - just above threshold
+        ("pyspark", [3, 4, 5], 2, "success", None, None),
+        ("pyspark", [2.1, 3, 4], 2, "success", None, None),
+        # Boundary conditions - at threshold (violation)
+        (
+            "pyspark",
+            [2, 3, 4],
+            2,
+            "failure",
+            [2],
+            "Found 1 row(s) where 'col1' is not greater than 2.",
+        ),
+        (
+            "pyspark",
+            [5, 5, 5],
+            5,
+            "failure",
+            [5, 5, 5],
+            "Found 3 row(s) where 'col1' is not greater than 5.",
+        ),
+        # Boundary conditions - just below threshold
+        (
+            "pyspark",
+            [1, 2, 3],
+            2,
+            "failure",
+            [1, 2],
+            "Found 2 row(s) where 'col1' is not greater than 2.",
+        ),
+        # Negative values - success
+        ("pyspark", [0, 1, 2], -1, "success", None, None),
+        ("pyspark", [-2, -1, 0], -3, "success", None, None),
+        ("pyspark", [-5, -3, 0], -10, "success", None, None),
+        # Negative values - violations
+        (
+            "pyspark",
+            [-3, -2, -1],
+            -2,
+            "failure",
+            [-3, -2],
+            "Found 2 row(s) where 'col1' is not greater than -2.",
+        ),
+        (
+            "pyspark",
+            [-5, -4, -3],
+            -3,
+            "failure",
+            [-5, -4, -3],
+            "Found 3 row(s) where 'col1' is not greater than -3.",
+        ),
+        # Float values - success
+        ("pyspark", [2.5, 3.7, 4.2], 2.0, "success", None, None),
+        ("pyspark", [3.1, 4.5, 5.9], 3.0, "success", None, None),
+        ("pyspark", [10.1, 10.2, 10.3], 10.0, "success", None, None),
+        # Float values - violations
+        (
+            "pyspark",
+            [2.0, 2.5, 3.0],
+            2.5,
+            "failure",
+            [2.0, 2.5],
+            "Found 2 row(s) where 'col1' is not greater than 2.5.",
+        ),
+        (
+            "pyspark",
+            [1.5, 2.5, 3.5],
+            3.0,
+            "failure",
+            [1.5, 2.5],
+            "Found 2 row(s) where 'col1' is not greater than 3.0.",
+        ),
+        # Zero as threshold - success
+        ("pyspark", [1, 2, 3], 0, "success", None, None),
+        ("pyspark", [0.1, 0.5, 1.0], 0, "success", None, None),
+        # Zero as threshold - violations
+        (
+            "pyspark",
+            [-2, -1, 0],
+            0,
+            "failure",
+            [-2, -1, 0],
+            "Found 3 row(s) where 'col1' is not greater than 0.",
+        ),
+        (
+            "pyspark",
+            [-1, 0, 1],
+            0,
+            "failure",
+            [-1, 0],
+            "Found 2 row(s) where 'col1' is not greater than 0.",
+        ),
+        # Zero in data - success
+        ("pyspark", [1, 2, 3], -1, "success", None, None),
+        # Zero in data - violations
+        (
+            "pyspark",
+            [0, 1, 2],
+            0,
+            "failure",
+            [0],
+            "Found 1 row(s) where 'col1' is not greater than 0.",
+        ),
+        # Single value - success
+        ("pyspark", [5], 4, "success", None, None),
+        ("pyspark", [10], 0, "success", None, None),
+        # Single value - violation
+        (
+            "pyspark",
+            [3],
+            3,
+            "failure",
+            [3],
+            "Found 1 row(s) where 'col1' is not greater than 3.",
+        ),
+        (
+            "pyspark",
+            [2],
+            5,
+            "failure",
+            [2],
+            "Found 1 row(s) where 'col1' is not greater than 5.",
+        ),
+        # All values equal to threshold
+        (
+            "pyspark",
+            [5, 5, 5, 5],
+            5,
+            "failure",
+            [5, 5, 5, 5],
+            "Found 4 row(s) where 'col1' is not greater than 5.",
+        ),
+        # Mixed integers and floats
+        ("pyspark", [3, 3.5, 4, 4.5], 2, "success", None, None),
+        (
+            "pyspark",
+            [2, 2.5, 3, 3.5],
+            3,
+            "failure",
+            [2, 2.5, 3],
+            "Found 3 row(s) where 'col1' is not greater than 3.",
+        ),
+        # Large values
+        ("pyspark", [1000, 2000, 3000], 999, "success", None, None),
+        (
+            "pyspark",
+            [1000, 1500, 2000],
+            2000,
+            "failure",
+            [1000, 1500, 2000],
+            "Found 3 row(s) where 'col1' is not greater than 2000.",
+        ),
+        # All values below threshold
+        (
+            "pyspark",
+            [1, 2, 3],
+            5,
+            "failure",
+            [1, 2, 3],
+            "Found 3 row(s) where 'col1' is not greater than 5.",
+        ),
+        # With nulls - success (nulls are ignored)
+        ("pyspark", [3, None, 4, None, 5], 2, "success", None, None),
+        ("pyspark", [10, None, 20, None], 5, "success", None, None),
+        # With nulls - violations
+        (
+            "pyspark",
+            [2, None, 3, 4],
+            3,
+            "failure",
+            [2, 3],
+            "Found 2 row(s) where 'col1' is not greater than 3.",
+        ),
+    ],
+    ids=[
+        "pyspark_basic_success",
+        "pyspark_success_different_data",
+        "pyspark_success_large_values",
+        "pyspark_basic_violations",
+        "pyspark_all_violations",
+        "pyspark_partial_violations",
+        "pyspark_boundary_just_above",
+        "pyspark_boundary_just_above_float",
+        "pyspark_boundary_at_threshold",
+        "pyspark_boundary_all_at_threshold",
+        "pyspark_boundary_below_threshold",
+        "pyspark_negative_success",
+        "pyspark_negative_range_success",
+        "pyspark_negative_large_success",
+        "pyspark_negative_violations",
+        "pyspark_negative_all_violations",
+        "pyspark_float_success",
+        "pyspark_float_different_success",
+        "pyspark_float_precise_success",
+        "pyspark_float_violations",
+        "pyspark_float_mixed_violations",
+        "pyspark_zero_threshold_success",
+        "pyspark_zero_threshold_float_success",
+        "pyspark_zero_threshold_violations",
+        "pyspark_zero_threshold_mixed_violations",
+        "pyspark_zero_in_data_success",
+        "pyspark_zero_in_data_violation",
+        "pyspark_single_value_success",
+        "pyspark_single_value_large_success",
+        "pyspark_single_value_violation",
+        "pyspark_single_value_below_violation",
+        "pyspark_all_equal_threshold",
+        "pyspark_mixed_types_success",
+        "pyspark_mixed_types_violations",
+        "pyspark_large_values_success",
+        "pyspark_large_values_violations",
+        "pyspark_all_below_threshold",
+        "pyspark_with_nulls_success",
+        "pyspark_with_nulls_large_success",
+        "pyspark_with_nulls_violations",
+    ],
+)
+def test_expectation_basic_scenarios_pyspark(
+    df_type, data, threshold, expected_result, expected_violations, expected_message, spark
+):
+    """
+    Test the expectation for various scenarios across PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases, boundary conditions, violations, negative values, floats,
+    zero values, single values, mixed types, large values, and nulls.
+    """
+    # Determine data type based on whether we have float values (excluding None)
+    has_float = any(isinstance(val, float) for val in data if val is not None)
+    data_type = "double" if has_float else "long"
+    data_frame = create_pyspark_dataframe(data, "col1", spark, data_type)
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueGreaterThan",
+        column_name="col1",
+        value=threshold,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationValueGreaterThan")
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        expected_violations_df = create_pyspark_dataframe(
+            expected_violations, "col1", spark, data_type
         )
         expected_failure_message = DataFrameExpectationFailureMessage(
             expectation_str=str(expectation),
@@ -587,19 +666,11 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
-@pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
-)
-def test_column_missing_error(df_type, spark):
-    """Test that an error is raised when the specified column is missing in both pandas and PySpark."""
+def test_column_missing_error_pandas():
+    """Test that an error is raised when the specified column is missing in pandas."""
     expected_message = "Column 'col1' does not exist in the DataFrame."
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col2": [3, 4, 5]})
-    else:  # pyspark
-        data_frame = spark.createDataFrame([(3,), (4,), (5,)], ["col2"])
+    data_frame = pd.DataFrame({"col2": [3, 4, 5]})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -610,7 +681,36 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=data_frame)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_value_greater_than(
+        column_name="col1", value=2
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test that an error is raised when the specified column is missing in PySpark."""
+    expected_message = "Column 'col1' does not exist in the DataFrame."
+
+    data_frame = spark.createDataFrame([(3,), (4,), (5,)], ["col2"])
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueGreaterThan",
+        column_name="col1",
+        value=2,
+    )
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message=expected_message,
     )
     assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"

--- a/tests/expectations/column/numerical_expectations/test_expect_value_greater_than.py
+++ b/tests/expectations/column/numerical_expectations/test_expect_value_greater_than.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 import pandas as pd
 
 from dataframe_expectations.registry import (
@@ -725,8 +726,6 @@ def test_column_missing_error_pyspark(spark):
 
 def test_large_dataset_performance():
     """Test the expectation with a larger dataset to ensure performance."""
-    import numpy as np
-
     # Create a larger dataset with values between 10 and 100
     large_data = np.random.uniform(10, 100, 10000).tolist()
     data_frame = pd.DataFrame({"col1": large_data})

--- a/tests/expectations/column/numerical_expectations/test_expect_value_greater_than_equals.py
+++ b/tests/expectations/column/numerical_expectations/test_expect_value_greater_than_equals.py
@@ -15,37 +15,33 @@ from dataframe_expectations.result_message import (
 from dataframe_expectations.core.suite_result import SuiteExecutionResult
 
 
-def create_dataframe(df_type, data, column_name, spark, data_type="long"):
-    """Helper function to create pandas or pyspark DataFrame.
+def create_pyspark_dataframe(data, column_name, spark, data_type="long"):
+    """Helper function to create a PySpark DataFrame.
 
     Args:
-        df_type: "pandas" or "pyspark"
         data: List of values for the column
         column_name: Name of the column
         spark: Spark session (required for pyspark)
         data_type: Data type for the column - "long", "double"
     """
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        from pyspark.sql.types import (
-            StructType,
-            StructField,
-            LongType,
-            DoubleType,
-        )
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        LongType,
+        DoubleType,
+    )
 
-        type_mapping = {
-            "long": LongType(),
-            "double": DoubleType(),
-        }
+    type_mapping = {
+        "long": LongType(),
+        "double": DoubleType(),
+    }
 
-        # Convert integers to floats when using double type to avoid type mismatch
-        if data_type == "double":
-            data = [float(val) if val is not None else None for val in data]
+    # Convert integers to floats when using double type to avoid type mismatch
+    if data_type == "double":
+        data = [float(val) if val is not None else None for val in data]
 
-        schema = StructType([StructField(column_name, type_mapping[data_type], True)])
-        return spark.createDataFrame([(val,) for val in data], schema)
+    schema = StructType([StructField(column_name, type_mapping[data_type], True)])
+    return spark.createDataFrame([(val,) for val in data], schema)
 
 
 def test_expectation_name():
@@ -65,16 +61,11 @@ def test_expectation_name():
     [
         # Basic success scenarios
         ("pandas", [3, 4, 5], 2, "success", None, None),
-        ("pyspark", [3, 4, 5], 2, "success", None, None),
         ("pandas", [4, 5, 6], 3, "success", None, None),
-        ("pyspark", [4, 5, 6], 3, "success", None, None),
         ("pandas", [10, 20, 30], 5, "success", None, None),
-        ("pyspark", [10, 20, 30], 5, "success", None, None),
         # Success at threshold (key difference from greater than)
         ("pandas", [3, 4, 5], 3, "success", None, None),
-        ("pyspark", [3, 4, 5], 3, "success", None, None),
         ("pandas", [5, 5, 5], 5, "success", None, None),
-        ("pyspark", [5, 5, 5], 5, "success", None, None),
         # Basic violation scenarios
         (
             "pandas",
@@ -85,23 +76,7 @@ def test_expectation_name():
             "Found 3 row(s) where 'col1' is not greater than or equal to 4.",
         ),
         (
-            "pyspark",
-            [1, 2, 3],
-            4,
-            "failure",
-            [1, 2, 3],
-            "Found 3 row(s) where 'col1' is not greater than or equal to 4.",
-        ),
-        (
             "pandas",
-            [2, 3, 4, 5],
-            5,
-            "failure",
-            [2, 3, 4],
-            "Found 3 row(s) where 'col1' is not greater than or equal to 5.",
-        ),
-        (
-            "pyspark",
             [2, 3, 4, 5],
             5,
             "failure",
@@ -110,9 +85,7 @@ def test_expectation_name():
         ),
         # Boundary conditions - at threshold (success for >=)
         ("pandas", [2, 3, 4], 2, "success", None, None),
-        ("pyspark", [2, 3, 4], 2, "success", None, None),
         ("pandas", [5, 6, 7], 5, "success", None, None),
-        ("pyspark", [5, 6, 7], 5, "success", None, None),
         # Boundary conditions - just below threshold (violation)
         (
             "pandas",
@@ -123,23 +96,7 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not greater than or equal to 2.",
         ),
         (
-            "pyspark",
-            [1, 2, 3],
-            2,
-            "failure",
-            [1],
-            "Found 1 row(s) where 'col1' is not greater than or equal to 2.",
-        ),
-        (
             "pandas",
-            [1.9, 2, 3],
-            2,
-            "failure",
-            [1.9],
-            "Found 1 row(s) where 'col1' is not greater than or equal to 2.",
-        ),
-        (
-            "pyspark",
             [1.9, 2, 3],
             2,
             "failure",
@@ -148,14 +105,10 @@ def test_expectation_name():
         ),
         # Negative values - success
         ("pandas", [0, 1, 2], -1, "success", None, None),
-        ("pyspark", [0, 1, 2], -1, "success", None, None),
         ("pandas", [-2, -1, 0], -3, "success", None, None),
-        ("pyspark", [-2, -1, 0], -3, "success", None, None),
         ("pandas", [-5, -3, 0], -10, "success", None, None),
-        ("pyspark", [-5, -3, 0], -10, "success", None, None),
         # Negative values - success at threshold
         ("pandas", [-2, -1, 0], -2, "success", None, None),
-        ("pyspark", [-2, -1, 0], -2, "success", None, None),
         # Negative values - violations
         (
             "pandas",
@@ -166,23 +119,7 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is not greater than or equal to -1.",
         ),
         (
-            "pyspark",
-            [-3, -2, -1],
-            -1,
-            "failure",
-            [-3, -2],
-            "Found 2 row(s) where 'col1' is not greater than or equal to -1.",
-        ),
-        (
             "pandas",
-            [-5, -4, -3],
-            -2,
-            "failure",
-            [-5, -4, -3],
-            "Found 3 row(s) where 'col1' is not greater than or equal to -2.",
-        ),
-        (
-            "pyspark",
             [-5, -4, -3],
             -2,
             "failure",
@@ -191,11 +128,8 @@ def test_expectation_name():
         ),
         # Float values - success
         ("pandas", [2.5, 3.7, 4.2], 2.0, "success", None, None),
-        ("pyspark", [2.5, 3.7, 4.2], 2.0, "success", None, None),
         ("pandas", [3.0, 4.5, 5.9], 3.0, "success", None, None),
-        ("pyspark", [3.0, 4.5, 5.9], 3.0, "success", None, None),
         ("pandas", [10.0, 10.2, 10.3], 10.0, "success", None, None),
-        ("pyspark", [10.0, 10.2, 10.3], 10.0, "success", None, None),
         # Float values - violations
         (
             "pandas",
@@ -206,23 +140,7 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is not greater than or equal to 2.6.",
         ),
         (
-            "pyspark",
-            [2.0, 2.5, 3.0],
-            2.6,
-            "failure",
-            [2.0, 2.5],
-            "Found 2 row(s) where 'col1' is not greater than or equal to 2.6.",
-        ),
-        (
             "pandas",
-            [1.5, 2.5, 3.5],
-            3.1,
-            "failure",
-            [1.5, 2.5],
-            "Found 2 row(s) where 'col1' is not greater than or equal to 3.1.",
-        ),
-        (
-            "pyspark",
             [1.5, 2.5, 3.5],
             3.1,
             "failure",
@@ -231,9 +149,7 @@ def test_expectation_name():
         ),
         # Zero as threshold - success
         ("pandas", [0, 1, 2], 0, "success", None, None),
-        ("pyspark", [0, 1, 2], 0, "success", None, None),
         ("pandas", [0.0, 0.5, 1.0], 0, "success", None, None),
-        ("pyspark", [0.0, 0.5, 1.0], 0, "success", None, None),
         # Zero as threshold - violations
         (
             "pandas",
@@ -244,14 +160,6 @@ def test_expectation_name():
             "Found 3 row(s) where 'col1' is not greater than or equal to 1.",
         ),
         (
-            "pyspark",
-            [-2, -1, 0],
-            1,
-            "failure",
-            [-2, -1, 0],
-            "Found 3 row(s) where 'col1' is not greater than or equal to 1.",
-        ),
-        (
             "pandas",
             [-1, 0, 1],
             1,
@@ -259,24 +167,10 @@ def test_expectation_name():
             [-1, 0],
             "Found 2 row(s) where 'col1' is not greater than or equal to 1.",
         ),
-        (
-            "pyspark",
-            [-1, 0, 1],
-            1,
-            "failure",
-            [-1, 0],
-            "Found 2 row(s) where 'col1' is not greater than or equal to 1.",
-        ),
-        # Zero in data - success (including zero at threshold)
-        ("pandas", [0, 1, 2], 0, "success", None, None),
-        ("pyspark", [0, 1, 2], 0, "success", None, None),
         # Single value - success
         ("pandas", [5], 4, "success", None, None),
-        ("pyspark", [5], 4, "success", None, None),
         ("pandas", [5], 5, "success", None, None),
-        ("pyspark", [5], 5, "success", None, None),
         ("pandas", [10], 0, "success", None, None),
-        ("pyspark", [10], 0, "success", None, None),
         # Single value - violation
         (
             "pandas",
@@ -287,23 +181,7 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not greater than or equal to 4.",
         ),
         (
-            "pyspark",
-            [3],
-            4,
-            "failure",
-            [3],
-            "Found 1 row(s) where 'col1' is not greater than or equal to 4.",
-        ),
-        (
             "pandas",
-            [2],
-            5,
-            "failure",
-            [2],
-            "Found 1 row(s) where 'col1' is not greater than or equal to 5.",
-        ),
-        (
-            "pyspark",
             [2],
             5,
             "failure",
@@ -312,20 +190,10 @@ def test_expectation_name():
         ),
         # All values equal to threshold (success for >=)
         ("pandas", [5, 5, 5, 5], 5, "success", None, None),
-        ("pyspark", [5, 5, 5, 5], 5, "success", None, None),
         # Mixed integers and floats
         ("pandas", [3, 3.5, 4, 4.5], 3, "success", None, None),
-        ("pyspark", [3, 3.5, 4, 4.5], 3, "success", None, None),
         (
             "pandas",
-            [2, 2.5, 3, 3.5],
-            3.1,
-            "failure",
-            [2, 2.5, 3],
-            "Found 3 row(s) where 'col1' is not greater than or equal to 3.1.",
-        ),
-        (
-            "pyspark",
             [2, 2.5, 3, 3.5],
             3.1,
             "failure",
@@ -334,17 +202,8 @@ def test_expectation_name():
         ),
         # Large values
         ("pandas", [1000, 2000, 3000], 1000, "success", None, None),
-        ("pyspark", [1000, 2000, 3000], 1000, "success", None, None),
         (
             "pandas",
-            [1000, 1500, 2000],
-            2001,
-            "failure",
-            [1000, 1500, 2000],
-            "Found 3 row(s) where 'col1' is not greater than or equal to 2001.",
-        ),
-        (
-            "pyspark",
             [1000, 1500, 2000],
             2001,
             "failure",
@@ -360,19 +219,9 @@ def test_expectation_name():
             [1, 2, 3],
             "Found 3 row(s) where 'col1' is not greater than or equal to 5.",
         ),
-        (
-            "pyspark",
-            [1, 2, 3],
-            5,
-            "failure",
-            [1, 2, 3],
-            "Found 3 row(s) where 'col1' is not greater than or equal to 5.",
-        ),
         # With nulls - success (nulls are ignored)
         ("pandas", [3, None, 4, None, 5], 3, "success", None, None),
-        ("pyspark", [3, None, 4, None, 5], 3, "success", None, None),
         ("pandas", [10, None, 20, None], 5, "success", None, None),
-        ("pyspark", [10, None, 20, None], 5, "success", None, None),
         # With nulls - violations
         (
             "pandas",
@@ -382,113 +231,60 @@ def test_expectation_name():
             [2.0],
             "Found 1 row(s) where 'col1' is not greater than or equal to 3.",
         ),
-        (
-            "pyspark",
-            [2, None, 3, 4],
-            3,
-            "failure",
-            [2],
-            "Found 1 row(s) where 'col1' is not greater than or equal to 3.",
-        ),
     ],
     ids=[
         "pandas_basic_success",
-        "pyspark_basic_success",
         "pandas_success_different_data",
-        "pyspark_success_different_data",
         "pandas_success_large_values",
-        "pyspark_success_large_values",
         "pandas_success_at_threshold",
-        "pyspark_success_at_threshold",
         "pandas_success_all_equal_threshold",
-        "pyspark_success_all_equal_threshold",
         "pandas_basic_violations",
-        "pyspark_basic_violations",
         "pandas_partial_violations",
-        "pyspark_partial_violations",
         "pandas_boundary_at_threshold_success",
-        "pyspark_boundary_at_threshold_success",
         "pandas_boundary_at_threshold_success_2",
-        "pyspark_boundary_at_threshold_success_2",
         "pandas_boundary_below_threshold",
-        "pyspark_boundary_below_threshold",
         "pandas_boundary_below_threshold_float",
-        "pyspark_boundary_below_threshold_float",
         "pandas_negative_success",
-        "pyspark_negative_success",
         "pandas_negative_range_success",
-        "pyspark_negative_range_success",
         "pandas_negative_large_success",
-        "pyspark_negative_large_success",
         "pandas_negative_at_threshold_success",
-        "pyspark_negative_at_threshold_success",
         "pandas_negative_violations",
-        "pyspark_negative_violations",
         "pandas_negative_all_violations",
-        "pyspark_negative_all_violations",
         "pandas_float_success",
-        "pyspark_float_success",
         "pandas_float_at_threshold_success",
-        "pyspark_float_at_threshold_success",
         "pandas_float_precise_success",
-        "pyspark_float_precise_success",
         "pandas_float_violations",
-        "pyspark_float_violations",
         "pandas_float_mixed_violations",
-        "pyspark_float_mixed_violations",
         "pandas_zero_threshold_success",
-        "pyspark_zero_threshold_success",
         "pandas_zero_threshold_float_success",
-        "pyspark_zero_threshold_float_success",
         "pandas_zero_threshold_violations",
-        "pyspark_zero_threshold_violations",
         "pandas_zero_threshold_mixed_violations",
-        "pyspark_zero_threshold_mixed_violations",
-        "pandas_zero_in_data_success",
-        "pyspark_zero_in_data_success",
         "pandas_single_value_success",
-        "pyspark_single_value_success",
         "pandas_single_value_at_threshold_success",
-        "pyspark_single_value_at_threshold_success",
         "pandas_single_value_large_success",
-        "pyspark_single_value_large_success",
         "pandas_single_value_violation",
-        "pyspark_single_value_violation",
         "pandas_single_value_below_violation",
-        "pyspark_single_value_below_violation",
         "pandas_all_equal_threshold_success",
-        "pyspark_all_equal_threshold_success",
         "pandas_mixed_types_success",
-        "pyspark_mixed_types_success",
         "pandas_mixed_types_violations",
-        "pyspark_mixed_types_violations",
         "pandas_large_values_success",
-        "pyspark_large_values_success",
         "pandas_large_values_violations",
-        "pyspark_large_values_violations",
         "pandas_all_below_threshold",
-        "pyspark_all_below_threshold",
         "pandas_with_nulls_success",
-        "pyspark_with_nulls_success",
         "pandas_with_nulls_large_success",
-        "pyspark_with_nulls_large_success",
         "pandas_with_nulls_violations",
-        "pyspark_with_nulls_violations",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, data, threshold, expected_result, expected_violations, expected_message, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, data, threshold, expected_result, expected_violations, expected_message
 ):
     """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
+    Test the expectation for various scenarios across pandas DataFrames.
     Tests both direct expectation validation and suite-based validation.
     Covers: success cases, boundary conditions (including equals), violations, negative values,
     floats, zero values, single values, mixed types, large values, and nulls.
     """
-    # Determine data type based on whether we have float values (excluding None)
-    has_float = any(isinstance(val, float) for val in data if val is not None)
-    data_type = "double" if has_float else "long"
-    data_frame = create_dataframe(df_type, data, "col1", spark, data_type)
+    data_frame = pd.DataFrame({"col1": data})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -504,8 +300,285 @@ def test_expectation_basic_scenarios(
             DataFrameExpectationSuccessMessage(expectation_name="ExpectationValueGreaterThanEquals")
         ), f"Expected success message but got: {result}"
     else:  # failure
-        expected_violations_df = create_dataframe(
-            df_type, expected_violations, "col1", spark, data_type
+        expected_violations_df = pd.DataFrame({"col1": expected_violations})
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            violations_data_frame=expected_violations_df,
+            message=expected_message,
+            limit_violations=5,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_value_greater_than_equals(
+        column_name="col1", value=threshold
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+@pytest.mark.parametrize(
+    "df_type, data, threshold, expected_result, expected_violations, expected_message",
+    [
+        # Basic success scenarios
+        ("pyspark", [3, 4, 5], 2, "success", None, None),
+        ("pyspark", [4, 5, 6], 3, "success", None, None),
+        ("pyspark", [10, 20, 30], 5, "success", None, None),
+        # Success at threshold (key difference from greater than)
+        ("pyspark", [3, 4, 5], 3, "success", None, None),
+        ("pyspark", [5, 5, 5], 5, "success", None, None),
+        # Basic violation scenarios
+        (
+            "pyspark",
+            [1, 2, 3],
+            4,
+            "failure",
+            [1, 2, 3],
+            "Found 3 row(s) where 'col1' is not greater than or equal to 4.",
+        ),
+        (
+            "pyspark",
+            [2, 3, 4, 5],
+            5,
+            "failure",
+            [2, 3, 4],
+            "Found 3 row(s) where 'col1' is not greater than or equal to 5.",
+        ),
+        # Boundary conditions - at threshold (success for >=)
+        ("pyspark", [2, 3, 4], 2, "success", None, None),
+        ("pyspark", [5, 6, 7], 5, "success", None, None),
+        # Boundary conditions - just below threshold (violation)
+        (
+            "pyspark",
+            [1, 2, 3],
+            2,
+            "failure",
+            [1],
+            "Found 1 row(s) where 'col1' is not greater than or equal to 2.",
+        ),
+        (
+            "pyspark",
+            [1.9, 2, 3],
+            2,
+            "failure",
+            [1.9],
+            "Found 1 row(s) where 'col1' is not greater than or equal to 2.",
+        ),
+        # Negative values - success
+        ("pyspark", [0, 1, 2], -1, "success", None, None),
+        ("pyspark", [-2, -1, 0], -3, "success", None, None),
+        ("pyspark", [-5, -3, 0], -10, "success", None, None),
+        # Negative values - success at threshold
+        ("pyspark", [-2, -1, 0], -2, "success", None, None),
+        # Negative values - violations
+        (
+            "pyspark",
+            [-3, -2, -1],
+            -1,
+            "failure",
+            [-3, -2],
+            "Found 2 row(s) where 'col1' is not greater than or equal to -1.",
+        ),
+        (
+            "pyspark",
+            [-5, -4, -3],
+            -2,
+            "failure",
+            [-5, -4, -3],
+            "Found 3 row(s) where 'col1' is not greater than or equal to -2.",
+        ),
+        # Float values - success
+        ("pyspark", [2.5, 3.7, 4.2], 2.0, "success", None, None),
+        ("pyspark", [3.0, 4.5, 5.9], 3.0, "success", None, None),
+        ("pyspark", [10.0, 10.2, 10.3], 10.0, "success", None, None),
+        # Float values - violations
+        (
+            "pyspark",
+            [2.0, 2.5, 3.0],
+            2.6,
+            "failure",
+            [2.0, 2.5],
+            "Found 2 row(s) where 'col1' is not greater than or equal to 2.6.",
+        ),
+        (
+            "pyspark",
+            [1.5, 2.5, 3.5],
+            3.1,
+            "failure",
+            [1.5, 2.5],
+            "Found 2 row(s) where 'col1' is not greater than or equal to 3.1.",
+        ),
+        # Zero as threshold - success
+        ("pyspark", [0, 1, 2], 0, "success", None, None),
+        ("pyspark", [0.0, 0.5, 1.0], 0, "success", None, None),
+        # Zero as threshold - violations
+        (
+            "pyspark",
+            [-2, -1, 0],
+            1,
+            "failure",
+            [-2, -1, 0],
+            "Found 3 row(s) where 'col1' is not greater than or equal to 1.",
+        ),
+        (
+            "pyspark",
+            [-1, 0, 1],
+            1,
+            "failure",
+            [-1, 0],
+            "Found 2 row(s) where 'col1' is not greater than or equal to 1.",
+        ),
+        # Single value - success
+        ("pyspark", [5], 4, "success", None, None),
+        ("pyspark", [5], 5, "success", None, None),
+        ("pyspark", [10], 0, "success", None, None),
+        # Single value - violation
+        (
+            "pyspark",
+            [3],
+            4,
+            "failure",
+            [3],
+            "Found 1 row(s) where 'col1' is not greater than or equal to 4.",
+        ),
+        (
+            "pyspark",
+            [2],
+            5,
+            "failure",
+            [2],
+            "Found 1 row(s) where 'col1' is not greater than or equal to 5.",
+        ),
+        # All values equal to threshold (success for >=)
+        ("pyspark", [5, 5, 5, 5], 5, "success", None, None),
+        # Mixed integers and floats
+        ("pyspark", [3, 3.5, 4, 4.5], 3, "success", None, None),
+        (
+            "pyspark",
+            [2, 2.5, 3, 3.5],
+            3.1,
+            "failure",
+            [2, 2.5, 3],
+            "Found 3 row(s) where 'col1' is not greater than or equal to 3.1.",
+        ),
+        # Large values
+        ("pyspark", [1000, 2000, 3000], 1000, "success", None, None),
+        (
+            "pyspark",
+            [1000, 1500, 2000],
+            2001,
+            "failure",
+            [1000, 1500, 2000],
+            "Found 3 row(s) where 'col1' is not greater than or equal to 2001.",
+        ),
+        # All values below threshold
+        (
+            "pyspark",
+            [1, 2, 3],
+            5,
+            "failure",
+            [1, 2, 3],
+            "Found 3 row(s) where 'col1' is not greater than or equal to 5.",
+        ),
+        # With nulls - success (nulls are ignored)
+        ("pyspark", [3, None, 4, None, 5], 3, "success", None, None),
+        ("pyspark", [10, None, 20, None], 5, "success", None, None),
+        # With nulls - violations
+        (
+            "pyspark",
+            [2, None, 3, 4],
+            3,
+            "failure",
+            [2],
+            "Found 1 row(s) where 'col1' is not greater than or equal to 3.",
+        ),
+    ],
+    ids=[
+        "pyspark_basic_success",
+        "pyspark_success_different_data",
+        "pyspark_success_large_values",
+        "pyspark_success_at_threshold",
+        "pyspark_success_all_equal_threshold",
+        "pyspark_basic_violations",
+        "pyspark_partial_violations",
+        "pyspark_boundary_at_threshold_success",
+        "pyspark_boundary_at_threshold_success_2",
+        "pyspark_boundary_below_threshold",
+        "pyspark_boundary_below_threshold_float",
+        "pyspark_negative_success",
+        "pyspark_negative_range_success",
+        "pyspark_negative_large_success",
+        "pyspark_negative_at_threshold_success",
+        "pyspark_negative_violations",
+        "pyspark_negative_all_violations",
+        "pyspark_float_success",
+        "pyspark_float_at_threshold_success",
+        "pyspark_float_precise_success",
+        "pyspark_float_violations",
+        "pyspark_float_mixed_violations",
+        "pyspark_zero_threshold_success",
+        "pyspark_zero_threshold_float_success",
+        "pyspark_zero_threshold_violations",
+        "pyspark_zero_threshold_mixed_violations",
+        "pyspark_single_value_success",
+        "pyspark_single_value_at_threshold_success",
+        "pyspark_single_value_large_success",
+        "pyspark_single_value_violation",
+        "pyspark_single_value_below_violation",
+        "pyspark_all_equal_threshold_success",
+        "pyspark_mixed_types_success",
+        "pyspark_mixed_types_violations",
+        "pyspark_large_values_success",
+        "pyspark_large_values_violations",
+        "pyspark_all_below_threshold",
+        "pyspark_with_nulls_success",
+        "pyspark_with_nulls_large_success",
+        "pyspark_with_nulls_violations",
+    ],
+)
+def test_expectation_basic_scenarios_pyspark(
+    df_type, data, threshold, expected_result, expected_violations, expected_message, spark
+):
+    """
+    Test the expectation for various scenarios across PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases, boundary conditions (including equals), violations, negative values,
+    floats, zero values, single values, mixed types, large values, and nulls.
+    """
+    # Determine data type based on whether we have float values (excluding None)
+    has_float = any(isinstance(val, float) for val in data if val is not None)
+    data_type = "double" if has_float else "long"
+    data_frame = create_pyspark_dataframe(data, "col1", spark, data_type)
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueGreaterThanEquals",
+        column_name="col1",
+        value=threshold,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationValueGreaterThanEquals")
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        expected_violations_df = create_pyspark_dataframe(
+            expected_violations, "col1", spark, data_type
         )
         expected_failure_message = DataFrameExpectationFailureMessage(
             expectation_str=str(expectation),
@@ -535,19 +608,11 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
-@pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
-)
-def test_column_missing_error(df_type, spark):
-    """Test that an error is raised when the specified column is missing in both pandas and PySpark."""
+def test_column_missing_error_pandas():
+    """Test that an error is raised when the specified column is missing in pandas."""
     expected_message = "Column 'col1' does not exist in the DataFrame."
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col2": [3, 4, 5]})
-    else:  # pyspark
-        data_frame = spark.createDataFrame([(3,), (4,), (5,)], ["col2"])
+    data_frame = pd.DataFrame({"col2": [3, 4, 5]})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -558,12 +623,39 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=data_frame)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
         message=expected_message,
     )
     assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
 
     # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_value_greater_than_equals(
+        column_name="col1", value=2
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test that an error is raised when the specified column is missing in PySpark."""
+    expected_message = "Column 'col1' does not exist in the DataFrame."
+
+    data_frame = spark.createDataFrame([(3,), (4,), (5,)], ["col2"])
+
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueGreaterThanEquals",
+        column_name="col1",
+        value=2,
+    )
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
+
     expectations_suite = DataFrameExpectationsSuite().expect_value_greater_than_equals(
         column_name="col1", value=2
     )

--- a/tests/expectations/column/numerical_expectations/test_expect_value_greater_than_equals.py
+++ b/tests/expectations/column/numerical_expectations/test_expect_value_greater_than_equals.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 import pandas as pd
 
 from dataframe_expectations.registry import (
@@ -665,8 +666,6 @@ def test_column_missing_error_pyspark(spark):
 
 def test_large_dataset_performance():
     """Test the expectation with a larger dataset to ensure performance."""
-    import numpy as np
-
     # Create a larger dataset with values between 10 and 100
     large_data = np.random.uniform(10, 100, 10000).tolist()
     data_frame = pd.DataFrame({"col1": large_data})

--- a/tests/expectations/column/numerical_expectations/test_expect_value_less_than.py
+++ b/tests/expectations/column/numerical_expectations/test_expect_value_less_than.py
@@ -7,45 +7,41 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark, data_type="long"):
-    """Helper function to create pandas or pyspark DataFrame.
+def create_pyspark_dataframe(data, column_name, spark, data_type="long"):
+    """Helper function to create a PySpark DataFrame.
 
     Args:
-        df_type: "pandas" or "pyspark"
         data: List of values for the column
         column_name: Name of the column
         spark: Spark session (required for pyspark)
         data_type: Data type for the column - "long", "double"
     """
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        from pyspark.sql.types import (
-            StructType,
-            StructField,
-            LongType,
-            DoubleType,
-        )
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        LongType,
+        DoubleType,
+    )
 
-        type_mapping = {
-            "long": LongType(),
-            "double": DoubleType(),
-        }
+    type_mapping = {
+        "long": LongType(),
+        "double": DoubleType(),
+    }
 
-        # Convert integers to floats when using double type to avoid type mismatch
-        if data_type == "double":
-            data = [float(val) if val is not None else None for val in data]
+    # Convert integers to floats when using double type to avoid type mismatch
+    if data_type == "double":
+        data = [float(val) if val is not None else None for val in data]
 
-        schema = StructType([StructField(column_name, type_mapping[data_type], True)])
-        return spark.createDataFrame([(val,) for val in data], schema)
+    schema = StructType([StructField(column_name, type_mapping[data_type], True)])
+    return spark.createDataFrame([(val,) for val in data], schema)
 
 
 def test_expectation_name():
@@ -65,11 +61,8 @@ def test_expectation_name():
     [
         # Basic success scenarios
         ("pandas", [3, 4, 5], 6, "success", None, None),
-        ("pyspark", [3, 4, 5], 6, "success", None, None),
         ("pandas", [1, 2, 3], 4, "success", None, None),
-        ("pyspark", [1, 2, 3], 4, "success", None, None),
         ("pandas", [0, 1, 2], 5, "success", None, None),
-        ("pyspark", [0, 1, 2], 5, "success", None, None),
         # Basic violation scenarios
         (
             "pandas",
@@ -80,14 +73,6 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not less than 5.",
         ),
         (
-            "pyspark",
-            [3, 4, 5],
-            5,
-            "failure",
-            [5],
-            "Found 1 row(s) where 'col1' is not less than 5.",
-        ),
-        (
             "pandas",
             [3, 4, 5],
             3,
@@ -96,23 +81,7 @@ def test_expectation_name():
             "Found 3 row(s) where 'col1' is not less than 3.",
         ),
         (
-            "pyspark",
-            [3, 4, 5],
-            3,
-            "failure",
-            [3, 4, 5],
-            "Found 3 row(s) where 'col1' is not less than 3.",
-        ),
-        (
             "pandas",
-            [2, 3, 4, 5],
-            4,
-            "failure",
-            [4, 5],
-            "Found 2 row(s) where 'col1' is not less than 4.",
-        ),
-        (
-            "pyspark",
             [2, 3, 4, 5],
             4,
             "failure",
@@ -121,9 +90,7 @@ def test_expectation_name():
         ),
         # Boundary conditions - just below threshold - pandas
         ("pandas", [1, 2, 3], 4, "success", None, None),
-        ("pyspark", [1, 2, 3], 4, "success", None, None),
         ("pandas", [1.5, 1.8, 1.9], 2.0, "success", None, None),
-        ("pyspark", [1.5, 1.8, 1.9], 2.0, "success", None, None),
         # Boundary conditions - at threshold (violation) - pandas
         (
             "pandas",
@@ -134,23 +101,7 @@ def test_expectation_name():
             "Found 3 row(s) where 'col1' is not less than 2.",
         ),
         (
-            "pyspark",
-            [2, 3, 4],
-            2,
-            "failure",
-            [2, 3, 4],
-            "Found 3 row(s) where 'col1' is not less than 2.",
-        ),
-        (
             "pandas",
-            [5, 5, 5],
-            5,
-            "failure",
-            [5, 5, 5],
-            "Found 3 row(s) where 'col1' is not less than 5.",
-        ),
-        (
-            "pyspark",
             [5, 5, 5],
             5,
             "failure",
@@ -166,21 +117,10 @@ def test_expectation_name():
             [3, 4, 5],
             "Found 3 row(s) where 'col1' is not less than 3.",
         ),
-        (
-            "pyspark",
-            [3, 4, 5],
-            3,
-            "failure",
-            [3, 4, 5],
-            "Found 3 row(s) where 'col1' is not less than 3.",
-        ),
         # Negative values - success
         ("pandas", [-5, -3, -2], 0, "success", None, None),
-        ("pyspark", [-5, -3, -2], 0, "success", None, None),
         ("pandas", [-10, -8, -6], -5, "success", None, None),
-        ("pyspark", [-10, -8, -6], -5, "success", None, None),
         ("pandas", [-3, -2, -1], 0, "success", None, None),
-        ("pyspark", [-3, -2, -1], 0, "success", None, None),
         # Negative values - violations
         (
             "pandas",
@@ -191,23 +131,7 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is not less than -2.",
         ),
         (
-            "pyspark",
-            [-1, -2, -3],
-            -2,
-            "failure",
-            [-1, -2],
-            "Found 2 row(s) where 'col1' is not less than -2.",
-        ),
-        (
             "pandas",
-            [-3, -4, -5],
-            -5,
-            "failure",
-            [-3, -4, -5],
-            "Found 3 row(s) where 'col1' is not less than -5.",
-        ),
-        (
-            "pyspark",
             [-3, -4, -5],
             -5,
             "failure",
@@ -216,11 +140,8 @@ def test_expectation_name():
         ),
         # Float values - success
         ("pandas", [1.5, 2.3, 3.8], 4.0, "success", None, None),
-        ("pyspark", [1.5, 2.3, 3.8], 4.0, "success", None, None),
         ("pandas", [0.5, 1.5, 2.5], 3.0, "success", None, None),
-        ("pyspark", [0.5, 1.5, 2.5], 3.0, "success", None, None),
         ("pandas", [9.8, 9.9, 9.95], 10.0, "success", None, None),
-        ("pyspark", [9.8, 9.9, 9.95], 10.0, "success", None, None),
         # Float values - violations
         (
             "pandas",
@@ -231,23 +152,7 @@ def test_expectation_name():
             "Found 3 row(s) where 'col1' is not less than 2.5.",
         ),
         (
-            "pyspark",
-            [2.5, 3.0, 3.5],
-            2.5,
-            "failure",
-            [2.5, 3.0, 3.5],
-            "Found 3 row(s) where 'col1' is not less than 2.5.",
-        ),
-        (
             "pandas",
-            [1.5, 2.5, 3.5],
-            2.0,
-            "failure",
-            [2.5, 3.5],
-            "Found 2 row(s) where 'col1' is not less than 2.0.",
-        ),
-        (
-            "pyspark",
             [1.5, 2.5, 3.5],
             2.0,
             "failure",
@@ -256,9 +161,7 @@ def test_expectation_name():
         ),
         # Zero as threshold - success
         ("pandas", [-3, -2, -1], 0, "success", None, None),
-        ("pyspark", [-3, -2, -1], 0, "success", None, None),
         ("pandas", [-1.0, -0.5, -0.1], 0, "success", None, None),
-        ("pyspark", [-1.0, -0.5, -0.1], 0, "success", None, None),
         # Zero as threshold - violations
         (
             "pandas",
@@ -269,23 +172,7 @@ def test_expectation_name():
             "Found 3 row(s) where 'col1' is not less than 0.",
         ),
         (
-            "pyspark",
-            [0, 1, 2],
-            0,
-            "failure",
-            [0, 1, 2],
-            "Found 3 row(s) where 'col1' is not less than 0.",
-        ),
-        (
             "pandas",
-            [-1, 0, 1],
-            0,
-            "failure",
-            [0, 1],
-            "Found 2 row(s) where 'col1' is not less than 0.",
-        ),
-        (
-            "pyspark",
             [-1, 0, 1],
             0,
             "failure",
@@ -294,7 +181,6 @@ def test_expectation_name():
         ),
         # Zero in data - success - pandas
         ("pandas", [-2, -1, 0], 1, "success", None, None),
-        ("pyspark", [-2, -1, 0], 1, "success", None, None),
         # Zero in data - violations - pandas
         (
             "pandas",
@@ -304,19 +190,9 @@ def test_expectation_name():
             [0, 1, 2],
             "Found 3 row(s) where 'col1' is not less than 0.",
         ),
-        (
-            "pyspark",
-            [0, 1, 2],
-            0,
-            "failure",
-            [0, 1, 2],
-            "Found 3 row(s) where 'col1' is not less than 0.",
-        ),
         # Single value - success
         ("pandas", [3], 4, "success", None, None),
-        ("pyspark", [3], 4, "success", None, None),
         ("pandas", [0], 10, "success", None, None),
-        ("pyspark", [0], 10, "success", None, None),
         # Single value - violation
         (
             "pandas",
@@ -327,23 +203,7 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not less than 5.",
         ),
         (
-            "pyspark",
-            [5],
-            5,
-            "failure",
-            [5],
-            "Found 1 row(s) where 'col1' is not less than 5.",
-        ),
-        (
             "pandas",
-            [10],
-            5,
-            "failure",
-            [10],
-            "Found 1 row(s) where 'col1' is not less than 5.",
-        ),
-        (
-            "pyspark",
             [10],
             5,
             "failure",
@@ -359,27 +219,10 @@ def test_expectation_name():
             [5, 5, 5, 5],
             "Found 4 row(s) where 'col1' is not less than 5.",
         ),
-        (
-            "pyspark",
-            [5, 5, 5, 5],
-            5,
-            "failure",
-            [5, 5, 5, 5],
-            "Found 4 row(s) where 'col1' is not less than 5.",
-        ),
         # Mixed integers and floats
         ("pandas", [1, 1.5, 2, 2.5], 3, "success", None, None),
-        ("pyspark", [1, 1.5, 2, 2.5], 3, "success", None, None),
         (
             "pandas",
-            [2, 2.5, 3, 3.5],
-            2.5,
-            "failure",
-            [2.5, 3, 3.5],
-            "Found 3 row(s) where 'col1' is not less than 2.5.",
-        ),
-        (
-            "pyspark",
             [2, 2.5, 3, 3.5],
             2.5,
             "failure",
@@ -388,17 +231,8 @@ def test_expectation_name():
         ),
         # Large values
         ("pandas", [100, 500, 900], 1000, "success", None, None),
-        ("pyspark", [100, 500, 900], 1000, "success", None, None),
         (
             "pandas",
-            [1000, 1500, 2000],
-            1000,
-            "failure",
-            [1000, 1500, 2000],
-            "Found 3 row(s) where 'col1' is not less than 1000.",
-        ),
-        (
-            "pyspark",
             [1000, 1500, 2000],
             1000,
             "failure",
@@ -414,19 +248,9 @@ def test_expectation_name():
             [6, 7, 8],
             "Found 3 row(s) where 'col1' is not less than 5.",
         ),
-        (
-            "pyspark",
-            [6, 7, 8],
-            5,
-            "failure",
-            [6, 7, 8],
-            "Found 3 row(s) where 'col1' is not less than 5.",
-        ),
         # With nulls - success (nulls are ignored)
         ("pandas", [1, None, 2, None, 3], 5, "success", None, None),
-        ("pyspark", [1, None, 2, None, 3], 5, "success", None, None),
         ("pandas", [0, None, 5, None], 10, "success", None, None),
-        ("pyspark", [0, None, 5, None], 10, "success", None, None),
         # With nulls - violations
         (
             "pandas",
@@ -436,111 +260,60 @@ def test_expectation_name():
             [5.0, 6.0],
             "Found 2 row(s) where 'col1' is not less than 5.",
         ),
-        (
-            "pyspark",
-            [2, None, 5, 6],
-            5,
-            "failure",
-            [5, 6],
-            "Found 2 row(s) where 'col1' is not less than 5.",
-        ),
     ],
     ids=[
         "pandas_basic_success",
-        "pyspark_basic_success",
         "pandas_success_different_data",
-        "pyspark_success_different_data",
         "pandas_success_small_values",
-        "pyspark_success_small_values",
         "pandas_basic_violations",
-        "pyspark_basic_violations",
         "pandas_all_violations",
-        "pyspark_all_violations",
         "pandas_partial_violations",
-        "pyspark_partial_violations",
         "pandas_boundary_just_below",
-        "pyspark_boundary_just_below",
         "pandas_boundary_just_below_float",
-        "pyspark_boundary_just_below_float",
         "pandas_boundary_at_threshold",
-        "pyspark_boundary_at_threshold",
         "pandas_boundary_all_at_threshold",
-        "pyspark_boundary_all_at_threshold",
         "pandas_boundary_above_threshold",
-        "pyspark_boundary_above_threshold",
         "pandas_negative_success",
-        "pyspark_negative_success",
         "pandas_negative_range_success",
-        "pyspark_negative_range_success",
         "pandas_negative_to_zero_success",
-        "pyspark_negative_to_zero_success",
         "pandas_negative_violations",
-        "pyspark_negative_violations",
         "pandas_negative_all_violations",
-        "pyspark_negative_all_violations",
         "pandas_float_success",
-        "pyspark_float_success",
         "pandas_float_different_success",
-        "pyspark_float_different_success",
         "pandas_float_precise_success",
-        "pyspark_float_precise_success",
         "pandas_float_violations",
-        "pyspark_float_violations",
         "pandas_float_mixed_violations",
-        "pyspark_float_mixed_violations",
         "pandas_zero_threshold_success",
-        "pyspark_zero_threshold_success",
         "pandas_zero_threshold_float_success",
-        "pyspark_zero_threshold_float_success",
         "pandas_zero_threshold_violations",
-        "pyspark_zero_threshold_violations",
         "pandas_zero_threshold_mixed_violations",
-        "pyspark_zero_threshold_mixed_violations",
         "pandas_zero_in_data_success",
-        "pyspark_zero_in_data_success",
         "pandas_zero_in_data_violation",
-        "pyspark_zero_in_data_violation",
         "pandas_single_value_success",
-        "pyspark_single_value_success",
         "pandas_single_value_large_success",
-        "pyspark_single_value_large_success",
         "pandas_single_value_violation",
-        "pyspark_single_value_violation",
         "pandas_single_value_above_violation",
-        "pyspark_single_value_above_violation",
         "pandas_all_equal_threshold",
-        "pyspark_all_equal_threshold",
         "pandas_mixed_types_success",
-        "pyspark_mixed_types_success",
         "pandas_mixed_types_violations",
-        "pyspark_mixed_types_violations",
         "pandas_large_values_success",
-        "pyspark_large_values_success",
         "pandas_large_values_violations",
-        "pyspark_large_values_violations",
         "pandas_all_above_threshold",
-        "pyspark_all_above_threshold",
         "pandas_with_nulls_success",
-        "pyspark_with_nulls_success",
         "pandas_with_nulls_large_success",
-        "pyspark_with_nulls_large_success",
         "pandas_with_nulls_violations",
-        "pyspark_with_nulls_violations",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, data, threshold, expected_result, expected_violations, expected_message, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, data, threshold, expected_result, expected_violations, expected_message
 ):
     """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
+    Test the expectation for various scenarios across pandas DataFrames.
     Tests both direct expectation validation and suite-based validation.
     Covers: success cases, boundary conditions, violations, negative values, floats,
     zero values, single values, mixed types, large values, and nulls.
     """
-    # Determine data type based on whether we have float values (excluding None)
-    has_float = any(isinstance(val, float) for val in data if val is not None)
-    data_type = "double" if has_float else "long"
-    data_frame = create_dataframe(df_type, data, "col1", spark, data_type)
+    data_frame = pd.DataFrame({"col1": data})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -556,8 +329,314 @@ def test_expectation_basic_scenarios(
             DataFrameExpectationSuccessMessage(expectation_name="ExpectationValueLessThan")
         ), f"Expected success message but got: {result}"
     else:  # failure
-        expected_violations_df = create_dataframe(
-            df_type, expected_violations, "col1", spark, data_type
+        expected_violations_df = pd.DataFrame({"col1": expected_violations})
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            violations_data_frame=expected_violations_df,
+            message=expected_message,
+            limit_violations=5,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_value_less_than(
+        column_name="col1", value=threshold
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+@pytest.mark.parametrize(
+    "df_type, data, threshold, expected_result, expected_violations, expected_message",
+    [
+        # Basic success scenarios
+        ("pyspark", [3, 4, 5], 6, "success", None, None),
+        ("pyspark", [1, 2, 3], 4, "success", None, None),
+        ("pyspark", [0, 1, 2], 5, "success", None, None),
+        # Basic violation scenarios
+        (
+            "pyspark",
+            [3, 4, 5],
+            5,
+            "failure",
+            [5],
+            "Found 1 row(s) where 'col1' is not less than 5.",
+        ),
+        (
+            "pyspark",
+            [3, 4, 5],
+            3,
+            "failure",
+            [3, 4, 5],
+            "Found 3 row(s) where 'col1' is not less than 3.",
+        ),
+        (
+            "pyspark",
+            [2, 3, 4, 5],
+            4,
+            "failure",
+            [4, 5],
+            "Found 2 row(s) where 'col1' is not less than 4.",
+        ),
+        # Boundary conditions - just below threshold - pandas
+        ("pyspark", [1, 2, 3], 4, "success", None, None),
+        ("pyspark", [1.5, 1.8, 1.9], 2.0, "success", None, None),
+        # Boundary conditions - at threshold (violation) - pandas
+        (
+            "pyspark",
+            [2, 3, 4],
+            2,
+            "failure",
+            [2, 3, 4],
+            "Found 3 row(s) where 'col1' is not less than 2.",
+        ),
+        (
+            "pyspark",
+            [5, 5, 5],
+            5,
+            "failure",
+            [5, 5, 5],
+            "Found 3 row(s) where 'col1' is not less than 5.",
+        ),
+        # Boundary conditions - just above threshold - pandas
+        (
+            "pyspark",
+            [3, 4, 5],
+            3,
+            "failure",
+            [3, 4, 5],
+            "Found 3 row(s) where 'col1' is not less than 3.",
+        ),
+        # Negative values - success
+        ("pyspark", [-5, -3, -2], 0, "success", None, None),
+        ("pyspark", [-10, -8, -6], -5, "success", None, None),
+        ("pyspark", [-3, -2, -1], 0, "success", None, None),
+        # Negative values - violations
+        (
+            "pyspark",
+            [-1, -2, -3],
+            -2,
+            "failure",
+            [-1, -2],
+            "Found 2 row(s) where 'col1' is not less than -2.",
+        ),
+        (
+            "pyspark",
+            [-3, -4, -5],
+            -5,
+            "failure",
+            [-3, -4, -5],
+            "Found 3 row(s) where 'col1' is not less than -5.",
+        ),
+        # Float values - success
+        ("pyspark", [1.5, 2.3, 3.8], 4.0, "success", None, None),
+        ("pyspark", [0.5, 1.5, 2.5], 3.0, "success", None, None),
+        ("pyspark", [9.8, 9.9, 9.95], 10.0, "success", None, None),
+        # Float values - violations
+        (
+            "pyspark",
+            [2.5, 3.0, 3.5],
+            2.5,
+            "failure",
+            [2.5, 3.0, 3.5],
+            "Found 3 row(s) where 'col1' is not less than 2.5.",
+        ),
+        (
+            "pyspark",
+            [1.5, 2.5, 3.5],
+            2.0,
+            "failure",
+            [2.5, 3.5],
+            "Found 2 row(s) where 'col1' is not less than 2.0.",
+        ),
+        # Zero as threshold - success
+        ("pyspark", [-3, -2, -1], 0, "success", None, None),
+        ("pyspark", [-1.0, -0.5, -0.1], 0, "success", None, None),
+        # Zero as threshold - violations
+        (
+            "pyspark",
+            [0, 1, 2],
+            0,
+            "failure",
+            [0, 1, 2],
+            "Found 3 row(s) where 'col1' is not less than 0.",
+        ),
+        (
+            "pyspark",
+            [-1, 0, 1],
+            0,
+            "failure",
+            [0, 1],
+            "Found 2 row(s) where 'col1' is not less than 0.",
+        ),
+        # Zero in data - success - pandas
+        ("pyspark", [-2, -1, 0], 1, "success", None, None),
+        # Zero in data - violations - pandas
+        (
+            "pyspark",
+            [0, 1, 2],
+            0,
+            "failure",
+            [0, 1, 2],
+            "Found 3 row(s) where 'col1' is not less than 0.",
+        ),
+        # Single value - success
+        ("pyspark", [3], 4, "success", None, None),
+        ("pyspark", [0], 10, "success", None, None),
+        # Single value - violation
+        (
+            "pyspark",
+            [5],
+            5,
+            "failure",
+            [5],
+            "Found 1 row(s) where 'col1' is not less than 5.",
+        ),
+        (
+            "pyspark",
+            [10],
+            5,
+            "failure",
+            [10],
+            "Found 1 row(s) where 'col1' is not less than 5.",
+        ),
+        # All values equal to threshold
+        (
+            "pyspark",
+            [5, 5, 5, 5],
+            5,
+            "failure",
+            [5, 5, 5, 5],
+            "Found 4 row(s) where 'col1' is not less than 5.",
+        ),
+        # Mixed integers and floats
+        ("pyspark", [1, 1.5, 2, 2.5], 3, "success", None, None),
+        (
+            "pyspark",
+            [2, 2.5, 3, 3.5],
+            2.5,
+            "failure",
+            [2.5, 3, 3.5],
+            "Found 3 row(s) where 'col1' is not less than 2.5.",
+        ),
+        # Large values
+        ("pyspark", [100, 500, 900], 1000, "success", None, None),
+        (
+            "pyspark",
+            [1000, 1500, 2000],
+            1000,
+            "failure",
+            [1000, 1500, 2000],
+            "Found 3 row(s) where 'col1' is not less than 1000.",
+        ),
+        # All values above threshold
+        (
+            "pyspark",
+            [6, 7, 8],
+            5,
+            "failure",
+            [6, 7, 8],
+            "Found 3 row(s) where 'col1' is not less than 5.",
+        ),
+        # With nulls - success (nulls are ignored)
+        ("pyspark", [1, None, 2, None, 3], 5, "success", None, None),
+        ("pyspark", [0, None, 5, None], 10, "success", None, None),
+        # With nulls - violations
+        (
+            "pyspark",
+            [2, None, 5, 6],
+            5,
+            "failure",
+            [5, 6],
+            "Found 2 row(s) where 'col1' is not less than 5.",
+        ),
+    ],
+    ids=[
+        "pyspark_basic_success",
+        "pyspark_success_different_data",
+        "pyspark_success_small_values",
+        "pyspark_basic_violations",
+        "pyspark_all_violations",
+        "pyspark_partial_violations",
+        "pyspark_boundary_just_below",
+        "pyspark_boundary_just_below_float",
+        "pyspark_boundary_at_threshold",
+        "pyspark_boundary_all_at_threshold",
+        "pyspark_boundary_above_threshold",
+        "pyspark_negative_success",
+        "pyspark_negative_range_success",
+        "pyspark_negative_to_zero_success",
+        "pyspark_negative_violations",
+        "pyspark_negative_all_violations",
+        "pyspark_float_success",
+        "pyspark_float_different_success",
+        "pyspark_float_precise_success",
+        "pyspark_float_violations",
+        "pyspark_float_mixed_violations",
+        "pyspark_zero_threshold_success",
+        "pyspark_zero_threshold_float_success",
+        "pyspark_zero_threshold_violations",
+        "pyspark_zero_threshold_mixed_violations",
+        "pyspark_zero_in_data_success",
+        "pyspark_zero_in_data_violation",
+        "pyspark_single_value_success",
+        "pyspark_single_value_large_success",
+        "pyspark_single_value_violation",
+        "pyspark_single_value_above_violation",
+        "pyspark_all_equal_threshold",
+        "pyspark_mixed_types_success",
+        "pyspark_mixed_types_violations",
+        "pyspark_large_values_success",
+        "pyspark_large_values_violations",
+        "pyspark_all_above_threshold",
+        "pyspark_with_nulls_success",
+        "pyspark_with_nulls_large_success",
+        "pyspark_with_nulls_violations",
+    ],
+)
+def test_expectation_basic_scenarios_pyspark(
+    df_type, data, threshold, expected_result, expected_violations, expected_message, spark
+):
+    """
+    Test the expectation for various scenarios across PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases, boundary conditions, violations, negative values, floats,
+    zero values, single values, mixed types, large values, and nulls.
+    """
+    # Determine data type based on whether we have float values (excluding None)
+    has_float = any(isinstance(val, float) for val in data if val is not None)
+    data_type = "double" if has_float else "long"
+    data_frame = create_pyspark_dataframe(data, "col1", spark, data_type)
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueLessThan",
+        column_name="col1",
+        value=threshold,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationValueLessThan")
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        expected_violations_df = create_pyspark_dataframe(
+            expected_violations, "col1", spark, data_type
         )
         expected_failure_message = DataFrameExpectationFailureMessage(
             expectation_str=str(expectation),
@@ -587,19 +666,11 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
-@pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
-)
-def test_column_missing_error(df_type, spark):
-    """Test that an error is raised when the specified column is missing in both pandas and PySpark."""
+def test_column_missing_error_pandas():
+    """Test that an error is raised when the specified column is missing in pandas."""
     expected_message = "Column 'col1' does not exist in the DataFrame."
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col2": [3, 4, 5]})
-    else:  # pyspark
-        data_frame = spark.createDataFrame([(3,), (4,), (5,)], ["col2"])
+    data_frame = pd.DataFrame({"col2": [3, 4, 5]})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -610,7 +681,36 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=data_frame)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_value_less_than(
+        column_name="col1", value=5
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test that an error is raised when the specified column is missing in PySpark."""
+    expected_message = "Column 'col1' does not exist in the DataFrame."
+
+    data_frame = spark.createDataFrame([(3,), (4,), (5,)], ["col2"])
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueLessThan",
+        column_name="col1",
+        value=5,
+    )
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message=expected_message,
     )
     assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"

--- a/tests/expectations/column/numerical_expectations/test_expect_value_less_than.py
+++ b/tests/expectations/column/numerical_expectations/test_expect_value_less_than.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 import pandas as pd
 
 from dataframe_expectations.registry import (
@@ -88,10 +89,10 @@ def test_expectation_name():
             [4, 5],
             "Found 2 row(s) where 'col1' is not less than 4.",
         ),
-        # Boundary conditions - just below threshold - pandas
+        # Boundary conditions - just below threshold
         ("pandas", [1, 2, 3], 4, "success", None, None),
         ("pandas", [1.5, 1.8, 1.9], 2.0, "success", None, None),
-        # Boundary conditions - at threshold (violation) - pandas
+        # Boundary conditions - at threshold (violation)
         (
             "pandas",
             [2, 3, 4],
@@ -108,7 +109,7 @@ def test_expectation_name():
             [5, 5, 5],
             "Found 3 row(s) where 'col1' is not less than 5.",
         ),
-        # Boundary conditions - just above threshold - pandas
+        # Boundary conditions - just above threshold
         (
             "pandas",
             [3, 4, 5],
@@ -179,9 +180,9 @@ def test_expectation_name():
             [0, 1],
             "Found 2 row(s) where 'col1' is not less than 0.",
         ),
-        # Zero in data - success - pandas
+        # Zero in data - success
         ("pandas", [-2, -1, 0], 1, "success", None, None),
-        # Zero in data - violations - pandas
+        # Zero in data - violations
         (
             "pandas",
             [0, 1, 2],
@@ -391,10 +392,10 @@ def test_expectation_basic_scenarios_pandas(
             [4, 5],
             "Found 2 row(s) where 'col1' is not less than 4.",
         ),
-        # Boundary conditions - just below threshold - pandas
+        # Boundary conditions - just below threshold
         ("pyspark", [1, 2, 3], 4, "success", None, None),
         ("pyspark", [1.5, 1.8, 1.9], 2.0, "success", None, None),
-        # Boundary conditions - at threshold (violation) - pandas
+        # Boundary conditions - at threshold (violation)
         (
             "pyspark",
             [2, 3, 4],
@@ -411,7 +412,7 @@ def test_expectation_basic_scenarios_pandas(
             [5, 5, 5],
             "Found 3 row(s) where 'col1' is not less than 5.",
         ),
-        # Boundary conditions - just above threshold - pandas
+        # Boundary conditions - just above threshold
         (
             "pyspark",
             [3, 4, 5],
@@ -482,9 +483,9 @@ def test_expectation_basic_scenarios_pandas(
             [0, 1],
             "Found 2 row(s) where 'col1' is not less than 0.",
         ),
-        # Zero in data - success - pandas
+        # Zero in data - success
         ("pyspark", [-2, -1, 0], 1, "success", None, None),
-        # Zero in data - violations - pandas
+        # Zero in data - violations
         (
             "pyspark",
             [0, 1, 2],
@@ -725,8 +726,6 @@ def test_column_missing_error_pyspark(spark):
 
 def test_large_dataset_performance():
     """Test the expectation with a larger dataset to ensure performance."""
-    import numpy as np
-
     # Create a larger dataset with values between 10 and 100
     large_data = np.random.uniform(10, 100, 10000).tolist()
     data_frame = pd.DataFrame({"col1": large_data})

--- a/tests/expectations/column/numerical_expectations/test_expect_value_less_than_equals.py
+++ b/tests/expectations/column/numerical_expectations/test_expect_value_less_than_equals.py
@@ -8,44 +8,40 @@ from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
-from dataframe_expectations.core.suite_result import SuiteExecutionResult
 
 
-def create_dataframe(df_type, data, column_name, spark, data_type="long"):
-    """Helper function to create pandas or pyspark DataFrame.
+def create_pyspark_dataframe(data, column_name, spark, data_type="long"):
+    """Helper function to create a PySpark DataFrame.
 
     Args:
-        df_type: "pandas" or "pyspark"
         data: List of values for the column
         column_name: Name of the column
         spark: Spark session (required for pyspark)
         data_type: Data type for the column - "long", "double"
     """
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        from pyspark.sql.types import (
-            StructType,
-            StructField,
-            LongType,
-            DoubleType,
-        )
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        LongType,
+        DoubleType,
+    )
 
-        type_mapping = {
-            "long": LongType(),
-            "double": DoubleType(),
-        }
+    type_mapping = {
+        "long": LongType(),
+        "double": DoubleType(),
+    }
 
-        # Convert integers to floats when using double type to avoid type mismatch
-        if data_type == "double":
-            data = [float(val) if val is not None else None for val in data]
+    # Convert integers to floats when using double type to avoid type mismatch
+    if data_type == "double":
+        data = [float(val) if val is not None else None for val in data]
 
-        schema = StructType([StructField(column_name, type_mapping[data_type], True)])
-        return spark.createDataFrame([(val,) for val in data], schema)
+    schema = StructType([StructField(column_name, type_mapping[data_type], True)])
+    return spark.createDataFrame([(val,) for val in data], schema)
 
 
 def test_expectation_name():
@@ -65,16 +61,11 @@ def test_expectation_name():
     [
         # Basic success scenarios
         ("pandas", [1, 2, 3], 5, "success", None, None),
-        ("pyspark", [1, 2, 3], 5, "success", None, None),
         ("pandas", [1, 2, 3], 4, "success", None, None),
-        ("pyspark", [1, 2, 3], 4, "success", None, None),
         ("pandas", [5, 10, 15], 20, "success", None, None),
-        ("pyspark", [5, 10, 15], 20, "success", None, None),
         # Success at threshold (key difference from less than)
         ("pandas", [3, 4, 5], 5, "success", None, None),
-        ("pyspark", [3, 4, 5], 5, "success", None, None),
         ("pandas", [5, 5, 5], 5, "success", None, None),
-        ("pyspark", [5, 5, 5], 5, "success", None, None),
         # Basic violation scenarios
         (
             "pandas",
@@ -85,23 +76,7 @@ def test_expectation_name():
             "Found 3 row(s) where 'col1' is not less than or equal to 3.",
         ),
         (
-            "pyspark",
-            [4, 5, 6],
-            3,
-            "failure",
-            [4, 5, 6],
-            "Found 3 row(s) where 'col1' is not less than or equal to 3.",
-        ),
-        (
             "pandas",
-            [3, 4, 5, 6],
-            4,
-            "failure",
-            [5, 6],
-            "Found 2 row(s) where 'col1' is not less than or equal to 4.",
-        ),
-        (
-            "pyspark",
             [3, 4, 5, 6],
             4,
             "failure",
@@ -110,9 +85,7 @@ def test_expectation_name():
         ),
         # Boundary conditions - at threshold (success for <=)
         ("pandas", [2, 3, 4], 4, "success", None, None),
-        ("pyspark", [2, 3, 4], 4, "success", None, None),
         ("pandas", [1, 2, 3], 3, "success", None, None),
-        ("pyspark", [1, 2, 3], 3, "success", None, None),
         # Boundary conditions - just above threshold (violation)
         (
             "pandas",
@@ -123,23 +96,7 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not less than or equal to 4.",
         ),
         (
-            "pyspark",
-            [3, 4, 5],
-            4,
-            "failure",
-            [5],
-            "Found 1 row(s) where 'col1' is not less than or equal to 4.",
-        ),
-        (
             "pandas",
-            [2, 2.1, 3],
-            2,
-            "failure",
-            [2.1, 3],
-            "Found 2 row(s) where 'col1' is not less than or equal to 2.",
-        ),
-        (
-            "pyspark",
             [2, 2.1, 3],
             2,
             "failure",
@@ -148,14 +105,10 @@ def test_expectation_name():
         ),
         # Negative values - success
         ("pandas", [-3, -2, -1], 0, "success", None, None),
-        ("pyspark", [-3, -2, -1], 0, "success", None, None),
         ("pandas", [-5, -4, -3], -2, "success", None, None),
-        ("pyspark", [-5, -4, -3], -2, "success", None, None),
         ("pandas", [-10, -5, 0], 5, "success", None, None),
-        ("pyspark", [-10, -5, 0], 5, "success", None, None),
         # Negative values - success at threshold
         ("pandas", [-2, -1, 0], 0, "success", None, None),
-        ("pyspark", [-2, -1, 0], 0, "success", None, None),
         # Negative values - violations
         (
             "pandas",
@@ -166,23 +119,7 @@ def test_expectation_name():
             "Found 3 row(s) where 'col1' is not less than or equal to -2.",
         ),
         (
-            "pyspark",
-            [-1, 0, 1],
-            -2,
-            "failure",
-            [-1, 0, 1],
-            "Found 3 row(s) where 'col1' is not less than or equal to -2.",
-        ),
-        (
             "pandas",
-            [-3, -2, -1],
-            -2,
-            "failure",
-            [-1],
-            "Found 1 row(s) where 'col1' is not less than or equal to -2.",
-        ),
-        (
-            "pyspark",
             [-3, -2, -1],
             -2,
             "failure",
@@ -191,11 +128,8 @@ def test_expectation_name():
         ),
         # Float values - success
         ("pandas", [1.5, 2.0, 2.5], 3.0, "success", None, None),
-        ("pyspark", [1.5, 2.0, 2.5], 3.0, "success", None, None),
         ("pandas", [1.0, 2.0, 3.0], 3.0, "success", None, None),
-        ("pyspark", [1.0, 2.0, 3.0], 3.0, "success", None, None),
         ("pandas", [9.7, 9.8, 10.0], 10.0, "success", None, None),
-        ("pyspark", [9.7, 9.8, 10.0], 10.0, "success", None, None),
         # Float values - violations
         (
             "pandas",
@@ -206,23 +140,7 @@ def test_expectation_name():
             "Found 2 row(s) where 'col1' is not less than or equal to 2.4.",
         ),
         (
-            "pyspark",
-            [2.0, 2.5, 3.0],
-            2.4,
-            "failure",
-            [2.5, 3.0],
-            "Found 2 row(s) where 'col1' is not less than or equal to 2.4.",
-        ),
-        (
             "pandas",
-            [1.5, 2.5, 3.5],
-            2.9,
-            "failure",
-            [3.5],
-            "Found 1 row(s) where 'col1' is not less than or equal to 2.9.",
-        ),
-        (
-            "pyspark",
             [1.5, 2.5, 3.5],
             2.9,
             "failure",
@@ -231,9 +149,7 @@ def test_expectation_name():
         ),
         # Zero as threshold - success
         ("pandas", [-2, -1, 0], 0, "success", None, None),
-        ("pyspark", [-2, -1, 0], 0, "success", None, None),
         ("pandas", [-1.0, -0.5, 0.0], 0, "success", None, None),
-        ("pyspark", [-1.0, -0.5, 0.0], 0, "success", None, None),
         # Zero as threshold - violations
         (
             "pandas",
@@ -244,23 +160,7 @@ def test_expectation_name():
             "Found 3 row(s) where 'col1' is not less than or equal to -1.",
         ),
         (
-            "pyspark",
-            [0, 1, 2],
-            -1,
-            "failure",
-            [0, 1, 2],
-            "Found 3 row(s) where 'col1' is not less than or equal to -1.",
-        ),
-        (
             "pandas",
-            [-1, 0, 1],
-            0,
-            "failure",
-            [1],
-            "Found 1 row(s) where 'col1' is not less than or equal to 0.",
-        ),
-        (
-            "pyspark",
             [-1, 0, 1],
             0,
             "failure",
@@ -269,14 +169,10 @@ def test_expectation_name():
         ),
         # Zero in data - success (including zero at threshold)
         ("pandas", [0, 1, 2], 2, "success", None, None),
-        ("pyspark", [0, 1, 2], 2, "success", None, None),
         # Single value - success
         ("pandas", [3], 5, "success", None, None),
-        ("pyspark", [3], 5, "success", None, None),
         ("pandas", [5], 5, "success", None, None),
-        ("pyspark", [5], 5, "success", None, None),
         ("pandas", [0], 10, "success", None, None),
-        ("pyspark", [0], 10, "success", None, None),
         # Single value - violation
         (
             "pandas",
@@ -287,23 +183,7 @@ def test_expectation_name():
             "Found 1 row(s) where 'col1' is not less than or equal to 4.",
         ),
         (
-            "pyspark",
-            [5],
-            4,
-            "failure",
-            [5],
-            "Found 1 row(s) where 'col1' is not less than or equal to 4.",
-        ),
-        (
             "pandas",
-            [10],
-            5,
-            "failure",
-            [10],
-            "Found 1 row(s) where 'col1' is not less than or equal to 5.",
-        ),
-        (
-            "pyspark",
             [10],
             5,
             "failure",
@@ -312,20 +192,10 @@ def test_expectation_name():
         ),
         # All values equal to threshold (success for <=)
         ("pandas", [5, 5, 5, 5], 5, "success", None, None),
-        ("pyspark", [5, 5, 5, 5], 5, "success", None, None),
         # Mixed integers and floats
         ("pandas", [1, 1.5, 2, 2.5], 3, "success", None, None),
-        ("pyspark", [1, 1.5, 2, 2.5], 3, "success", None, None),
         (
             "pandas",
-            [2, 2.5, 3, 3.5],
-            2.9,
-            "failure",
-            [3, 3.5],
-            "Found 2 row(s) where 'col1' is not less than or equal to 2.9.",
-        ),
-        (
-            "pyspark",
             [2, 2.5, 3, 3.5],
             2.9,
             "failure",
@@ -334,17 +204,8 @@ def test_expectation_name():
         ),
         # Large values
         ("pandas", [1000, 2000, 3000], 3000, "success", None, None),
-        ("pyspark", [1000, 2000, 3000], 3000, "success", None, None),
         (
             "pandas",
-            [1000, 1500, 2000],
-            999,
-            "failure",
-            [1000, 1500, 2000],
-            "Found 3 row(s) where 'col1' is not less than or equal to 999.",
-        ),
-        (
-            "pyspark",
             [1000, 1500, 2000],
             999,
             "failure",
@@ -360,19 +221,9 @@ def test_expectation_name():
             [6, 7, 8],
             "Found 3 row(s) where 'col1' is not less than or equal to 5.",
         ),
-        (
-            "pyspark",
-            [6, 7, 8],
-            5,
-            "failure",
-            [6, 7, 8],
-            "Found 3 row(s) where 'col1' is not less than or equal to 5.",
-        ),
         # With nulls - success (nulls are ignored)
         ("pandas", [1, None, 2, None, 3], 3, "success", None, None),
-        ("pyspark", [1, None, 2, None, 3], 3, "success", None, None),
         ("pandas", [5, None, 10, None], 15, "success", None, None),
-        ("pyspark", [5, None, 10, None], 15, "success", None, None),
         # With nulls - violations
         (
             "pandas",
@@ -382,113 +233,61 @@ def test_expectation_name():
             [4.0],
             "Found 1 row(s) where 'col1' is not less than or equal to 3.",
         ),
-        (
-            "pyspark",
-            [2, None, 3, 4],
-            3,
-            "failure",
-            [4],
-            "Found 1 row(s) where 'col1' is not less than or equal to 3.",
-        ),
     ],
     ids=[
         "pandas_basic_success",
-        "pyspark_basic_success",
         "pandas_success_different_data",
-        "pyspark_success_different_data",
         "pandas_success_large_values",
-        "pyspark_success_large_values",
         "pandas_success_at_threshold",
-        "pyspark_success_at_threshold",
         "pandas_success_all_equal_threshold",
-        "pyspark_success_all_equal_threshold",
         "pandas_basic_violations",
-        "pyspark_basic_violations",
         "pandas_partial_violations",
-        "pyspark_partial_violations",
         "pandas_boundary_at_threshold_success",
-        "pyspark_boundary_at_threshold_success",
         "pandas_boundary_at_threshold_success_2",
-        "pyspark_boundary_at_threshold_success_2",
         "pandas_boundary_above_threshold",
-        "pyspark_boundary_above_threshold",
         "pandas_boundary_above_threshold_float",
-        "pyspark_boundary_above_threshold_float",
         "pandas_negative_success",
-        "pyspark_negative_success",
         "pandas_negative_range_success",
-        "pyspark_negative_range_success",
         "pandas_negative_large_success",
-        "pyspark_negative_large_success",
         "pandas_negative_at_threshold_success",
-        "pyspark_negative_at_threshold_success",
         "pandas_negative_violations",
-        "pyspark_negative_violations",
         "pandas_negative_partial_violations",
-        "pyspark_negative_partial_violations",
         "pandas_float_success",
-        "pyspark_float_success",
         "pandas_float_at_threshold_success",
-        "pyspark_float_at_threshold_success",
         "pandas_float_precise_success",
-        "pyspark_float_precise_success",
         "pandas_float_violations",
-        "pyspark_float_violations",
         "pandas_float_partial_violations",
-        "pyspark_float_partial_violations",
         "pandas_zero_threshold_success",
-        "pyspark_zero_threshold_success",
         "pandas_zero_threshold_float_success",
-        "pyspark_zero_threshold_float_success",
         "pandas_zero_threshold_violations",
-        "pyspark_zero_threshold_violations",
         "pandas_zero_threshold_partial_violations",
-        "pyspark_zero_threshold_partial_violations",
         "pandas_zero_in_data_success",
-        "pyspark_zero_in_data_success",
         "pandas_single_value_success",
-        "pyspark_single_value_success",
         "pandas_single_value_at_threshold_success",
-        "pyspark_single_value_at_threshold_success",
         "pandas_single_value_large_success",
-        "pyspark_single_value_large_success",
         "pandas_single_value_violation",
-        "pyspark_single_value_violation",
         "pandas_single_value_above_violation",
-        "pyspark_single_value_above_violation",
         "pandas_all_equal_threshold_success",
-        "pyspark_all_equal_threshold_success",
         "pandas_mixed_types_success",
-        "pyspark_mixed_types_success",
         "pandas_mixed_types_violations",
-        "pyspark_mixed_types_violations",
         "pandas_large_values_success",
-        "pyspark_large_values_success",
         "pandas_large_values_violations",
-        "pyspark_large_values_violations",
         "pandas_all_above_threshold",
-        "pyspark_all_above_threshold",
         "pandas_with_nulls_success",
-        "pyspark_with_nulls_success",
         "pandas_with_nulls_large_success",
-        "pyspark_with_nulls_large_success",
         "pandas_with_nulls_violations",
-        "pyspark_with_nulls_violations",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, data, threshold, expected_result, expected_violations, expected_message, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, data, threshold, expected_result, expected_violations, expected_message
 ):
     """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
+    Test the expectation for various scenarios across pandas DataFrames.
     Tests both direct expectation validation and suite-based validation.
     Covers: success cases, boundary conditions (including equals), violations, negative values,
     floats, zero values, single values, mixed types, large values, and nulls.
     """
-    # Determine data type based on whether we have float values (excluding None)
-    has_float = any(isinstance(val, float) for val in data if val is not None)
-    data_type = "double" if has_float else "long"
-    data_frame = create_dataframe(df_type, data, "col1", spark, data_type)
+    data_frame = pd.DataFrame({"col1": data})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -504,8 +303,287 @@ def test_expectation_basic_scenarios(
             DataFrameExpectationSuccessMessage(expectation_name="ExpectationValueLessThanEquals")
         ), f"Expected success message but got: {result}"
     else:  # failure
-        expected_violations_df = create_dataframe(
-            df_type, expected_violations, "col1", spark, data_type
+        expected_violations_df = pd.DataFrame({"col1": expected_violations})
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            violations_data_frame=expected_violations_df,
+            message=expected_message,
+            limit_violations=5,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_value_less_than_equals(
+        column_name="col1", value=threshold
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+@pytest.mark.parametrize(
+    "df_type, data, threshold, expected_result, expected_violations, expected_message",
+    [
+        # Basic success scenarios
+        ("pyspark", [1, 2, 3], 5, "success", None, None),
+        ("pyspark", [1, 2, 3], 4, "success", None, None),
+        ("pyspark", [5, 10, 15], 20, "success", None, None),
+        # Success at threshold (key difference from less than)
+        ("pyspark", [3, 4, 5], 5, "success", None, None),
+        ("pyspark", [5, 5, 5], 5, "success", None, None),
+        # Basic violation scenarios
+        (
+            "pyspark",
+            [4, 5, 6],
+            3,
+            "failure",
+            [4, 5, 6],
+            "Found 3 row(s) where 'col1' is not less than or equal to 3.",
+        ),
+        (
+            "pyspark",
+            [3, 4, 5, 6],
+            4,
+            "failure",
+            [5, 6],
+            "Found 2 row(s) where 'col1' is not less than or equal to 4.",
+        ),
+        # Boundary conditions - at threshold (success for <=)
+        ("pyspark", [2, 3, 4], 4, "success", None, None),
+        ("pyspark", [1, 2, 3], 3, "success", None, None),
+        # Boundary conditions - just above threshold (violation)
+        (
+            "pyspark",
+            [3, 4, 5],
+            4,
+            "failure",
+            [5],
+            "Found 1 row(s) where 'col1' is not less than or equal to 4.",
+        ),
+        (
+            "pyspark",
+            [2, 2.1, 3],
+            2,
+            "failure",
+            [2.1, 3],
+            "Found 2 row(s) where 'col1' is not less than or equal to 2.",
+        ),
+        # Negative values - success
+        ("pyspark", [-3, -2, -1], 0, "success", None, None),
+        ("pyspark", [-5, -4, -3], -2, "success", None, None),
+        ("pyspark", [-10, -5, 0], 5, "success", None, None),
+        # Negative values - success at threshold
+        ("pyspark", [-2, -1, 0], 0, "success", None, None),
+        # Negative values - violations
+        (
+            "pyspark",
+            [-1, 0, 1],
+            -2,
+            "failure",
+            [-1, 0, 1],
+            "Found 3 row(s) where 'col1' is not less than or equal to -2.",
+        ),
+        (
+            "pyspark",
+            [-3, -2, -1],
+            -2,
+            "failure",
+            [-1],
+            "Found 1 row(s) where 'col1' is not less than or equal to -2.",
+        ),
+        # Float values - success
+        ("pyspark", [1.5, 2.0, 2.5], 3.0, "success", None, None),
+        ("pyspark", [1.0, 2.0, 3.0], 3.0, "success", None, None),
+        ("pyspark", [9.7, 9.8, 10.0], 10.0, "success", None, None),
+        # Float values - violations
+        (
+            "pyspark",
+            [2.0, 2.5, 3.0],
+            2.4,
+            "failure",
+            [2.5, 3.0],
+            "Found 2 row(s) where 'col1' is not less than or equal to 2.4.",
+        ),
+        (
+            "pyspark",
+            [1.5, 2.5, 3.5],
+            2.9,
+            "failure",
+            [3.5],
+            "Found 1 row(s) where 'col1' is not less than or equal to 2.9.",
+        ),
+        # Zero as threshold - success
+        ("pyspark", [-2, -1, 0], 0, "success", None, None),
+        ("pyspark", [-1.0, -0.5, 0.0], 0, "success", None, None),
+        # Zero as threshold - violations
+        (
+            "pyspark",
+            [0, 1, 2],
+            -1,
+            "failure",
+            [0, 1, 2],
+            "Found 3 row(s) where 'col1' is not less than or equal to -1.",
+        ),
+        (
+            "pyspark",
+            [-1, 0, 1],
+            0,
+            "failure",
+            [1],
+            "Found 1 row(s) where 'col1' is not less than or equal to 0.",
+        ),
+        # Zero in data - success (including zero at threshold)
+        ("pyspark", [0, 1, 2], 2, "success", None, None),
+        # Single value - success
+        ("pyspark", [3], 5, "success", None, None),
+        ("pyspark", [5], 5, "success", None, None),
+        ("pyspark", [0], 10, "success", None, None),
+        # Single value - violation
+        (
+            "pyspark",
+            [5],
+            4,
+            "failure",
+            [5],
+            "Found 1 row(s) where 'col1' is not less than or equal to 4.",
+        ),
+        (
+            "pyspark",
+            [10],
+            5,
+            "failure",
+            [10],
+            "Found 1 row(s) where 'col1' is not less than or equal to 5.",
+        ),
+        # All values equal to threshold (success for <=)
+        ("pyspark", [5, 5, 5, 5], 5, "success", None, None),
+        # Mixed integers and floats
+        ("pyspark", [1, 1.5, 2, 2.5], 3, "success", None, None),
+        (
+            "pyspark",
+            [2, 2.5, 3, 3.5],
+            2.9,
+            "failure",
+            [3, 3.5],
+            "Found 2 row(s) where 'col1' is not less than or equal to 2.9.",
+        ),
+        # Large values
+        ("pyspark", [1000, 2000, 3000], 3000, "success", None, None),
+        (
+            "pyspark",
+            [1000, 1500, 2000],
+            999,
+            "failure",
+            [1000, 1500, 2000],
+            "Found 3 row(s) where 'col1' is not less than or equal to 999.",
+        ),
+        # All values above threshold
+        (
+            "pyspark",
+            [6, 7, 8],
+            5,
+            "failure",
+            [6, 7, 8],
+            "Found 3 row(s) where 'col1' is not less than or equal to 5.",
+        ),
+        # With nulls - success (nulls are ignored)
+        ("pyspark", [1, None, 2, None, 3], 3, "success", None, None),
+        ("pyspark", [5, None, 10, None], 15, "success", None, None),
+        # With nulls - violations
+        (
+            "pyspark",
+            [2, None, 3, 4],
+            3,
+            "failure",
+            [4],
+            "Found 1 row(s) where 'col1' is not less than or equal to 3.",
+        ),
+    ],
+    ids=[
+        "pyspark_basic_success",
+        "pyspark_success_different_data",
+        "pyspark_success_large_values",
+        "pyspark_success_at_threshold",
+        "pyspark_success_all_equal_threshold",
+        "pyspark_basic_violations",
+        "pyspark_partial_violations",
+        "pyspark_boundary_at_threshold_success",
+        "pyspark_boundary_at_threshold_success_2",
+        "pyspark_boundary_above_threshold",
+        "pyspark_boundary_above_threshold_float",
+        "pyspark_negative_success",
+        "pyspark_negative_range_success",
+        "pyspark_negative_large_success",
+        "pyspark_negative_at_threshold_success",
+        "pyspark_negative_violations",
+        "pyspark_negative_partial_violations",
+        "pyspark_float_success",
+        "pyspark_float_at_threshold_success",
+        "pyspark_float_precise_success",
+        "pyspark_float_violations",
+        "pyspark_float_partial_violations",
+        "pyspark_zero_threshold_success",
+        "pyspark_zero_threshold_float_success",
+        "pyspark_zero_threshold_violations",
+        "pyspark_zero_threshold_partial_violations",
+        "pyspark_zero_in_data_success",
+        "pyspark_single_value_success",
+        "pyspark_single_value_at_threshold_success",
+        "pyspark_single_value_large_success",
+        "pyspark_single_value_violation",
+        "pyspark_single_value_above_violation",
+        "pyspark_all_equal_threshold_success",
+        "pyspark_mixed_types_success",
+        "pyspark_mixed_types_violations",
+        "pyspark_large_values_success",
+        "pyspark_large_values_violations",
+        "pyspark_all_above_threshold",
+        "pyspark_with_nulls_success",
+        "pyspark_with_nulls_large_success",
+        "pyspark_with_nulls_violations",
+    ],
+)
+def test_expectation_basic_scenarios_pyspark(
+    df_type, data, threshold, expected_result, expected_violations, expected_message, spark
+):
+    """
+    Test the expectation for various scenarios across PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases, boundary conditions (including equals), violations, negative values,
+    floats, zero values, single values, mixed types, large values, and nulls.
+    """
+    has_float = any(isinstance(val, float) for val in data if val is not None)
+    data_type = "double" if has_float else "long"
+    data_frame = create_pyspark_dataframe(data, "col1", spark, data_type)
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueLessThanEquals",
+        column_name="col1",
+        value=threshold,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationValueLessThanEquals")
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        expected_violations_df = create_pyspark_dataframe(
+            expected_violations, "col1", spark, data_type
         )
         expected_failure_message = DataFrameExpectationFailureMessage(
             expectation_str=str(expectation),
@@ -535,21 +613,12 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
-@pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
-)
-def test_column_missing_error(df_type, spark):
-    """Test that an error is raised when the specified column is missing in both pandas and PySpark."""
+def test_column_missing_error_pandas():
+    """Test that an error is raised when the specified column is missing in pandas."""
     expected_message = "Column 'col1' does not exist in the DataFrame."
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col2": [3, 4, 5]})
-    else:  # pyspark
-        data_frame = spark.createDataFrame([(3,), (4,), (5,)], ["col2"])
+    data_frame = pd.DataFrame({"col2": [3, 4, 5]})
 
-    # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
         expectation_name="ExpectationValueLessThanEquals",
         column_name="col1",
@@ -558,12 +627,38 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=data_frame)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
         message=expected_message,
     )
     assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
 
-    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_value_less_than_equals(
+        column_name="col1", value=2
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test that an error is raised when the specified column is missing in PySpark."""
+    expected_message = "Column 'col1' does not exist in the DataFrame."
+
+    data_frame = spark.createDataFrame([(3,), (4,), (5,)], ["col2"])
+
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationValueLessThanEquals",
+        column_name="col1",
+        value=2,
+    )
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
+
     expectations_suite = DataFrameExpectationsSuite().expect_value_less_than_equals(
         column_name="col1", value=2
     )

--- a/tests/expectations/column/numerical_expectations/test_expect_value_less_than_equals.py
+++ b/tests/expectations/column/numerical_expectations/test_expect_value_less_than_equals.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 import pandas as pd
 
 from dataframe_expectations.registry import (
@@ -668,8 +669,6 @@ def test_column_missing_error_pyspark(spark):
 
 def test_large_dataset_performance():
     """Test the expectation with a larger dataset to ensure performance."""
-    import numpy as np
-
     # Create a larger dataset with values between 0 and 90
     large_data = np.random.uniform(0, 90, 10000).tolist()
     data_frame = pd.DataFrame({"col1": large_data})

--- a/tests/expectations/column/string_expectations/test_expect_string_contains.py
+++ b/tests/expectations/column/string_expectations/test_expect_string_contains.py
@@ -7,34 +7,24 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark):
-    """Helper function to create pandas or pyspark DataFrame.
+def create_pyspark_dataframe(data, column_name, spark):
+    """Helper function to create a PySpark DataFrame."""
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        StringType,
+    )
 
-    Args:
-        df_type: "pandas" or "pyspark"
-        data: List of values for the column
-        column_name: Name of the column
-        spark: Spark session (required for pyspark)
-    """
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        from pyspark.sql.types import (
-            StructType,
-            StructField,
-            StringType,
-        )
-
-        schema = StructType([StructField(column_name, StringType(), True)])
-        return spark.createDataFrame([(val,) for val in data], schema)
+    schema = StructType([StructField(column_name, StringType(), True)])
+    return spark.createDataFrame([(val,) for val in data], schema)
 
 
 def test_expectation_name():
@@ -52,18 +42,10 @@ def test_expectation_name():
 @pytest.mark.parametrize(
     "df_type, data, substring, expected_result, expected_violations, expected_message",
     [
-        # Basic success - pandas
+        # Basic success scenarios - pandas
         ("pandas", ["foobar", "foo123", "barfoo"], "foo", "success", None, None),
-        # Basic success - pyspark
-        ("pyspark", ["foobar", "foo123", "barfoo"], "foo", "success", None, None),
-        # Success hello - pandas
         ("pandas", ["hello", "hello world", "say hello"], "hello", "success", None, None),
-        # Success hello - pyspark
-        ("pyspark", ["hello", "hello world", "say hello"], "hello", "success", None, None),
-        # Success test - pandas
         ("pandas", ["test123", "test456", "testing"], "test", "success", None, None),
-        # Success test - pyspark
-        ("pyspark", ["test123", "test456", "testing"], "test", "success", None, None),
         # Basic violation scenarios - pandas
         (
             "pandas",
@@ -89,6 +71,201 @@ def test_expectation_name():
             ["test", "best"],
             "Found 2 row(s) where 'col1' does not contain 'testing'.",
         ),
+        # Case sensitivity scenarios - pandas
+        (
+            "pandas",
+            ["Foo", "FOO", "fOo"],
+            "foo",
+            "failure",
+            ["Foo", "FOO", "fOo"],
+            "Found 3 row(s) where 'col1' does not contain 'foo'.",
+        ),
+        ("pandas", ["foo", "foobar", "barfoo"], "foo", "success", None, None),
+        (
+            "pandas",
+            ["Hello", "HELLO", "hello"],
+            "Hello",
+            "failure",
+            ["HELLO", "hello"],
+            "Found 2 row(s) where 'col1' does not contain 'Hello'.",
+        ),
+        # Substring position scenarios - pandas
+        ("pandas", ["foobar", "foobaz", "foo"], "foo", "success", None, None),
+        ("pandas", ["barfoo", "bazfoo", "foo"], "foo", "success", None, None),
+        ("pandas", ["barfoobar", "bazfoobaz"], "foo", "success", None, None),
+        # Single character scenarios - pandas
+        ("pandas", ["a", "ab", "abc"], "a", "success", None, None),
+        (
+            "pandas",
+            ["b", "c", "d"],
+            "a",
+            "failure",
+            ["b", "c", "d"],
+            "Found 3 row(s) where 'col1' does not contain 'a'.",
+        ),
+        (
+            "pandas",
+            ["", "text", "more"],
+            "text",
+            "failure",
+            ["", "more"],
+            "Found 2 row(s) where 'col1' does not contain 'text'.",
+        ),
+        # Whitespace handling scenarios - pandas
+        ("pandas", ["foo bar", "foo  bar", "foobar"], "foo", "success", None, None),
+        ("pandas", [" foo", "foo ", " foo "], "foo", "success", None, None),
+        (
+            "pandas",
+            ["foo bar", "bar", "baz"],
+            "foo bar",
+            "failure",
+            ["bar", "baz"],
+            "Found 2 row(s) where 'col1' does not contain 'foo bar'.",
+        ),
+        # Special character scenarios - pandas
+        ("pandas", ["test@email.com", "user@domain.org"], "@", "success", None, None),
+        (
+            "pandas",
+            ["hello!", "world!", "test"],
+            "!",
+            "failure",
+            ["test"],
+            "Found 1 row(s) where 'col1' does not contain '!'.",
+        ),
+        ("pandas", ["path/to/file", "another/path"], "/", "success", None, None),
+        (
+            "pandas",
+            ["#tag1", "#tag2", "notag"],
+            "#",
+            "failure",
+            ["notag"],
+            "Found 1 row(s) where 'col1' does not contain '#'.",
+        ),
+        # Number scenarios - pandas
+        (
+            "pandas",
+            ["test123", "test456", "test"],
+            "123",
+            "failure",
+            ["test456", "test"],
+            "Found 2 row(s) where 'col1' does not contain '123'.",
+        ),
+        (
+            "pandas",
+            ["v1.0.0", "v2.0.0", "v1.1.0"],
+            "1.",
+            "failure",
+            ["v2.0.0"],
+            "Found 1 row(s) where 'col1' does not contain '1.'.",
+        ),
+        # Multiple occurrence and long string scenarios - pandas
+        ("pandas", ["foofoo", "foobarfoo", "foo"], "foo", "success", None, None),
+        (
+            "pandas",
+            ["a" * 100 + "foo" + "b" * 100, "c" * 200],
+            "foo",
+            "failure",
+            ["c" * 200],
+            "Found 1 row(s) where 'col1' does not contain 'foo'.",
+        ),
+        ("pandas", ["football", "foolish", "foo"], "foo", "success", None, None),
+        (
+            "pandas",
+            ["food", "foot", "bar"],
+            "foo",
+            "failure",
+            ["bar"],
+            "Found 1 row(s) where 'col1' does not contain 'foo'.",
+        ),
+    ],
+    ids=[
+        "pandas_basic_success",
+        "pandas_success_hello",
+        "pandas_success_test",
+        "pandas_basic_violations",
+        "pandas_all_violations",
+        "pandas_partial_match_violations",
+        "pandas_case_sensitive_all_fail",
+        "pandas_case_sensitive_mixed",
+        "pandas_case_hello_violations",
+        "pandas_position_start",
+        "pandas_position_end",
+        "pandas_position_middle",
+        "pandas_single_char_success",
+        "pandas_single_char_violations",
+        "pandas_empty_string_violations",
+        "pandas_whitespace_in_data",
+        "pandas_whitespace_around",
+        "pandas_whitespace_in_substring",
+        "pandas_special_at_sign",
+        "pandas_special_exclamation",
+        "pandas_special_slash",
+        "pandas_special_hash",
+        "pandas_numbers_123",
+        "pandas_numbers_version",
+        "pandas_multiple_occurrences",
+        "pandas_long_strings",
+        "pandas_partial_word_success",
+        "pandas_partial_word_violation",
+    ],
+)
+def test_expectation_basic_scenarios_pandas(
+    df_type, data, substring, expected_result, expected_violations, expected_message
+):
+    """Test the expectation for various scenarios for pandas DataFrames."""
+    data_frame = pd.DataFrame({"col1": data})
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationStringContains",
+        column_name="col1",
+        substring=substring,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationStringContains")
+        ), f"Expected success message but got: {result}"
+    else:
+        expected_violations_df = pd.DataFrame({"col1": expected_violations})
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            violations_data_frame=expected_violations_df,
+            message=expected_message,
+            limit_violations=5,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_string_contains(
+        column_name="col1", substring=substring
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+@pytest.mark.parametrize(
+    "df_type, data, substring, expected_result, expected_violations, expected_message",
+    [
+        # Basic success scenarios - pyspark
+        ("pyspark", ["foobar", "foo123", "barfoo"], "foo", "success", None, None),
+        ("pyspark", ["hello", "hello world", "say hello"], "hello", "success", None, None),
+        ("pyspark", ["test123", "test456", "testing"], "test", "success", None, None),
         # Basic violation scenarios - pyspark
         (
             "pyspark",
@@ -114,16 +291,7 @@ def test_expectation_name():
             ["test", "best"],
             "Found 2 row(s) where 'col1' does not contain 'testing'.",
         ),
-        # Case sensitive all fail - pandas
-        (
-            "pandas",
-            ["Foo", "FOO", "fOo"],
-            "foo",
-            "failure",
-            ["Foo", "FOO", "fOo"],
-            "Found 3 row(s) where 'col1' does not contain 'foo'.",
-        ),
-        # Case sensitive all fail - pyspark
+        # Case sensitivity scenarios - pyspark
         (
             "pyspark",
             ["Foo", "FOO", "fOo"],
@@ -132,20 +300,7 @@ def test_expectation_name():
             ["Foo", "FOO", "fOo"],
             "Found 3 row(s) where 'col1' does not contain 'foo'.",
         ),
-        # Case sensitive mixed - pandas
-        ("pandas", ["foo", "foobar", "barfoo"], "foo", "success", None, None),
-        # Case sensitive mixed - pyspark
         ("pyspark", ["foo", "foobar", "barfoo"], "foo", "success", None, None),
-        # Case hello violations - pandas
-        (
-            "pandas",
-            ["Hello", "HELLO", "hello"],
-            "Hello",
-            "failure",
-            ["HELLO", "hello"],
-            "Found 2 row(s) where 'col1' does not contain 'Hello'.",
-        ),
-        # Case hello violations - pyspark
         (
             "pyspark",
             ["Hello", "HELLO", "hello"],
@@ -154,29 +309,11 @@ def test_expectation_name():
             ["HELLO", "hello"],
             "Found 2 row(s) where 'col1' does not contain 'Hello'.",
         ),
-        # Position start - pandas
-        ("pandas", ["foobar", "foobaz", "foo"], "foo", "success", None, None),
-        # Position start - pyspark
+        # Substring position scenarios - pyspark
         ("pyspark", ["foobar", "foobaz", "foo"], "foo", "success", None, None),
-        # Position end - pandas
-        ("pandas", ["barfoo", "bazfoo", "foo"], "foo", "success", None, None),
-        # Position end - pyspark
         ("pyspark", ["barfoo", "bazfoo", "foo"], "foo", "success", None, None),
-        # Position middle - pandas
-        ("pandas", ["barfoobar", "bazfoobaz"], "foo", "success", None, None),
-        # Position middle - pyspark
         ("pyspark", ["barfoobar", "bazfoobaz"], "foo", "success", None, None),
-        # Single character substring - pandas
-        ("pandas", ["a", "ab", "abc"], "a", "success", None, None),
-        (
-            "pandas",
-            ["b", "c", "d"],
-            "a",
-            "failure",
-            ["b", "c", "d"],
-            "Found 3 row(s) where 'col1' does not contain 'a'.",
-        ),
-        # Single character substring - pyspark
+        # Single character scenarios - pyspark
         ("pyspark", ["a", "ab", "abc"], "a", "success", None, None),
         (
             "pyspark",
@@ -186,16 +323,6 @@ def test_expectation_name():
             ["b", "c", "d"],
             "Found 3 row(s) where 'col1' does not contain 'a'.",
         ),
-        # Empty string scenarios - pandas
-        (
-            "pandas",
-            ["", "text", "more"],
-            "text",
-            "failure",
-            ["", "more"],
-            "Found 2 row(s) where 'col1' does not contain 'text'.",
-        ),
-        # Empty string scenarios - pyspark
         (
             "pyspark",
             ["", "text", "more"],
@@ -204,24 +331,9 @@ def test_expectation_name():
             ["", "more"],
             "Found 2 row(s) where 'col1' does not contain 'text'.",
         ),
-        # Whitespace in data - pandas
-        ("pandas", ["foo bar", "foo  bar", "foobar"], "foo", "success", None, None),
-        # Whitespace in data - pyspark
+        # Whitespace handling scenarios - pyspark
         ("pyspark", ["foo bar", "foo  bar", "foobar"], "foo", "success", None, None),
-        # Whitespace around - pandas
-        ("pandas", [" foo", "foo ", " foo "], "foo", "success", None, None),
-        # Whitespace around - pyspark
         ("pyspark", [" foo", "foo ", " foo "], "foo", "success", None, None),
-        # Whitespace in substring - pandas
-        (
-            "pandas",
-            ["foo bar", "bar", "baz"],
-            "foo bar",
-            "failure",
-            ["bar", "baz"],
-            "Found 2 row(s) where 'col1' does not contain 'foo bar'.",
-        ),
-        # Whitespace in substring - pyspark
         (
             "pyspark",
             ["foo bar", "bar", "baz"],
@@ -230,20 +342,8 @@ def test_expectation_name():
             ["bar", "baz"],
             "Found 2 row(s) where 'col1' does not contain 'foo bar'.",
         ),
-        # Special at sign - pandas
-        ("pandas", ["test@email.com", "user@domain.org"], "@", "success", None, None),
-        # Special at sign - pyspark
+        # Special character scenarios - pyspark
         ("pyspark", ["test@email.com", "user@domain.org"], "@", "success", None, None),
-        # Special exclamation - pandas
-        (
-            "pandas",
-            ["hello!", "world!", "test"],
-            "!",
-            "failure",
-            ["test"],
-            "Found 1 row(s) where 'col1' does not contain '!'.",
-        ),
-        # Special exclamation - pyspark
         (
             "pyspark",
             ["hello!", "world!", "test"],
@@ -252,20 +352,7 @@ def test_expectation_name():
             ["test"],
             "Found 1 row(s) where 'col1' does not contain '!'.",
         ),
-        # Special slash - pandas
-        ("pandas", ["path/to/file", "another/path"], "/", "success", None, None),
-        # Special slash - pyspark
         ("pyspark", ["path/to/file", "another/path"], "/", "success", None, None),
-        # Special hash - pandas
-        (
-            "pandas",
-            ["#tag1", "#tag2", "notag"],
-            "#",
-            "failure",
-            ["notag"],
-            "Found 1 row(s) where 'col1' does not contain '#'.",
-        ),
-        # Special hash - pyspark
         (
             "pyspark",
             ["#tag1", "#tag2", "notag"],
@@ -274,16 +361,7 @@ def test_expectation_name():
             ["notag"],
             "Found 1 row(s) where 'col1' does not contain '#'.",
         ),
-        # Numbers 123 - pandas
-        (
-            "pandas",
-            ["test123", "test456", "test"],
-            "123",
-            "failure",
-            ["test456", "test"],
-            "Found 2 row(s) where 'col1' does not contain '123'.",
-        ),
-        # Numbers 123 - pyspark
+        # Number scenarios - pyspark
         (
             "pyspark",
             ["test123", "test456", "test"],
@@ -292,16 +370,6 @@ def test_expectation_name():
             ["test456", "test"],
             "Found 2 row(s) where 'col1' does not contain '123'.",
         ),
-        # Numbers version - pandas
-        (
-            "pandas",
-            ["v1.0.0", "v2.0.0", "v1.1.0"],
-            "1.",
-            "failure",
-            ["v2.0.0"],
-            "Found 1 row(s) where 'col1' does not contain '1.'.",
-        ),
-        # Numbers version - pyspark
         (
             "pyspark",
             ["v1.0.0", "v2.0.0", "v1.1.0"],
@@ -310,20 +378,8 @@ def test_expectation_name():
             ["v2.0.0"],
             "Found 1 row(s) where 'col1' does not contain '1.'.",
         ),
-        # Multiple occurrences - pandas
-        ("pandas", ["foofoo", "foobarfoo", "foo"], "foo", "success", None, None),
-        # Multiple occurrences - pyspark
+        # Multiple occurrence and long string scenarios - pyspark
         ("pyspark", ["foofoo", "foobarfoo", "foo"], "foo", "success", None, None),
-        # Long strings - pandas
-        (
-            "pandas",
-            ["a" * 100 + "foo" + "b" * 100, "c" * 200],
-            "foo",
-            "failure",
-            ["c" * 200],
-            "Found 1 row(s) where 'col1' does not contain 'foo'.",
-        ),
-        # Long strings - pyspark
         (
             "pyspark",
             ["a" * 100 + "foo" + "b" * 100, "c" * 200],
@@ -332,20 +388,7 @@ def test_expectation_name():
             ["c" * 200],
             "Found 1 row(s) where 'col1' does not contain 'foo'.",
         ),
-        # Partial word success - pandas
-        ("pandas", ["football", "foolish", "foo"], "foo", "success", None, None),
-        # Partial word success - pyspark
         ("pyspark", ["football", "foolish", "foo"], "foo", "success", None, None),
-        # Partial word violation - pandas
-        (
-            "pandas",
-            ["food", "foot", "bar"],
-            "foo",
-            "failure",
-            ["bar"],
-            "Found 1 row(s) where 'col1' does not contain 'foo'.",
-        ),
-        # Partial word violation - pyspark
         (
             "pyspark",
             ["food", "foot", "bar"],
@@ -356,75 +399,41 @@ def test_expectation_name():
         ),
     ],
     ids=[
-        "pandas_basic_success",
         "pyspark_basic_success",
-        "pandas_success_hello",
         "pyspark_success_hello",
-        "pandas_success_test",
         "pyspark_success_test",
-        "pandas_basic_violations",
         "pyspark_basic_violations",
-        "pandas_all_violations",
         "pyspark_all_violations",
-        "pandas_partial_match_violations",
         "pyspark_partial_match_violations",
-        "pandas_case_sensitive_all_fail",
         "pyspark_case_sensitive_all_fail",
-        "pandas_case_sensitive_mixed",
         "pyspark_case_sensitive_mixed",
-        "pandas_case_hello_violations",
         "pyspark_case_hello_violations",
-        "pandas_position_start",
         "pyspark_position_start",
-        "pandas_position_end",
         "pyspark_position_end",
-        "pandas_position_middle",
         "pyspark_position_middle",
-        "pandas_single_char_success",
         "pyspark_single_char_success",
-        "pandas_single_char_violations",
         "pyspark_single_char_violations",
-        "pandas_empty_string_violations",
         "pyspark_empty_string_violations",
-        "pandas_whitespace_in_data",
         "pyspark_whitespace_in_data",
-        "pandas_whitespace_around",
         "pyspark_whitespace_around",
-        "pandas_whitespace_in_substring",
         "pyspark_whitespace_in_substring",
-        "pandas_special_at_sign",
         "pyspark_special_at_sign",
-        "pandas_special_exclamation",
         "pyspark_special_exclamation",
-        "pandas_special_slash",
         "pyspark_special_slash",
-        "pandas_special_hash",
         "pyspark_special_hash",
-        "pandas_numbers_123",
         "pyspark_numbers_123",
-        "pandas_numbers_version",
         "pyspark_numbers_version",
-        "pandas_multiple_occurrences",
         "pyspark_multiple_occurrences",
-        "pandas_long_strings",
         "pyspark_long_strings",
-        "pandas_partial_word_success",
         "pyspark_partial_word_success",
-        "pandas_partial_word_violation",
         "pyspark_partial_word_violation",
     ],
 )
-def test_expectation_basic_scenarios(
+def test_expectation_basic_scenarios_pyspark(
     df_type, data, substring, expected_result, expected_violations, expected_message, spark
 ):
-    """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
-    Tests both direct expectation validation and suite-based validation.
-    Covers: success cases, violations, case sensitivity, position of substring,
-    empty strings, whitespace, special characters, numbers, multiple occurrences,
-    long strings, and partial word matches.
-    """
-    data_frame = create_dataframe(df_type, data, "col1", spark)
+    """Test the expectation for various scenarios for PySpark DataFrames."""
+    data_frame = create_pyspark_dataframe(data, "col1", spark)
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -439,8 +448,8 @@ def test_expectation_basic_scenarios(
         assert str(result) == str(
             DataFrameExpectationSuccessMessage(expectation_name="ExpectationStringContains")
         ), f"Expected success message but got: {result}"
-    else:  # failure
-        expected_violations_df = create_dataframe(df_type, expected_violations, "col1", spark)
+    else:
+        expected_violations_df = create_pyspark_dataframe(expected_violations, "col1", spark)
         expected_failure_message = DataFrameExpectationFailureMessage(
             expectation_str=str(expectation),
             data_frame_type=str(df_type),
@@ -464,26 +473,17 @@ def test_expectation_basic_scenarios(
         assert result.success, "Expected all expectations to pass"
         assert result.total_passed == 1, "Expected 1 passed expectation"
         assert result.total_failed == 0, "Expected 0 failed expectations"
-    else:  # failure
+    else:
         with pytest.raises(DataFrameExpectationsSuiteFailure):
             expectations_suite.build().run(data_frame=data_frame)
 
 
-@pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
-)
-def test_column_missing_error(df_type, spark):
-    """Test that an error is raised when the specified column is missing in both pandas and PySpark."""
+def test_column_missing_error_pandas():
+    """Test that an error is raised when the specified column is missing in pandas."""
     expected_message = "Column 'col1' does not exist in the DataFrame."
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col2": ["foobar", "foo123", "barfoo"]})
-    else:  # pyspark
-        data_frame = spark.createDataFrame([("foobar",), ("foo123",), ("barfoo",)], ["col2"])
+    data_frame = pd.DataFrame({"col2": ["foobar", "foo123", "barfoo"]})
 
-    # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
         expectation_name="ExpectationStringContains",
         column_name="col1",
@@ -492,12 +492,38 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=data_frame)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
         message=expected_message,
     )
     assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
 
-    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_string_contains(
+        column_name="col1", substring="foo"
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test that an error is raised when the specified column is missing in PySpark."""
+    expected_message = "Column 'col1' does not exist in the DataFrame."
+
+    data_frame = spark.createDataFrame([("foobar",), ("foo123",), ("barfoo",)], ["col2"])
+
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationStringContains",
+        column_name="col1",
+        substring="foo",
+    )
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
+
     expectations_suite = DataFrameExpectationsSuite().expect_string_contains(
         column_name="col1", substring="foo"
     )

--- a/tests/expectations/column/string_expectations/test_expect_string_ends_with.py
+++ b/tests/expectations/column/string_expectations/test_expect_string_ends_with.py
@@ -7,34 +7,24 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark):
-    """Helper function to create pandas or pyspark DataFrame.
+def create_pyspark_dataframe(data, column_name, spark):
+    """Helper function to create a PySpark DataFrame."""
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        StringType,
+    )
 
-    Args:
-        df_type: "pandas" or "pyspark"
-        data: List of values for the column
-        column_name: Name of the column
-        spark: Spark session (required for pyspark)
-    """
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        from pyspark.sql.types import (
-            StructType,
-            StructField,
-            StringType,
-        )
-
-        schema = StructType([StructField(column_name, StringType(), True)])
-        return spark.createDataFrame([(val,) for val in data], schema)
+    schema = StructType([StructField(column_name, StringType(), True)])
+    return spark.createDataFrame([(val,) for val in data], schema)
 
 
 def test_expectation_name():
@@ -52,18 +42,10 @@ def test_expectation_name():
 @pytest.mark.parametrize(
     "df_type, data, suffix, expected_result, expected_violations, expected_message",
     [
-        # Basic success - pandas
+        # Basic success scenarios - pandas
         ("pandas", ["foobar", "bar", "bazbar"], "bar", "success", None, None),
-        # Basic success - pyspark
-        ("pyspark", ["foobar", "bar", "bazbar"], "bar", "success", None, None),
-        # Success hello - pandas
         ("pandas", ["hello", "say hello", "greet with hello"], "hello", "success", None, None),
-        # Success hello - pyspark
-        ("pyspark", ["hello", "say hello", "greet with hello"], "hello", "success", None, None),
-        # Success test - pandas
         ("pandas", ["test", "mytest", "anothertest"], "test", "success", None, None),
-        # Success test - pyspark
-        ("pyspark", ["test", "mytest", "anothertest"], "test", "success", None, None),
         # Basic violation scenarios - pandas
         (
             "pandas",
@@ -89,6 +71,213 @@ def test_expectation_name():
             ["testing", "best"],
             "Found 2 row(s) where 'col1' does not end with 'test'.",
         ),
+        # Case sensitivity scenarios - pandas
+        (
+            "pandas",
+            ["fooBar", "fooBAR", "foobar"],
+            "bar",
+            "failure",
+            ["fooBar", "fooBAR"],
+            "Found 2 row(s) where 'col1' does not end with 'bar'.",
+        ),
+        ("pandas", ["foobar", "bazbar", "bar"], "bar", "success", None, None),
+        (
+            "pandas",
+            ["testHello", "testHELLO", "testhello"],
+            "hello",
+            "failure",
+            ["testHello", "testHELLO"],
+            "Found 2 row(s) where 'col1' does not end with 'hello'.",
+        ),
+        # Exact match scenarios - pandas
+        (
+            "pandas",
+            ["bar", "foo", "baz"],
+            "bar",
+            "failure",
+            ["foo", "baz"],
+            "Found 2 row(s) where 'col1' does not end with 'bar'.",
+        ),
+        ("pandas", ["test", "test", "test"], "test", "success", None, None),
+        # Single character suffix scenarios - pandas
+        ("pandas", ["a", "ba", "cba"], "a", "success", None, None),
+        (
+            "pandas",
+            ["b", "c", "d"],
+            "a",
+            "failure",
+            ["b", "c", "d"],
+            "Found 3 row(s) where 'col1' does not end with 'a'.",
+        ),
+        (
+            "pandas",
+            ["", "text", "more"],
+            "text",
+            "failure",
+            ["", "more"],
+            "Found 2 row(s) where 'col1' does not end with 'text'.",
+        ),
+        # Whitespace handling scenarios - pandas
+        ("pandas", ["foo bar", "baz bar", "test bar"], "bar", "success", None, None),
+        ("pandas", ["foo ", "bar ", "baz "], " ", "success", None, None),
+        (
+            "pandas",
+            ["foo bar", "bar", "baz"],
+            " bar",
+            "failure",
+            ["bar", "baz"],
+            "Found 2 row(s) where 'col1' does not end with ' bar'.",
+        ),
+        # Special character scenarios - pandas
+        ("pandas", ["test@", "user@", "admin@"], "@", "success", None, None),
+        (
+            "pandas",
+            ["hello!", "world!", "test"],
+            "!",
+            "failure",
+            ["test"],
+            "Found 1 row(s) where 'col1' does not end with '!'.",
+        ),
+        ("pandas", ["path/to/", "another/"], "/", "success", None, None),
+        (
+            "pandas",
+            ["tag1#", "tag2#", "notag"],
+            "#",
+            "failure",
+            ["notag"],
+            "Found 1 row(s) where 'col1' does not end with '#'.",
+        ),
+        # Number scenarios - pandas
+        (
+            "pandas",
+            ["test123", "file123", "data456"],
+            "123",
+            "failure",
+            ["data456"],
+            "Found 1 row(s) where 'col1' does not end with '123'.",
+        ),
+        (
+            "pandas",
+            ["v1.0", "v2.0", "v1.1"],
+            ".0",
+            "failure",
+            ["v1.1"],
+            "Found 1 row(s) where 'col1' does not end with '.0'.",
+        ),
+        # Long string and suffix-length scenarios - pandas
+        ("pandas", ["a" * 100 + "bar", "b" * 100 + "bar"], "bar", "success", None, None),
+        (
+            "pandas",
+            ["a" * 100 + "foo", "b" * 100 + "bar"],
+            "bar",
+            "failure",
+            ["a" * 100 + "foo"],
+            "Found 1 row(s) where 'col1' does not end with 'bar'.",
+        ),
+        (
+            "pandas",
+            ["foo", "ba", "b"],
+            "foobar",
+            "failure",
+            ["foo", "ba", "b"],
+            "Found 3 row(s) where 'col1' does not end with 'foobar'.",
+        ),
+        (
+            "pandas",
+            ["barfoo", "foobar", "bazbar"],
+            "foo",
+            "failure",
+            ["foobar", "bazbar"],
+            "Found 2 row(s) where 'col1' does not end with 'foo'.",
+        ),
+    ],
+    ids=[
+        "pandas_basic_success",
+        "pandas_success_hello",
+        "pandas_success_test",
+        "pandas_basic_violations",
+        "pandas_all_violations",
+        "pandas_partial_match_violations",
+        "pandas_case_sensitive_violations",
+        "pandas_case_sensitive_success",
+        "pandas_case_hello_violations",
+        "pandas_exact_match_partial",
+        "pandas_exact_match_all",
+        "pandas_single_char_success",
+        "pandas_single_char_violations",
+        "pandas_empty_string_violations",
+        "pandas_whitespace_success",
+        "pandas_whitespace_trailing",
+        "pandas_whitespace_in_suffix",
+        "pandas_special_at_sign",
+        "pandas_special_exclamation",
+        "pandas_special_slash",
+        "pandas_special_hash",
+        "pandas_numbers_123",
+        "pandas_numbers_version",
+        "pandas_long_strings_success",
+        "pandas_long_strings_violation",
+        "pandas_suffix_longer",
+        "pandas_partial_not_at_end",
+    ],
+)
+def test_expectation_basic_scenarios_pandas(
+    df_type, data, suffix, expected_result, expected_violations, expected_message
+):
+    """Test the expectation for various scenarios for pandas DataFrames."""
+    data_frame = pd.DataFrame({"col1": data})
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationStringEndsWith",
+        column_name="col1",
+        suffix=suffix,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationStringEndsWith")
+        ), f"Expected success message but got: {result}"
+    else:
+        expected_violations_df = pd.DataFrame({"col1": expected_violations})
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            violations_data_frame=expected_violations_df,
+            message=expected_message,
+            limit_violations=5,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_string_ends_with(
+        column_name="col1", suffix=suffix
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+@pytest.mark.parametrize(
+    "df_type, data, suffix, expected_result, expected_violations, expected_message",
+    [
+        # Basic success scenarios - pyspark
+        ("pyspark", ["foobar", "bar", "bazbar"], "bar", "success", None, None),
+        ("pyspark", ["hello", "say hello", "greet with hello"], "hello", "success", None, None),
+        ("pyspark", ["test", "mytest", "anothertest"], "test", "success", None, None),
         # Basic violation scenarios - pyspark
         (
             "pyspark",
@@ -114,16 +303,7 @@ def test_expectation_name():
             ["testing", "best"],
             "Found 2 row(s) where 'col1' does not end with 'test'.",
         ),
-        # Case sensitive violations - pandas
-        (
-            "pandas",
-            ["fooBar", "fooBAR", "foobar"],
-            "bar",
-            "failure",
-            ["fooBar", "fooBAR"],
-            "Found 2 row(s) where 'col1' does not end with 'bar'.",
-        ),
-        # Case sensitive violations - pyspark
+        # Case sensitivity scenarios - pyspark
         (
             "pyspark",
             ["fooBar", "fooBAR", "foobar"],
@@ -132,20 +312,7 @@ def test_expectation_name():
             ["fooBar", "fooBAR"],
             "Found 2 row(s) where 'col1' does not end with 'bar'.",
         ),
-        # Case sensitive success - pandas
-        ("pandas", ["foobar", "bazbar", "bar"], "bar", "success", None, None),
-        # Case sensitive success - pyspark
         ("pyspark", ["foobar", "bazbar", "bar"], "bar", "success", None, None),
-        # Case hello violations - pandas
-        (
-            "pandas",
-            ["testHello", "testHELLO", "testhello"],
-            "hello",
-            "failure",
-            ["testHello", "testHELLO"],
-            "Found 2 row(s) where 'col1' does not end with 'hello'.",
-        ),
-        # Case hello violations - pyspark
         (
             "pyspark",
             ["testHello", "testHELLO", "testhello"],
@@ -154,16 +321,7 @@ def test_expectation_name():
             ["testHello", "testHELLO"],
             "Found 2 row(s) where 'col1' does not end with 'hello'.",
         ),
-        # Exact match partial - pandas
-        (
-            "pandas",
-            ["bar", "foo", "baz"],
-            "bar",
-            "failure",
-            ["foo", "baz"],
-            "Found 2 row(s) where 'col1' does not end with 'bar'.",
-        ),
-        # Exact match partial - pyspark
+        # Exact match scenarios - pyspark
         (
             "pyspark",
             ["bar", "foo", "baz"],
@@ -172,21 +330,8 @@ def test_expectation_name():
             ["foo", "baz"],
             "Found 2 row(s) where 'col1' does not end with 'bar'.",
         ),
-        # Exact match all - pandas
-        ("pandas", ["test", "test", "test"], "test", "success", None, None),
-        # Exact match all - pyspark
         ("pyspark", ["test", "test", "test"], "test", "success", None, None),
-        # Single character suffix - pandas
-        ("pandas", ["a", "ba", "cba"], "a", "success", None, None),
-        (
-            "pandas",
-            ["b", "c", "d"],
-            "a",
-            "failure",
-            ["b", "c", "d"],
-            "Found 3 row(s) where 'col1' does not end with 'a'.",
-        ),
-        # Single character suffix - pyspark
+        # Single character suffix scenarios - pyspark
         ("pyspark", ["a", "ba", "cba"], "a", "success", None, None),
         (
             "pyspark",
@@ -196,16 +341,6 @@ def test_expectation_name():
             ["b", "c", "d"],
             "Found 3 row(s) where 'col1' does not end with 'a'.",
         ),
-        # Empty string scenarios - pandas
-        (
-            "pandas",
-            ["", "text", "more"],
-            "text",
-            "failure",
-            ["", "more"],
-            "Found 2 row(s) where 'col1' does not end with 'text'.",
-        ),
-        # Empty string scenarios - pyspark
         (
             "pyspark",
             ["", "text", "more"],
@@ -214,24 +349,9 @@ def test_expectation_name():
             ["", "more"],
             "Found 2 row(s) where 'col1' does not end with 'text'.",
         ),
-        # Whitespace success - pandas
-        ("pandas", ["foo bar", "baz bar", "test bar"], "bar", "success", None, None),
-        # Whitespace success - pyspark
+        # Whitespace handling scenarios - pyspark
         ("pyspark", ["foo bar", "baz bar", "test bar"], "bar", "success", None, None),
-        # Whitespace trailing - pandas
-        ("pandas", ["foo ", "bar ", "baz "], " ", "success", None, None),
-        # Whitespace trailing - pyspark
         ("pyspark", ["foo ", "bar ", "baz "], " ", "success", None, None),
-        # Whitespace in suffix - pandas
-        (
-            "pandas",
-            ["foo bar", "bar", "baz"],
-            " bar",
-            "failure",
-            ["bar", "baz"],
-            "Found 2 row(s) where 'col1' does not end with ' bar'.",
-        ),
-        # Whitespace in suffix - pyspark
         (
             "pyspark",
             ["foo bar", "bar", "baz"],
@@ -240,20 +360,8 @@ def test_expectation_name():
             ["bar", "baz"],
             "Found 2 row(s) where 'col1' does not end with ' bar'.",
         ),
-        # Special at sign - pandas
-        ("pandas", ["test@", "user@", "admin@"], "@", "success", None, None),
-        # Special at sign - pyspark
+        # Special character scenarios - pyspark
         ("pyspark", ["test@", "user@", "admin@"], "@", "success", None, None),
-        # Special exclamation - pandas
-        (
-            "pandas",
-            ["hello!", "world!", "test"],
-            "!",
-            "failure",
-            ["test"],
-            "Found 1 row(s) where 'col1' does not end with '!'.",
-        ),
-        # Special exclamation - pyspark
         (
             "pyspark",
             ["hello!", "world!", "test"],
@@ -262,20 +370,7 @@ def test_expectation_name():
             ["test"],
             "Found 1 row(s) where 'col1' does not end with '!'.",
         ),
-        # Special slash - pandas
-        ("pandas", ["path/to/", "another/"], "/", "success", None, None),
-        # Special slash - pyspark
         ("pyspark", ["path/to/", "another/"], "/", "success", None, None),
-        # Special hash - pandas
-        (
-            "pandas",
-            ["tag1#", "tag2#", "notag"],
-            "#",
-            "failure",
-            ["notag"],
-            "Found 1 row(s) where 'col1' does not end with '#'.",
-        ),
-        # Special hash - pyspark
         (
             "pyspark",
             ["tag1#", "tag2#", "notag"],
@@ -284,16 +379,7 @@ def test_expectation_name():
             ["notag"],
             "Found 1 row(s) where 'col1' does not end with '#'.",
         ),
-        # Numbers 123 - pandas
-        (
-            "pandas",
-            ["test123", "file123", "data456"],
-            "123",
-            "failure",
-            ["data456"],
-            "Found 1 row(s) where 'col1' does not end with '123'.",
-        ),
-        # Numbers 123 - pyspark
+        # Number scenarios - pyspark
         (
             "pyspark",
             ["test123", "file123", "data456"],
@@ -302,16 +388,6 @@ def test_expectation_name():
             ["data456"],
             "Found 1 row(s) where 'col1' does not end with '123'.",
         ),
-        # Numbers version - pandas
-        (
-            "pandas",
-            ["v1.0", "v2.0", "v1.1"],
-            ".0",
-            "failure",
-            ["v1.1"],
-            "Found 1 row(s) where 'col1' does not end with '.0'.",
-        ),
-        # Numbers version - pyspark
         (
             "pyspark",
             ["v1.0", "v2.0", "v1.1"],
@@ -320,20 +396,8 @@ def test_expectation_name():
             ["v1.1"],
             "Found 1 row(s) where 'col1' does not end with '.0'.",
         ),
-        # Long strings success - pandas
-        ("pandas", ["a" * 100 + "bar", "b" * 100 + "bar"], "bar", "success", None, None),
-        # Long strings success - pyspark
+        # Long string and suffix-length scenarios - pyspark
         ("pyspark", ["a" * 100 + "bar", "b" * 100 + "bar"], "bar", "success", None, None),
-        # Long strings violation - pandas
-        (
-            "pandas",
-            ["a" * 100 + "foo", "b" * 100 + "bar"],
-            "bar",
-            "failure",
-            ["a" * 100 + "foo"],
-            "Found 1 row(s) where 'col1' does not end with 'bar'.",
-        ),
-        # Long strings violation - pyspark
         (
             "pyspark",
             ["a" * 100 + "foo", "b" * 100 + "bar"],
@@ -342,16 +406,6 @@ def test_expectation_name():
             ["a" * 100 + "foo"],
             "Found 1 row(s) where 'col1' does not end with 'bar'.",
         ),
-        # Suffix longer than string - pandas
-        (
-            "pandas",
-            ["foo", "ba", "b"],
-            "foobar",
-            "failure",
-            ["foo", "ba", "b"],
-            "Found 3 row(s) where 'col1' does not end with 'foobar'.",
-        ),
-        # Suffix longer than string - pyspark
         (
             "pyspark",
             ["foo", "ba", "b"],
@@ -360,16 +414,6 @@ def test_expectation_name():
             ["foo", "ba", "b"],
             "Found 3 row(s) where 'col1' does not end with 'foobar'.",
         ),
-        # Partial matches not at end - pandas
-        (
-            "pandas",
-            ["barfoo", "foobar", "bazbar"],
-            "foo",
-            "failure",
-            ["foobar", "bazbar"],
-            "Found 2 row(s) where 'col1' does not end with 'foo'.",
-        ),
-        # Partial matches not at end - pyspark
         (
             "pyspark",
             ["barfoo", "foobar", "bazbar"],
@@ -380,73 +424,40 @@ def test_expectation_name():
         ),
     ],
     ids=[
-        "pandas_basic_success",
         "pyspark_basic_success",
-        "pandas_success_hello",
         "pyspark_success_hello",
-        "pandas_success_test",
         "pyspark_success_test",
-        "pandas_basic_violations",
         "pyspark_basic_violations",
-        "pandas_all_violations",
         "pyspark_all_violations",
-        "pandas_partial_match_violations",
         "pyspark_partial_match_violations",
-        "pandas_case_sensitive_violations",
         "pyspark_case_sensitive_violations",
-        "pandas_case_sensitive_success",
         "pyspark_case_sensitive_success",
-        "pandas_case_hello_violations",
         "pyspark_case_hello_violations",
-        "pandas_exact_match_partial",
         "pyspark_exact_match_partial",
-        "pandas_exact_match_all",
         "pyspark_exact_match_all",
-        "pandas_single_char_success",
         "pyspark_single_char_success",
-        "pandas_single_char_violations",
         "pyspark_single_char_violations",
-        "pandas_empty_string_violations",
         "pyspark_empty_string_violations",
-        "pandas_whitespace_success",
         "pyspark_whitespace_success",
-        "pandas_whitespace_trailing",
         "pyspark_whitespace_trailing",
-        "pandas_whitespace_in_suffix",
         "pyspark_whitespace_in_suffix",
-        "pandas_special_at_sign",
         "pyspark_special_at_sign",
-        "pandas_special_exclamation",
         "pyspark_special_exclamation",
-        "pandas_special_slash",
         "pyspark_special_slash",
-        "pandas_special_hash",
         "pyspark_special_hash",
-        "pandas_numbers_123",
         "pyspark_numbers_123",
-        "pandas_numbers_version",
         "pyspark_numbers_version",
-        "pandas_long_strings_success",
         "pyspark_long_strings_success",
-        "pandas_long_strings_violation",
         "pyspark_long_strings_violation",
-        "pandas_suffix_longer",
         "pyspark_suffix_longer",
-        "pandas_partial_not_at_end",
         "pyspark_partial_not_at_end",
     ],
 )
-def test_expectation_basic_scenarios(
+def test_expectation_basic_scenarios_pyspark(
     df_type, data, suffix, expected_result, expected_violations, expected_message, spark
 ):
-    """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
-    Tests both direct expectation validation and suite-based validation.
-    Covers: success cases, violations, case sensitivity, exact matches,
-    empty strings, whitespace, special characters, numbers, long strings,
-    and partial matches not at the end.
-    """
-    data_frame = create_dataframe(df_type, data, "col1", spark)
+    """Test the expectation for various scenarios for PySpark DataFrames."""
+    data_frame = create_pyspark_dataframe(data, "col1", spark)
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -461,8 +472,8 @@ def test_expectation_basic_scenarios(
         assert str(result) == str(
             DataFrameExpectationSuccessMessage(expectation_name="ExpectationStringEndsWith")
         ), f"Expected success message but got: {result}"
-    else:  # failure
-        expected_violations_df = create_dataframe(df_type, expected_violations, "col1", spark)
+    else:
+        expected_violations_df = create_pyspark_dataframe(expected_violations, "col1", spark)
         expected_failure_message = DataFrameExpectationFailureMessage(
             expectation_str=str(expectation),
             data_frame_type=str(df_type),
@@ -486,24 +497,16 @@ def test_expectation_basic_scenarios(
         assert result.success, "Expected all expectations to pass"
         assert result.total_passed == 1, "Expected 1 passed expectation"
         assert result.total_failed == 0, "Expected 0 failed expectations"
-    else:  # failure
+    else:
         with pytest.raises(DataFrameExpectationsSuiteFailure):
             expectations_suite.build().run(data_frame=data_frame)
 
 
-@pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
-)
-def test_column_missing_error(df_type, spark):
-    """Test that an error is raised when the specified column is missing in both pandas and PySpark."""
+def test_column_missing_error_pandas():
+    """Test that an error is raised when the specified column is missing in pandas."""
     expected_message = "Column 'col1' does not exist in the DataFrame."
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col2": ["foobar", "bar", "bazbar"]})
-    else:  # pyspark
-        data_frame = spark.createDataFrame([("foobar",), ("bar",), ("bazbar",)], ["col2"])
+    data_frame = pd.DataFrame({"col2": ["foobar", "bar", "bazbar"]})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -514,7 +517,36 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=data_frame)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_string_ends_with(
+        column_name="col1", suffix="bar"
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test that an error is raised when the specified column is missing in PySpark."""
+    expected_message = "Column 'col1' does not exist in the DataFrame."
+
+    data_frame = spark.createDataFrame([("foobar",), ("bar",), ("bazbar",)], ["col2"])
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationStringEndsWith",
+        column_name="col1",
+        suffix="bar",
+    )
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message=expected_message,
     )
     assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"

--- a/tests/expectations/column/string_expectations/test_expect_string_length_between.py
+++ b/tests/expectations/column/string_expectations/test_expect_string_length_between.py
@@ -7,20 +7,17 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark):
-    """Helper function to create pandas or pyspark DataFrame."""
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        return spark.createDataFrame([(val,) for val in data], [column_name])
+def create_pyspark_dataframe(data, column_name, spark):
+    """Helper function to create a PySpark DataFrame."""
+    return spark.createDataFrame([(val,) for val in data], [column_name])
 
 
 def test_expectation_name():
@@ -39,18 +36,10 @@ def test_expectation_name():
 @pytest.mark.parametrize(
     "df_type, data, min_length, max_length, expected_result, expected_violations, expected_message",
     [
-        # Basic success - pandas
+        # Basic success scenarios - pandas
         ("pandas", ["foo", "bazz", "hello", "foobar"], 3, 6, "success", None, None),
-        # Basic success - pyspark
-        ("pyspark", ["foo", "bazz", "hello", "foobar"], 3, 6, "success", None, None),
-        # Success 2-4 - pandas
         ("pandas", ["ab", "abc", "abcd"], 2, 4, "success", None, None),
-        # Success 2-4 - pyspark
-        ("pyspark", ["ab", "abc", "abcd"], 2, 4, "success", None, None),
-        # Success 4-5 - pandas
         ("pandas", ["test", "data", "valid"], 4, 5, "success", None, None),
-        # Success 4-5 - pyspark
-        ("pyspark", ["test", "data", "valid"], 4, 5, "success", None, None),
         # Basic violation scenarios - pandas
         (
             "pandas",
@@ -79,6 +68,212 @@ def test_expectation_name():
             ["testing", "t"],
             "Found 2 row(s) where 'col1' length is not between 2 and 4.",
         ),
+        # Boundary conditions - pandas
+        ("pandas", ["abc", "abcd", "abcde"], 3, 5, "success", None, None),
+        (
+            "pandas",
+            ["ab", "abc", "abcd"],
+            3,
+            5,
+            "failure",
+            ["ab"],
+            "Found 1 row(s) where 'col1' length is not between 3 and 5.",
+        ),
+        ("pandas", ["abc", "abcd", "abcde"], 3, 5, "success", None, None),
+        (
+            "pandas",
+            ["abc", "abcd", "abcdef"],
+            3,
+            5,
+            "failure",
+            ["abcdef"],
+            "Found 1 row(s) where 'col1' length is not between 3 and 5.",
+        ),
+        ("pandas", ["abc", "def", "ghi"], 3, 3, "success", None, None),
+        (
+            "pandas",
+            ["ab", "abc", "abcd"],
+            3,
+            3,
+            "failure",
+            ["ab", "abcd"],
+            "Found 2 row(s) where 'col1' length is not between 3 and 3.",
+        ),
+        ("pandas", ["a", "b", "c"], 1, 1, "success", None, None),
+        (
+            "pandas",
+            ["a", "ab", "abc"],
+            1,
+            1,
+            "failure",
+            ["ab", "abc"],
+            "Found 2 row(s) where 'col1' length is not between 1 and 1.",
+        ),
+        # Empty string and whitespace scenarios - pandas
+        (
+            "pandas",
+            ["", "a", "ab"],
+            1,
+            3,
+            "failure",
+            [""],
+            "Found 1 row(s) where 'col1' length is not between 1 and 3.",
+        ),
+        ("pandas", ["", "a", "ab"], 0, 3, "success", None, None),
+        ("pandas", ["   ", "  ", " "], 1, 3, "success", None, None),
+        ("pandas", ["a b", "a  b", "a   b"], 3, 5, "success", None, None),
+        (
+            "pandas",
+            [" a ", "  a  ", "a"],
+            4,
+            6,
+            "failure",
+            [" a ", "a"],
+            "Found 2 row(s) where 'col1' length is not between 4 and 6.",
+        ),
+        # Special characters and number scenarios - pandas
+        ("pandas", ["@@@", "!!!", "###"], 3, 3, "success", None, None),
+        ("pandas", ["test@", "user!", "admin#"], 5, 6, "success", None, None),
+        (
+            "pandas",
+            ["@", "!!", "###"],
+            2,
+            2,
+            "failure",
+            ["@", "###"],
+            "Found 2 row(s) where 'col1' length is not between 2 and 2.",
+        ),
+        ("pandas", ["123", "456", "789"], 3, 3, "success", None, None),
+        ("pandas", ["v1.0", "v2.0", "v10.0"], 4, 6, "success", None, None),
+        (
+            "pandas",
+            ["1", "12", "123456"],
+            2,
+            4,
+            "failure",
+            ["1", "123456"],
+            "Found 2 row(s) where 'col1' length is not between 2 and 4.",
+        ),
+        # Long string and wide range scenarios - pandas
+        ("pandas", ["a" * 100, "b" * 100, "c" * 100], 100, 100, "success", None, None),
+        (
+            "pandas",
+            ["a" * 50, "b" * 100, "c" * 150],
+            100,
+            100,
+            "failure",
+            ["a" * 50, "c" * 150],
+            "Found 2 row(s) where 'col1' length is not between 100 and 100.",
+        ),
+        ("pandas", ["a", "ab", "a" * 50, "a" * 100], 1, 100, "success", None, None),
+        ("pandas", ["", "a", "ab", "abc"], 0, 3, "success", None, None),
+        (
+            "pandas",
+            ["", "a", "abcd"],
+            0,
+            3,
+            "failure",
+            ["abcd"],
+            "Found 1 row(s) where 'col1' length is not between 0 and 3.",
+        ),
+    ],
+    ids=[
+        "pandas_basic_success",
+        "pandas_success_2_4",
+        "pandas_success_4_5",
+        "pandas_basic_violations",
+        "pandas_all_violations",
+        "pandas_one_violation",
+        "pandas_boundary_min_success",
+        "pandas_boundary_min_violation",
+        "pandas_boundary_max_success",
+        "pandas_boundary_max_violation",
+        "pandas_min_equals_max_success",
+        "pandas_min_equals_max_violations",
+        "pandas_single_char_success",
+        "pandas_single_char_violations",
+        "pandas_empty_string_violation",
+        "pandas_empty_string_success",
+        "pandas_whitespace_success",
+        "pandas_whitespace_with_text",
+        "pandas_whitespace_violations",
+        "pandas_special_chars_success",
+        "pandas_special_chars_in_text",
+        "pandas_special_chars_violations",
+        "pandas_numbers_success",
+        "pandas_numbers_versions",
+        "pandas_numbers_violations",
+        "pandas_long_strings_success",
+        "pandas_long_strings_violations",
+        "pandas_wide_range",
+        "pandas_zero_min_success",
+        "pandas_zero_min_violation",
+    ],
+)
+def test_expectation_basic_scenarios_pandas(
+    df_type,
+    data,
+    min_length,
+    max_length,
+    expected_result,
+    expected_violations,
+    expected_message,
+):
+    """Test the expectation for various scenarios for pandas DataFrames."""
+    data_frame = pd.DataFrame({"col1": data})
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationStringLengthBetween",
+        column_name="col1",
+        min_length=min_length,
+        max_length=max_length,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationStringLengthBetween")
+        ), f"Expected success message but got: {result}"
+    else:
+        expected_violations_df = pd.DataFrame({"col1": expected_violations})
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            violations_data_frame=expected_violations_df,
+            message=expected_message,
+            limit_violations=5,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_string_length_between(
+        column_name="col1", min_length=min_length, max_length=max_length
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+@pytest.mark.parametrize(
+    "df_type, data, min_length, max_length, expected_result, expected_violations, expected_message",
+    [
+        # Basic success scenarios - pyspark
+        ("pyspark", ["foo", "bazz", "hello", "foobar"], 3, 6, "success", None, None),
+        ("pyspark", ["ab", "abc", "abcd"], 2, 4, "success", None, None),
+        ("pyspark", ["test", "data", "valid"], 4, 5, "success", None, None),
         # Basic violation scenarios - pyspark
         (
             "pyspark",
@@ -107,21 +302,8 @@ def test_expectation_name():
             ["testing", "t"],
             "Found 2 row(s) where 'col1' length is not between 2 and 4.",
         ),
-        # Boundary min success - pandas
-        ("pandas", ["abc", "abcd", "abcde"], 3, 5, "success", None, None),
-        # Boundary min success - pyspark
+        # Boundary conditions - pyspark
         ("pyspark", ["abc", "abcd", "abcde"], 3, 5, "success", None, None),
-        # Boundary min violation - pandas
-        (
-            "pandas",
-            ["ab", "abc", "abcd"],
-            3,
-            5,
-            "failure",
-            ["ab"],
-            "Found 1 row(s) where 'col1' length is not between 3 and 5.",
-        ),
-        # Boundary min violation - pyspark
         (
             "pyspark",
             ["ab", "abc", "abcd"],
@@ -131,21 +313,7 @@ def test_expectation_name():
             ["ab"],
             "Found 1 row(s) where 'col1' length is not between 3 and 5.",
         ),
-        # Boundary max success - pandas
-        ("pandas", ["abc", "abcd", "abcde"], 3, 5, "success", None, None),
-        # Boundary max success - pyspark
         ("pyspark", ["abc", "abcd", "abcde"], 3, 5, "success", None, None),
-        # Boundary max violation - pandas
-        (
-            "pandas",
-            ["abc", "abcd", "abcdef"],
-            3,
-            5,
-            "failure",
-            ["abcdef"],
-            "Found 1 row(s) where 'col1' length is not between 3 and 5.",
-        ),
-        # Boundary max violation - pyspark
         (
             "pyspark",
             ["abc", "abcd", "abcdef"],
@@ -155,18 +323,6 @@ def test_expectation_name():
             ["abcdef"],
             "Found 1 row(s) where 'col1' length is not between 3 and 5.",
         ),
-        # Min equals max - pandas
-        ("pandas", ["abc", "def", "ghi"], 3, 3, "success", None, None),
-        (
-            "pandas",
-            ["ab", "abc", "abcd"],
-            3,
-            3,
-            "failure",
-            ["ab", "abcd"],
-            "Found 2 row(s) where 'col1' length is not between 3 and 3.",
-        ),
-        # Min equals max - pyspark
         ("pyspark", ["abc", "def", "ghi"], 3, 3, "success", None, None),
         (
             "pyspark",
@@ -177,18 +333,6 @@ def test_expectation_name():
             ["ab", "abcd"],
             "Found 2 row(s) where 'col1' length is not between 3 and 3.",
         ),
-        # Single character strings - pandas
-        ("pandas", ["a", "b", "c"], 1, 1, "success", None, None),
-        (
-            "pandas",
-            ["a", "ab", "abc"],
-            1,
-            1,
-            "failure",
-            ["ab", "abc"],
-            "Found 2 row(s) where 'col1' length is not between 1 and 1.",
-        ),
-        # Single character strings - pyspark
         ("pyspark", ["a", "b", "c"], 1, 1, "success", None, None),
         (
             "pyspark",
@@ -199,17 +343,7 @@ def test_expectation_name():
             ["ab", "abc"],
             "Found 2 row(s) where 'col1' length is not between 1 and 1.",
         ),
-        # Empty string violation - pandas
-        (
-            "pandas",
-            ["", "a", "ab"],
-            1,
-            3,
-            "failure",
-            [""],
-            "Found 1 row(s) where 'col1' length is not between 1 and 3.",
-        ),
-        # Empty string violation - pyspark
+        # Empty string and whitespace scenarios - pyspark
         (
             "pyspark",
             ["", "a", "ab"],
@@ -219,29 +353,9 @@ def test_expectation_name():
             [""],
             "Found 1 row(s) where 'col1' length is not between 1 and 3.",
         ),
-        # Empty string success - pandas
-        ("pandas", ["", "a", "ab"], 0, 3, "success", None, None),
-        # Empty string success - pyspark
         ("pyspark", ["", "a", "ab"], 0, 3, "success", None, None),
-        # Whitespace success - pandas
-        ("pandas", ["   ", "  ", " "], 1, 3, "success", None, None),
-        # Whitespace success - pyspark
         ("pyspark", ["   ", "  ", " "], 1, 3, "success", None, None),
-        # Whitespace with text - pandas
-        ("pandas", ["a b", "a  b", "a   b"], 3, 5, "success", None, None),
-        # Whitespace with text - pyspark
         ("pyspark", ["a b", "a  b", "a   b"], 3, 5, "success", None, None),
-        # Whitespace violations - pandas
-        (
-            "pandas",
-            [" a ", "  a  ", "a"],
-            4,
-            6,
-            "failure",
-            [" a ", "a"],
-            "Found 2 row(s) where 'col1' length is not between 4 and 6.",
-        ),
-        # Whitespace violations - pyspark
         (
             "pyspark",
             [" a ", "  a  ", "a"],
@@ -251,25 +365,9 @@ def test_expectation_name():
             [" a ", "a"],
             "Found 2 row(s) where 'col1' length is not between 4 and 6.",
         ),
-        # Special chars success - pandas
-        ("pandas", ["@@@", "!!!", "###"], 3, 3, "success", None, None),
-        # Special chars success - pyspark
+        # Special characters and number scenarios - pyspark
         ("pyspark", ["@@@", "!!!", "###"], 3, 3, "success", None, None),
-        # Special chars in text - pandas
-        ("pandas", ["test@", "user!", "admin#"], 5, 6, "success", None, None),
-        # Special chars in text - pyspark
         ("pyspark", ["test@", "user!", "admin#"], 5, 6, "success", None, None),
-        # Special chars violations - pandas
-        (
-            "pandas",
-            ["@", "!!", "###"],
-            2,
-            2,
-            "failure",
-            ["@", "###"],
-            "Found 2 row(s) where 'col1' length is not between 2 and 2.",
-        ),
-        # Special chars violations - pyspark
         (
             "pyspark",
             ["@", "!!", "###"],
@@ -279,25 +377,8 @@ def test_expectation_name():
             ["@", "###"],
             "Found 2 row(s) where 'col1' length is not between 2 and 2.",
         ),
-        # Numbers success - pandas
-        ("pandas", ["123", "456", "789"], 3, 3, "success", None, None),
-        # Numbers success - pyspark
         ("pyspark", ["123", "456", "789"], 3, 3, "success", None, None),
-        # Numbers versions - pandas
-        ("pandas", ["v1.0", "v2.0", "v10.0"], 4, 6, "success", None, None),
-        # Numbers versions - pyspark
         ("pyspark", ["v1.0", "v2.0", "v10.0"], 4, 6, "success", None, None),
-        # Numbers violations - pandas
-        (
-            "pandas",
-            ["1", "12", "123456"],
-            2,
-            4,
-            "failure",
-            ["1", "123456"],
-            "Found 2 row(s) where 'col1' length is not between 2 and 4.",
-        ),
-        # Numbers violations - pyspark
         (
             "pyspark",
             ["1", "12", "123456"],
@@ -307,21 +388,8 @@ def test_expectation_name():
             ["1", "123456"],
             "Found 2 row(s) where 'col1' length is not between 2 and 4.",
         ),
-        # Long strings success - pandas
-        ("pandas", ["a" * 100, "b" * 100, "c" * 100], 100, 100, "success", None, None),
-        # Long strings success - pyspark
+        # Long string and wide range scenarios - pyspark
         ("pyspark", ["a" * 100, "b" * 100, "c" * 100], 100, 100, "success", None, None),
-        # Long strings violations - pandas
-        (
-            "pandas",
-            ["a" * 50, "b" * 100, "c" * 150],
-            100,
-            100,
-            "failure",
-            ["a" * 50, "c" * 150],
-            "Found 2 row(s) where 'col1' length is not between 100 and 100.",
-        ),
-        # Long strings violations - pyspark
         (
             "pyspark",
             ["a" * 50, "b" * 100, "c" * 150],
@@ -331,25 +399,8 @@ def test_expectation_name():
             ["a" * 50, "c" * 150],
             "Found 2 row(s) where 'col1' length is not between 100 and 100.",
         ),
-        # Wide range - pandas
-        ("pandas", ["a", "ab", "a" * 50, "a" * 100], 1, 100, "success", None, None),
-        # Wide range - pyspark
         ("pyspark", ["a", "ab", "a" * 50, "a" * 100], 1, 100, "success", None, None),
-        # Zero min success - pandas
-        ("pandas", ["", "a", "ab", "abc"], 0, 3, "success", None, None),
-        # Zero min success - pyspark
         ("pyspark", ["", "a", "ab", "abc"], 0, 3, "success", None, None),
-        # Zero min violation - pandas
-        (
-            "pandas",
-            ["", "a", "abcd"],
-            0,
-            3,
-            "failure",
-            ["abcd"],
-            "Found 1 row(s) where 'col1' length is not between 0 and 3.",
-        ),
-        # Zero min violation - pyspark
         (
             "pyspark",
             ["", "a", "abcd"],
@@ -361,69 +412,39 @@ def test_expectation_name():
         ),
     ],
     ids=[
-        "pandas_basic_success",
         "pyspark_basic_success",
-        "pandas_success_2_4",
         "pyspark_success_2_4",
-        "pandas_success_4_5",
         "pyspark_success_4_5",
-        "pandas_basic_violations",
         "pyspark_basic_violations",
-        "pandas_all_violations",
         "pyspark_all_violations",
-        "pandas_one_violation",
         "pyspark_one_violation",
-        "pandas_boundary_min_success",
         "pyspark_boundary_min_success",
-        "pandas_boundary_min_violation",
         "pyspark_boundary_min_violation",
-        "pandas_boundary_max_success",
         "pyspark_boundary_max_success",
-        "pandas_boundary_max_violation",
         "pyspark_boundary_max_violation",
-        "pandas_min_equals_max_success",
         "pyspark_min_equals_max_success",
-        "pandas_min_equals_max_violations",
         "pyspark_min_equals_max_violations",
-        "pandas_single_char_success",
         "pyspark_single_char_success",
-        "pandas_single_char_violations",
         "pyspark_single_char_violations",
-        "pandas_empty_string_violation",
         "pyspark_empty_string_violation",
-        "pandas_empty_string_success",
         "pyspark_empty_string_success",
-        "pandas_whitespace_success",
         "pyspark_whitespace_success",
-        "pandas_whitespace_with_text",
         "pyspark_whitespace_with_text",
-        "pandas_whitespace_violations",
         "pyspark_whitespace_violations",
-        "pandas_special_chars_success",
         "pyspark_special_chars_success",
-        "pandas_special_chars_in_text",
         "pyspark_special_chars_in_text",
-        "pandas_special_chars_violations",
         "pyspark_special_chars_violations",
-        "pandas_numbers_success",
         "pyspark_numbers_success",
-        "pandas_numbers_versions",
         "pyspark_numbers_versions",
-        "pandas_numbers_violations",
         "pyspark_numbers_violations",
-        "pandas_long_strings_success",
         "pyspark_long_strings_success",
-        "pandas_long_strings_violations",
         "pyspark_long_strings_violations",
-        "pandas_wide_range",
         "pyspark_wide_range",
-        "pandas_zero_min_success",
         "pyspark_zero_min_success",
-        "pandas_zero_min_violation",
         "pyspark_zero_min_violation",
     ],
 )
-def test_expectation_basic_scenarios(
+def test_expectation_basic_scenarios_pyspark(
     df_type,
     data,
     min_length,
@@ -433,15 +454,8 @@ def test_expectation_basic_scenarios(
     expected_message,
     spark,
 ):
-    """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
-    Tests both direct expectation validation and suite-based validation.
-    Covers: success cases, violations, boundary conditions (min/max exact),
-    min equals max scenarios, single character strings, empty strings,
-    whitespace handling, special characters, numbers in strings, long strings,
-    wide ranges, and zero min length.
-    """
-    data_frame = create_dataframe(df_type, data, "col1", spark)
+    """Test the expectation for various scenarios for PySpark DataFrames."""
+    data_frame = create_pyspark_dataframe(data, "col1", spark)
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -457,8 +471,8 @@ def test_expectation_basic_scenarios(
         assert str(result) == str(
             DataFrameExpectationSuccessMessage(expectation_name="ExpectationStringLengthBetween")
         ), f"Expected success message but got: {result}"
-    else:  # failure
-        expected_violations_df = create_dataframe(df_type, expected_violations, "col1", spark)
+    else:
+        expected_violations_df = create_pyspark_dataframe(expected_violations, "col1", spark)
         expected_failure_message = DataFrameExpectationFailureMessage(
             expectation_str=str(expectation),
             data_frame_type=str(df_type),
@@ -482,24 +496,16 @@ def test_expectation_basic_scenarios(
         assert result.success, "Expected all expectations to pass"
         assert result.total_passed == 1, "Expected 1 passed expectation"
         assert result.total_failed == 0, "Expected 0 failed expectations"
-    else:  # failure
+    else:
         with pytest.raises(DataFrameExpectationsSuiteFailure):
             expectations_suite.build().run(data_frame=data_frame)
 
 
-@pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
-)
-def test_column_missing_error(df_type, spark):
-    """Test that an error is raised when the specified column is missing in both pandas and PySpark."""
+def test_column_missing_error_pandas():
+    """Test that an error is raised when the specified column is missing in pandas."""
     expected_message = "Column 'col1' does not exist in the DataFrame."
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col2": ["foo", "bazz", "hello"]})
-    else:  # pyspark
-        data_frame = spark.createDataFrame([("foo",), ("bazz",), ("hello",)], ["col2"])
+    data_frame = pd.DataFrame({"col2": ["foo", "bazz", "hello"]})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -511,7 +517,37 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=data_frame)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_string_length_between(
+        column_name="col1", min_length=3, max_length=6
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test that an error is raised when the specified column is missing in PySpark."""
+    expected_message = "Column 'col1' does not exist in the DataFrame."
+
+    data_frame = spark.createDataFrame([("foo",), ("bazz",), ("hello",)], ["col2"])
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationStringLengthBetween",
+        column_name="col1",
+        min_length=3,
+        max_length=6,
+    )
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message=expected_message,
     )
     assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"

--- a/tests/expectations/column/string_expectations/test_expect_string_length_equals.py
+++ b/tests/expectations/column/string_expectations/test_expect_string_length_equals.py
@@ -7,20 +7,17 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark):
-    """Helper function to create pandas or pyspark DataFrame."""
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        return spark.createDataFrame([(val,) for val in data], [column_name])
+def create_pyspark_dataframe(data, column_name, spark):
+    """Helper function to create a PySpark DataFrame."""
+    return spark.createDataFrame([(val,) for val in data], [column_name])
 
 
 def test_expectation_name():
@@ -40,28 +37,13 @@ def test_expectation_name():
     [
         # Basic success - pandas
         ("pandas", ["foo", "bar", "baz"], 3, "success", None, None),
-        # Basic success - pyspark
-        ("pyspark", ["foo", "bar", "baz"], 3, "success", None, None),
         # Success length 2 - pandas
         ("pandas", ["ab", "cd", "ef"], 2, "success", None, None),
-        # Success length 2 - pyspark
-        ("pyspark", ["ab", "cd", "ef"], 2, "success", None, None),
         # Success length 5 - pandas
         ("pandas", ["hello", "world", "tests"], 5, "success", None, None),
-        # Success length 5 - pyspark
-        ("pyspark", ["hello", "world", "tests"], 5, "success", None, None),
         # Basic violations - pandas
         (
             "pandas",
-            ["foo", "bar", "bazz", "foobar"],
-            3,
-            "failure",
-            ["bazz", "foobar"],
-            "Found 2 row(s) where 'col1' length is not equal to 3.",
-        ),
-        # Basic violations - pyspark
-        (
-            "pyspark",
             ["foo", "bar", "bazz", "foobar"],
             3,
             "failure",
@@ -77,15 +59,6 @@ def test_expectation_name():
             ["a", "ab", "abc"],
             "Found 3 row(s) where 'col1' length is not equal to 5.",
         ),
-        # All violations - pyspark
-        (
-            "pyspark",
-            ["a", "ab", "abc"],
-            5,
-            "failure",
-            ["a", "ab", "abc"],
-            "Found 3 row(s) where 'col1' length is not equal to 5.",
-        ),
         # Mixed violations - pandas
         (
             "pandas",
@@ -95,19 +68,8 @@ def test_expectation_name():
             ["testing", "t"],
             "Found 2 row(s) where 'col1' length is not equal to 4.",
         ),
-        # Mixed violations - pyspark
-        (
-            "pyspark",
-            ["test", "testing", "t"],
-            4,
-            "failure",
-            ["testing", "t"],
-            "Found 2 row(s) where 'col1' length is not equal to 4.",
-        ),
         # Single char success - pandas
         ("pandas", ["a", "b", "c"], 1, "success", None, None),
-        # Single char success - pyspark
-        ("pyspark", ["a", "b", "c"], 1, "success", None, None),
         # Single char violations - pandas
         (
             "pandas",
@@ -117,31 +79,11 @@ def test_expectation_name():
             ["ab", "abc"],
             "Found 2 row(s) where 'col1' length is not equal to 1.",
         ),
-        # Single char violations - pyspark
-        (
-            "pyspark",
-            ["a", "ab", "abc"],
-            1,
-            "failure",
-            ["ab", "abc"],
-            "Found 2 row(s) where 'col1' length is not equal to 1.",
-        ),
         # Empty string success - pandas
         ("pandas", ["", "", ""], 0, "success", None, None),
-        # Empty string success - pyspark
-        ("pyspark", ["", "", ""], 0, "success", None, None),
         # Empty string violations length 0 - pandas
         (
             "pandas",
-            ["", "a", "ab"],
-            0,
-            "failure",
-            ["a", "ab"],
-            "Found 2 row(s) where 'col1' length is not equal to 0.",
-        ),
-        # Empty string violations length 0 - pyspark
-        (
-            "pyspark",
             ["", "a", "ab"],
             0,
             "failure",
@@ -157,27 +99,9 @@ def test_expectation_name():
             ["", "ab"],
             "Found 2 row(s) where 'col1' length is not equal to 1.",
         ),
-        # Empty string violations length 1 - pyspark
-        (
-            "pyspark",
-            ["", "a", "ab"],
-            1,
-            "failure",
-            ["", "ab"],
-            "Found 2 row(s) where 'col1' length is not equal to 1.",
-        ),
         # Whitespace length 1 - pandas
         (
             "pandas",
-            ["   ", "  ", " "],
-            1,
-            "failure",
-            ["   ", "  "],
-            "Found 2 row(s) where 'col1' length is not equal to 1.",
-        ),
-        # Whitespace length 1 - pyspark
-        (
-            "pyspark",
             ["   ", "  ", " "],
             1,
             "failure",
@@ -193,19 +117,8 @@ def test_expectation_name():
             ["  ", " "],
             "Found 2 row(s) where 'col1' length is not equal to 3.",
         ),
-        # Whitespace length 3 - pyspark
-        (
-            "pyspark",
-            ["   ", "  ", " "],
-            3,
-            "failure",
-            ["  ", " "],
-            "Found 2 row(s) where 'col1' length is not equal to 3.",
-        ),
         # Whitespace in text - pandas
         ("pandas", ["a b", "c d", "e f"], 3, "success", None, None),
-        # Whitespace in text - pyspark
-        ("pyspark", ["a b", "c d", "e f"], 3, "success", None, None),
         # Whitespace mixed - pandas
         (
             "pandas",
@@ -215,23 +128,10 @@ def test_expectation_name():
             ["  a  ", "a"],
             "Found 2 row(s) where 'col1' length is not equal to 3.",
         ),
-        # Whitespace mixed - pyspark
-        (
-            "pyspark",
-            [" a ", "  a  ", "a"],
-            3,
-            "failure",
-            ["  a  ", "a"],
-            "Found 2 row(s) where 'col1' length is not equal to 3.",
-        ),
         # Special chars success - pandas
         ("pandas", ["@@@", "!!!", "###"], 3, "success", None, None),
-        # Special chars success - pyspark
-        ("pyspark", ["@@@", "!!!", "###"], 3, "success", None, None),
         # Special chars in text - pandas
         ("pandas", ["test@", "user!", "data#"], 5, "success", None, None),
-        # Special chars in text - pyspark
-        ("pyspark", ["test@", "user!", "data#"], 5, "success", None, None),
         # Special chars violations - pandas
         (
             "pandas",
@@ -241,23 +141,10 @@ def test_expectation_name():
             ["@", "###"],
             "Found 2 row(s) where 'col1' length is not equal to 2.",
         ),
-        # Special chars violations - pyspark
-        (
-            "pyspark",
-            ["@", "!!", "###"],
-            2,
-            "failure",
-            ["@", "###"],
-            "Found 2 row(s) where 'col1' length is not equal to 2.",
-        ),
         # Numbers success - pandas
         ("pandas", ["123", "456", "789"], 3, "success", None, None),
-        # Numbers success - pyspark
-        ("pyspark", ["123", "456", "789"], 3, "success", None, None),
         # Numbers versions - pandas
         ("pandas", ["v1.0", "v2.0", "v3.0"], 4, "success", None, None),
-        # Numbers versions - pyspark
-        ("pyspark", ["v1.0", "v2.0", "v3.0"], 4, "success", None, None),
         # Numbers violations - pandas
         (
             "pandas",
@@ -267,23 +154,10 @@ def test_expectation_name():
             ["1", "123"],
             "Found 2 row(s) where 'col1' length is not equal to 2.",
         ),
-        # Numbers violations - pyspark
-        (
-            "pyspark",
-            ["1", "12", "123"],
-            2,
-            "failure",
-            ["1", "123"],
-            "Found 2 row(s) where 'col1' length is not equal to 2.",
-        ),
         # Length 10 success - pandas
         ("pandas", ["a" * 10, "b" * 10, "c" * 10], 10, "success", None, None),
-        # Length 10 success - pyspark
-        ("pyspark", ["a" * 10, "b" * 10, "c" * 10], 10, "success", None, None),
         # Length 20 success - pandas
         ("pandas", ["a" * 20, "b" * 20, "c" * 20], 20, "success", None, None),
-        # Length 20 success - pyspark
-        ("pyspark", ["a" * 20, "b" * 20, "c" * 20], 20, "success", None, None),
         # Length 10 violation - pandas
         (
             "pandas",
@@ -293,31 +167,11 @@ def test_expectation_name():
             ["b" * 20],
             "Found 1 row(s) where 'col1' length is not equal to 10.",
         ),
-        # Length 10 violation - pyspark
-        (
-            "pyspark",
-            ["a" * 10, "b" * 20, "c" * 10],
-            10,
-            "failure",
-            ["b" * 20],
-            "Found 1 row(s) where 'col1' length is not equal to 10.",
-        ),
         # Long strings success - pandas
         ("pandas", ["a" * 100, "b" * 100, "c" * 100], 100, "success", None, None),
-        # Long strings success - pyspark
-        ("pyspark", ["a" * 100, "b" * 100, "c" * 100], 100, "success", None, None),
         # Long strings violations - pandas
         (
             "pandas",
-            ["a" * 100, "b" * 99, "c" * 101],
-            100,
-            "failure",
-            ["b" * 99, "c" * 101],
-            "Found 2 row(s) where 'col1' length is not equal to 100.",
-        ),
-        # Long strings violations - pyspark
-        (
-            "pyspark",
             ["a" * 100, "b" * 99, "c" * 101],
             100,
             "failure",
@@ -333,84 +187,48 @@ def test_expectation_name():
             ["short", "way too long"],
             "Found 2 row(s) where 'col1' length is not equal to 8.",
         ),
-        # Mixed violations - pyspark
-        (
-            "pyspark",
-            ["short", "exactly3", "way too long"],
-            8,
-            "failure",
-            ["short", "way too long"],
-            "Found 2 row(s) where 'col1' length is not equal to 8.",
-        ),
     ],
     ids=[
         "pandas_basic_success",
-        "pyspark_basic_success",
         "pandas_success_length_2",
-        "pyspark_success_length_2",
         "pandas_success_length_5",
-        "pyspark_success_length_5",
         "pandas_basic_violations",
-        "pyspark_basic_violations",
         "pandas_all_violations",
-        "pyspark_all_violations",
         "pandas_mixed_violations",
-        "pyspark_mixed_violations",
         "pandas_single_char_success",
-        "pyspark_single_char_success",
         "pandas_single_char_violations",
-        "pyspark_single_char_violations",
         "pandas_empty_string_success",
-        "pyspark_empty_string_success",
         "pandas_empty_string_violations_length_0",
-        "pyspark_empty_string_violations_length_0",
         "pandas_empty_string_violations_length_1",
-        "pyspark_empty_string_violations_length_1",
         "pandas_whitespace_length_1",
-        "pyspark_whitespace_length_1",
         "pandas_whitespace_length_3",
-        "pyspark_whitespace_length_3",
         "pandas_whitespace_in_text",
-        "pyspark_whitespace_in_text",
         "pandas_whitespace_mixed",
-        "pyspark_whitespace_mixed",
         "pandas_special_chars_success",
-        "pyspark_special_chars_success",
         "pandas_special_chars_in_text",
-        "pyspark_special_chars_in_text",
         "pandas_special_chars_violations",
-        "pyspark_special_chars_violations",
         "pandas_numbers_success",
-        "pyspark_numbers_success",
         "pandas_numbers_versions",
-        "pyspark_numbers_versions",
         "pandas_numbers_violations",
-        "pyspark_numbers_violations",
         "pandas_length_10_success",
-        "pyspark_length_10_success",
         "pandas_length_20_success",
-        "pyspark_length_20_success",
         "pandas_length_10_violation",
-        "pyspark_length_10_violation",
         "pandas_long_strings_success",
-        "pyspark_long_strings_success",
         "pandas_long_strings_violations",
-        "pyspark_long_strings_violations",
         "pandas_mixed_short_and_long",
-        "pyspark_mixed_short_and_long",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, data, length, expected_result, expected_violations, expected_message, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, data, length, expected_result, expected_violations, expected_message
 ):
     """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
+    Test the expectation for various scenarios across pandas DataFrames.
     Tests both direct expectation validation and suite-based validation.
     Covers: success cases, violations, different length values, single character strings,
     empty strings, whitespace handling, special characters, numbers in strings,
     long strings, and mixed violations.
     """
-    data_frame = create_dataframe(df_type, data, "col1", spark)
+    data_frame = pd.DataFrame({"col1": data})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -426,7 +244,7 @@ def test_expectation_basic_scenarios(
             DataFrameExpectationSuccessMessage(expectation_name="ExpectationStringLengthEquals")
         ), f"Expected success message but got: {result}"
     else:  # failure
-        expected_violations_df = create_dataframe(df_type, expected_violations, "col1", spark)
+        expected_violations_df = pd.DataFrame({"col1": expected_violations})
         expected_failure_message = DataFrameExpectationFailureMessage(
             expectation_str=str(expectation),
             data_frame_type=str(df_type),
@@ -455,19 +273,253 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
+@pytest.mark.pyspark
 @pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
+    "df_type, data, length, expected_result, expected_violations, expected_message",
+    [
+        # Basic success - pyspark
+        ("pyspark", ["foo", "bar", "baz"], 3, "success", None, None),
+        # Success length 2 - pyspark
+        ("pyspark", ["ab", "cd", "ef"], 2, "success", None, None),
+        # Success length 5 - pyspark
+        ("pyspark", ["hello", "world", "tests"], 5, "success", None, None),
+        # Basic violations - pyspark
+        (
+            "pyspark",
+            ["foo", "bar", "bazz", "foobar"],
+            3,
+            "failure",
+            ["bazz", "foobar"],
+            "Found 2 row(s) where 'col1' length is not equal to 3.",
+        ),
+        # All violations - pyspark
+        (
+            "pyspark",
+            ["a", "ab", "abc"],
+            5,
+            "failure",
+            ["a", "ab", "abc"],
+            "Found 3 row(s) where 'col1' length is not equal to 5.",
+        ),
+        # Mixed violations - pyspark
+        (
+            "pyspark",
+            ["test", "testing", "t"],
+            4,
+            "failure",
+            ["testing", "t"],
+            "Found 2 row(s) where 'col1' length is not equal to 4.",
+        ),
+        # Single char success - pyspark
+        ("pyspark", ["a", "b", "c"], 1, "success", None, None),
+        # Single char violations - pyspark
+        (
+            "pyspark",
+            ["a", "ab", "abc"],
+            1,
+            "failure",
+            ["ab", "abc"],
+            "Found 2 row(s) where 'col1' length is not equal to 1.",
+        ),
+        # Empty string success - pyspark
+        ("pyspark", ["", "", ""], 0, "success", None, None),
+        # Empty string violations length 0 - pyspark
+        (
+            "pyspark",
+            ["", "a", "ab"],
+            0,
+            "failure",
+            ["a", "ab"],
+            "Found 2 row(s) where 'col1' length is not equal to 0.",
+        ),
+        # Empty string violations length 1 - pyspark
+        (
+            "pyspark",
+            ["", "a", "ab"],
+            1,
+            "failure",
+            ["", "ab"],
+            "Found 2 row(s) where 'col1' length is not equal to 1.",
+        ),
+        # Whitespace length 1 - pyspark
+        (
+            "pyspark",
+            ["   ", "  ", " "],
+            1,
+            "failure",
+            ["   ", "  "],
+            "Found 2 row(s) where 'col1' length is not equal to 1.",
+        ),
+        # Whitespace length 3 - pyspark
+        (
+            "pyspark",
+            ["   ", "  ", " "],
+            3,
+            "failure",
+            ["  ", " "],
+            "Found 2 row(s) where 'col1' length is not equal to 3.",
+        ),
+        # Whitespace in text - pyspark
+        ("pyspark", ["a b", "c d", "e f"], 3, "success", None, None),
+        # Whitespace mixed - pyspark
+        (
+            "pyspark",
+            [" a ", "  a  ", "a"],
+            3,
+            "failure",
+            ["  a  ", "a"],
+            "Found 2 row(s) where 'col1' length is not equal to 3.",
+        ),
+        # Special chars success - pyspark
+        ("pyspark", ["@@@", "!!!", "###"], 3, "success", None, None),
+        # Special chars in text - pyspark
+        ("pyspark", ["test@", "user!", "data#"], 5, "success", None, None),
+        # Special chars violations - pyspark
+        (
+            "pyspark",
+            ["@", "!!", "###"],
+            2,
+            "failure",
+            ["@", "###"],
+            "Found 2 row(s) where 'col1' length is not equal to 2.",
+        ),
+        # Numbers success - pyspark
+        ("pyspark", ["123", "456", "789"], 3, "success", None, None),
+        # Numbers versions - pyspark
+        ("pyspark", ["v1.0", "v2.0", "v3.0"], 4, "success", None, None),
+        # Numbers violations - pyspark
+        (
+            "pyspark",
+            ["1", "12", "123"],
+            2,
+            "failure",
+            ["1", "123"],
+            "Found 2 row(s) where 'col1' length is not equal to 2.",
+        ),
+        # Length 10 success - pyspark
+        ("pyspark", ["a" * 10, "b" * 10, "c" * 10], 10, "success", None, None),
+        # Length 20 success - pyspark
+        ("pyspark", ["a" * 20, "b" * 20, "c" * 20], 20, "success", None, None),
+        # Length 10 violation - pyspark
+        (
+            "pyspark",
+            ["a" * 10, "b" * 20, "c" * 10],
+            10,
+            "failure",
+            ["b" * 20],
+            "Found 1 row(s) where 'col1' length is not equal to 10.",
+        ),
+        # Long strings success - pyspark
+        ("pyspark", ["a" * 100, "b" * 100, "c" * 100], 100, "success", None, None),
+        # Long strings violations - pyspark
+        (
+            "pyspark",
+            ["a" * 100, "b" * 99, "c" * 101],
+            100,
+            "failure",
+            ["b" * 99, "c" * 101],
+            "Found 2 row(s) where 'col1' length is not equal to 100.",
+        ),
+        # Mixed violations - pyspark
+        (
+            "pyspark",
+            ["short", "exactly3", "way too long"],
+            8,
+            "failure",
+            ["short", "way too long"],
+            "Found 2 row(s) where 'col1' length is not equal to 8.",
+        ),
+    ],
+    ids=[
+        "pyspark_basic_success",
+        "pyspark_success_length_2",
+        "pyspark_success_length_5",
+        "pyspark_basic_violations",
+        "pyspark_all_violations",
+        "pyspark_mixed_violations",
+        "pyspark_single_char_success",
+        "pyspark_single_char_violations",
+        "pyspark_empty_string_success",
+        "pyspark_empty_string_violations_length_0",
+        "pyspark_empty_string_violations_length_1",
+        "pyspark_whitespace_length_1",
+        "pyspark_whitespace_length_3",
+        "pyspark_whitespace_in_text",
+        "pyspark_whitespace_mixed",
+        "pyspark_special_chars_success",
+        "pyspark_special_chars_in_text",
+        "pyspark_special_chars_violations",
+        "pyspark_numbers_success",
+        "pyspark_numbers_versions",
+        "pyspark_numbers_violations",
+        "pyspark_length_10_success",
+        "pyspark_length_20_success",
+        "pyspark_length_10_violation",
+        "pyspark_long_strings_success",
+        "pyspark_long_strings_violations",
+        "pyspark_mixed_short_and_long",
+    ],
 )
-def test_column_missing_error(df_type, spark):
-    """Test that an error is raised when the specified column is missing in both pandas and PySpark."""
+def test_expectation_basic_scenarios_pyspark(
+    df_type, data, length, expected_result, expected_violations, expected_message, spark
+):
+    """
+    Test the expectation for various scenarios across PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases, violations, different length values, single character strings,
+    empty strings, whitespace handling, special characters, numbers in strings,
+    long strings, and mixed violations.
+    """
+    data_frame = create_pyspark_dataframe(data, "col1", spark)
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationStringLengthEquals",
+        column_name="col1",
+        length=length,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationStringLengthEquals")
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        expected_violations_df = create_pyspark_dataframe(expected_violations, "col1", spark)
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            violations_data_frame=expected_violations_df,
+            message=expected_message,
+            limit_violations=5,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_string_length_equals(
+        column_name="col1", length=length
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+def test_column_missing_error_pandas():
+    """Test that an error is raised when the specified column is missing in pandas."""
     expected_message = "Column 'col1' does not exist in the DataFrame."
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col2": ["foo", "bar", "baz"]})
-    else:  # pyspark
-        data_frame = spark.createDataFrame([("foo",), ("bar",), ("baz",)], ["col2"])
+    data_frame = pd.DataFrame({"col2": ["foo", "bar", "baz"]})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -478,7 +530,36 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=data_frame)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_string_length_equals(
+        column_name="col1", length=3
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test that an error is raised when the specified column is missing in PySpark."""
+    expected_message = "Column 'col1' does not exist in the DataFrame."
+
+    data_frame = spark.createDataFrame([("foo",), ("bar",), ("baz",)], ["col2"])
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationStringLengthEquals",
+        column_name="col1",
+        length=3,
+    )
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message=expected_message,
     )
     assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"

--- a/tests/expectations/column/string_expectations/test_expect_string_length_greater_than.py
+++ b/tests/expectations/column/string_expectations/test_expect_string_length_greater_than.py
@@ -7,20 +7,17 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark):
-    """Helper function to create pandas or pyspark DataFrame."""
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        return spark.createDataFrame([(val,) for val in data], [column_name])
+def create_pyspark_dataframe(data, column_name, spark):
+    """Helper function to create a PySpark DataFrame."""
+    return spark.createDataFrame([(val,) for val in data], [column_name])
 
 
 def test_expectation_name():
@@ -40,28 +37,13 @@ def test_expectation_name():
     [
         # Basic success - pandas
         ("pandas", ["foobar", "bazz", "hello"], 3, "success", None, None),
-        # Basic success - pyspark
-        ("pyspark", ["foobar", "bazz", "hello"], 3, "success", None, None),
         # Success length 2 - pandas
         ("pandas", ["abc", "abcd", "abcde"], 2, "success", None, None),
-        # Success length 2 - pyspark
-        ("pyspark", ["abc", "abcd", "abcde"], 2, "success", None, None),
         # Success length 4 - pandas
         ("pandas", ["hello", "world", "testing"], 4, "success", None, None),
-        # Success length 4 - pyspark
-        ("pyspark", ["hello", "world", "testing"], 4, "success", None, None),
         # Basic violations - pandas
         (
             "pandas",
-            ["foo", "bar", "bazzz"],
-            3,
-            "failure",
-            ["foo", "bar"],
-            "Found 2 row(s) where 'col1' length is not greater than 3.",
-        ),
-        # Basic violations - pyspark
-        (
-            "pyspark",
             ["foo", "bar", "bazzz"],
             3,
             "failure",
@@ -77,27 +59,9 @@ def test_expectation_name():
             ["a", "ab", "abc"],
             "Found 3 row(s) where 'col1' length is not greater than 5.",
         ),
-        # All violations - pyspark
-        (
-            "pyspark",
-            ["a", "ab", "abc"],
-            5,
-            "failure",
-            ["a", "ab", "abc"],
-            "Found 3 row(s) where 'col1' length is not greater than 5.",
-        ),
         # Mixed violations - pandas
         (
             "pandas",
-            ["test", "testing", "t"],
-            4,
-            "failure",
-            ["test", "t"],
-            "Found 2 row(s) where 'col1' length is not greater than 4.",
-        ),
-        # Mixed violations - pyspark
-        (
-            "pyspark",
             ["test", "testing", "t"],
             4,
             "failure",
@@ -113,23 +77,10 @@ def test_expectation_name():
             ["abc"],
             "Found 1 row(s) where 'col1' length is not greater than 3.",
         ),
-        # Boundary exact violation - pyspark
-        (
-            "pyspark",
-            ["abc", "abcd", "abcde"],
-            3,
-            "failure",
-            ["abc"],
-            "Found 1 row(s) where 'col1' length is not greater than 3.",
-        ),
         # Boundary success - pandas
         ("pandas", ["abcd", "abcde", "abcdef"], 3, "success", None, None),
-        # Boundary success - pyspark
-        ("pyspark", ["abcd", "abcde", "abcdef"], 3, "success", None, None),
         # Zero length success - pandas
         ("pandas", ["a", "ab", "abc"], 0, "success", None, None),
-        # Zero length success - pyspark
-        ("pyspark", ["a", "ab", "abc"], 0, "success", None, None),
         # Zero length violation - pandas
         (
             "pandas",
@@ -139,31 +90,11 @@ def test_expectation_name():
             [""],
             "Found 1 row(s) where 'col1' length is not greater than 0.",
         ),
-        # Zero length violation - pyspark
-        (
-            "pyspark",
-            ["", "a", "ab"],
-            0,
-            "failure",
-            [""],
-            "Found 1 row(s) where 'col1' length is not greater than 0.",
-        ),
         # Single char success - pandas
         ("pandas", ["ab", "abc", "abcd"], 1, "success", None, None),
-        # Single char success - pyspark
-        ("pyspark", ["ab", "abc", "abcd"], 1, "success", None, None),
         # Single char violations - pandas
         (
             "pandas",
-            ["a", "b", "cd"],
-            1,
-            "failure",
-            ["a", "b"],
-            "Found 2 row(s) where 'col1' length is not greater than 1.",
-        ),
-        # Single char violations - pyspark
-        (
-            "pyspark",
             ["a", "b", "cd"],
             1,
             "failure",
@@ -179,23 +110,10 @@ def test_expectation_name():
             ["", "a"],
             "Found 2 row(s) where 'col1' length is not greater than 1.",
         ),
-        # Empty strings - pyspark
-        (
-            "pyspark",
-            ["", "a", "ab"],
-            1,
-            "failure",
-            ["", "a"],
-            "Found 2 row(s) where 'col1' length is not greater than 1.",
-        ),
         # Whitespace success - pandas
         ("pandas", ["    ", "   ", "   "], 2, "success", None, None),
-        # Whitespace success - pyspark
-        ("pyspark", ["    ", "   ", "   "], 2, "success", None, None),
         # Whitespace in text - pandas
         ("pandas", ["a b c", "a b ", "a  b"], 3, "success", None, None),
-        # Whitespace in text - pyspark
-        ("pyspark", ["a b c", "a b ", "a  b"], 3, "success", None, None),
         # Whitespace violations - pandas
         (
             "pandas",
@@ -205,23 +123,10 @@ def test_expectation_name():
             [" a ", "a"],
             "Found 2 row(s) where 'col1' length is not greater than 3.",
         ),
-        # Whitespace violations - pyspark
-        (
-            "pyspark",
-            [" a ", "  a  ", "a"],
-            3,
-            "failure",
-            [" a ", "a"],
-            "Found 2 row(s) where 'col1' length is not greater than 3.",
-        ),
         # Special chars success - pandas
         ("pandas", ["@@@@", "!!!!", "####"], 3, "success", None, None),
-        # Special chars success - pyspark
-        ("pyspark", ["@@@@", "!!!!", "####"], 3, "success", None, None),
         # Special chars in text - pandas
         ("pandas", ["test@@", "user!!", "data##"], 5, "success", None, None),
-        # Special chars in text - pyspark
-        ("pyspark", ["test@@", "user!!", "data##"], 5, "success", None, None),
         # Special chars violations - pandas
         (
             "pandas",
@@ -231,23 +136,10 @@ def test_expectation_name():
             ["@", "!!"],
             "Found 2 row(s) where 'col1' length is not greater than 2.",
         ),
-        # Special chars violations - pyspark
-        (
-            "pyspark",
-            ["@", "!!", "###"],
-            2,
-            "failure",
-            ["@", "!!"],
-            "Found 2 row(s) where 'col1' length is not greater than 2.",
-        ),
         # Numbers success - pandas
         ("pandas", ["1234", "5678", "9012"], 3, "success", None, None),
-        # Numbers success - pyspark
-        ("pyspark", ["1234", "5678", "9012"], 3, "success", None, None),
         # Numbers versions - pandas
         ("pandas", ["v1.0.0", "v2.0.0", "v3.0.0"], 5, "success", None, None),
-        # Numbers versions - pyspark
-        ("pyspark", ["v1.0.0", "v2.0.0", "v3.0.0"], 5, "success", None, None),
         # Numbers violations - pandas
         (
             "pandas",
@@ -257,23 +149,10 @@ def test_expectation_name():
             ["1", "12"],
             "Found 2 row(s) where 'col1' length is not greater than 2.",
         ),
-        # Numbers violations - pyspark
-        (
-            "pyspark",
-            ["1", "12", "123"],
-            2,
-            "failure",
-            ["1", "12"],
-            "Found 2 row(s) where 'col1' length is not greater than 2.",
-        ),
         # Length 10 success - pandas
         ("pandas", ["a" * 11, "b" * 12, "c" * 13], 10, "success", None, None),
-        # Length 10 success - pyspark
-        ("pyspark", ["a" * 11, "b" * 12, "c" * 13], 10, "success", None, None),
         # Length 20 success - pandas
         ("pandas", ["a" * 21, "b" * 22, "c" * 23], 20, "success", None, None),
-        # Length 20 success - pyspark
-        ("pyspark", ["a" * 21, "b" * 22, "c" * 23], 20, "success", None, None),
         # Length 10 violation - pandas
         (
             "pandas",
@@ -283,31 +162,11 @@ def test_expectation_name():
             ["a" * 10],
             "Found 1 row(s) where 'col1' length is not greater than 10.",
         ),
-        # Length 10 violation - pyspark
-        (
-            "pyspark",
-            ["a" * 10, "b" * 11, "c" * 12],
-            10,
-            "failure",
-            ["a" * 10],
-            "Found 1 row(s) where 'col1' length is not greater than 10.",
-        ),
         # Long strings success - pandas
         ("pandas", ["a" * 101, "b" * 102, "c" * 103], 100, "success", None, None),
-        # Long strings success - pyspark
-        ("pyspark", ["a" * 101, "b" * 102, "c" * 103], 100, "success", None, None),
         # Long strings violation - pandas
         (
             "pandas",
-            ["a" * 100, "b" * 101, "c" * 102],
-            100,
-            "failure",
-            ["a" * 100],
-            "Found 1 row(s) where 'col1' length is not greater than 100.",
-        ),
-        # Long strings violation - pyspark
-        (
-            "pyspark",
             ["a" * 100, "b" * 101, "c" * 102],
             100,
             "failure",
@@ -323,87 +182,50 @@ def test_expectation_name():
             ["short", "exactly8"],
             "Found 2 row(s) where 'col1' length is not greater than 8.",
         ),
-        # Mixed violations - pyspark
-        (
-            "pyspark",
-            ["short", "exactly8", "much longer string"],
-            8,
-            "failure",
-            ["short", "exactly8"],
-            "Found 2 row(s) where 'col1' length is not greater than 8.",
-        ),
     ],
     ids=[
         "pandas_basic_success",
-        "pyspark_basic_success",
         "pandas_success_length_2",
-        "pyspark_success_length_2",
         "pandas_success_length_4",
-        "pyspark_success_length_4",
         "pandas_basic_violations",
-        "pyspark_basic_violations",
         "pandas_all_violations",
-        "pyspark_all_violations",
         "pandas_mixed_violations",
-        "pyspark_mixed_violations",
         "pandas_boundary_exact_violation",
-        "pyspark_boundary_exact_violation",
         "pandas_boundary_success",
-        "pyspark_boundary_success",
         "pandas_zero_length_success",
-        "pyspark_zero_length_success",
         "pandas_zero_length_violation",
-        "pyspark_zero_length_violation",
         "pandas_single_char_success",
-        "pyspark_single_char_success",
         "pandas_single_char_violations",
-        "pyspark_single_char_violations",
         "pandas_empty_string_violations",
-        "pyspark_empty_string_violations",
         "pandas_whitespace_success",
-        "pyspark_whitespace_success",
         "pandas_whitespace_in_text",
-        "pyspark_whitespace_in_text",
         "pandas_whitespace_violations",
-        "pyspark_whitespace_violations",
         "pandas_special_chars_success",
-        "pyspark_special_chars_success",
         "pandas_special_chars_in_text",
-        "pyspark_special_chars_in_text",
         "pandas_special_chars_violations",
-        "pyspark_special_chars_violations",
         "pandas_numbers_success",
-        "pyspark_numbers_success",
         "pandas_numbers_versions",
-        "pyspark_numbers_versions",
         "pandas_numbers_violations",
-        "pyspark_numbers_violations",
         "pandas_length_10_success",
-        "pyspark_length_10_success",
         "pandas_length_20_success",
-        "pyspark_length_20_success",
         "pandas_length_10_violation",
-        "pyspark_length_10_violation",
         "pandas_long_strings_success",
-        "pyspark_long_strings_success",
         "pandas_long_strings_violation",
-        "pyspark_long_strings_violation",
         "pandas_mixed_short_and_exact",
-        "pyspark_mixed_short_and_exact",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, data, length, expected_result, expected_violations, expected_message, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, data, length, expected_result, expected_violations, expected_message
 ):
     """
-    Test the expectation for various scenarios across pandas and PySpark DataFrames.
+    Test the expectation for various scenarios across pandas DataFrames.
     Tests both direct expectation validation and suite-based validation.
     Covers: success cases, violations, boundary conditions (exact length),
     zero length threshold, single character strings, empty strings,
     whitespace handling, special characters, numbers in strings, long strings,
     and mixed violations (both short and exact length).
     """
-    data_frame = create_dataframe(df_type, data, "col1", spark)
+    data_frame = pd.DataFrame({"col1": data})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -421,7 +243,7 @@ def test_expectation_basic_scenarios(
             )
         ), f"Expected success message but got: {result}"
     else:  # failure
-        expected_violations_df = create_dataframe(df_type, expected_violations, "col1", spark)
+        expected_violations_df = pd.DataFrame({"col1": expected_violations})
         expected_failure_message = DataFrameExpectationFailureMessage(
             expectation_str=str(expectation),
             data_frame_type=str(df_type),
@@ -450,19 +272,252 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
+@pytest.mark.pyspark
 @pytest.mark.parametrize(
-    "df_type",
-    ["pandas", "pyspark"],
-    ids=["pandas", "pyspark"],
+    "df_type, data, length, expected_result, expected_violations, expected_message",
+    [
+        # Basic success - pyspark
+        ("pyspark", ["foobar", "bazz", "hello"], 3, "success", None, None),
+        # Success length 2 - pyspark
+        ("pyspark", ["abc", "abcd", "abcde"], 2, "success", None, None),
+        # Success length 4 - pyspark
+        ("pyspark", ["hello", "world", "testing"], 4, "success", None, None),
+        # Basic violations - pyspark
+        (
+            "pyspark",
+            ["foo", "bar", "bazzz"],
+            3,
+            "failure",
+            ["foo", "bar"],
+            "Found 2 row(s) where 'col1' length is not greater than 3.",
+        ),
+        # All violations - pyspark
+        (
+            "pyspark",
+            ["a", "ab", "abc"],
+            5,
+            "failure",
+            ["a", "ab", "abc"],
+            "Found 3 row(s) where 'col1' length is not greater than 5.",
+        ),
+        # Mixed violations - pyspark
+        (
+            "pyspark",
+            ["test", "testing", "t"],
+            4,
+            "failure",
+            ["test", "t"],
+            "Found 2 row(s) where 'col1' length is not greater than 4.",
+        ),
+        # Boundary exact violation - pyspark
+        (
+            "pyspark",
+            ["abc", "abcd", "abcde"],
+            3,
+            "failure",
+            ["abc"],
+            "Found 1 row(s) where 'col1' length is not greater than 3.",
+        ),
+        # Boundary success - pyspark
+        ("pyspark", ["abcd", "abcde", "abcdef"], 3, "success", None, None),
+        # Zero length success - pyspark
+        ("pyspark", ["a", "ab", "abc"], 0, "success", None, None),
+        # Zero length violation - pyspark
+        (
+            "pyspark",
+            ["", "a", "ab"],
+            0,
+            "failure",
+            [""],
+            "Found 1 row(s) where 'col1' length is not greater than 0.",
+        ),
+        # Single char success - pyspark
+        ("pyspark", ["ab", "abc", "abcd"], 1, "success", None, None),
+        # Single char violations - pyspark
+        (
+            "pyspark",
+            ["a", "b", "cd"],
+            1,
+            "failure",
+            ["a", "b"],
+            "Found 2 row(s) where 'col1' length is not greater than 1.",
+        ),
+        # Empty strings - pyspark
+        (
+            "pyspark",
+            ["", "a", "ab"],
+            1,
+            "failure",
+            ["", "a"],
+            "Found 2 row(s) where 'col1' length is not greater than 1.",
+        ),
+        # Whitespace success - pyspark
+        ("pyspark", ["    ", "   ", "   "], 2, "success", None, None),
+        # Whitespace in text - pyspark
+        ("pyspark", ["a b c", "a b ", "a  b"], 3, "success", None, None),
+        # Whitespace violations - pyspark
+        (
+            "pyspark",
+            [" a ", "  a  ", "a"],
+            3,
+            "failure",
+            [" a ", "a"],
+            "Found 2 row(s) where 'col1' length is not greater than 3.",
+        ),
+        # Special chars success - pyspark
+        ("pyspark", ["@@@@", "!!!!", "####"], 3, "success", None, None),
+        # Special chars in text - pyspark
+        ("pyspark", ["test@@", "user!!", "data##"], 5, "success", None, None),
+        # Special chars violations - pyspark
+        (
+            "pyspark",
+            ["@", "!!", "###"],
+            2,
+            "failure",
+            ["@", "!!"],
+            "Found 2 row(s) where 'col1' length is not greater than 2.",
+        ),
+        # Numbers success - pyspark
+        ("pyspark", ["1234", "5678", "9012"], 3, "success", None, None),
+        # Numbers versions - pyspark
+        ("pyspark", ["v1.0.0", "v2.0.0", "v3.0.0"], 5, "success", None, None),
+        # Numbers violations - pyspark
+        (
+            "pyspark",
+            ["1", "12", "123"],
+            2,
+            "failure",
+            ["1", "12"],
+            "Found 2 row(s) where 'col1' length is not greater than 2.",
+        ),
+        # Length 10 success - pyspark
+        ("pyspark", ["a" * 11, "b" * 12, "c" * 13], 10, "success", None, None),
+        # Length 20 success - pyspark
+        ("pyspark", ["a" * 21, "b" * 22, "c" * 23], 20, "success", None, None),
+        # Length 10 violation - pyspark
+        (
+            "pyspark",
+            ["a" * 10, "b" * 11, "c" * 12],
+            10,
+            "failure",
+            ["a" * 10],
+            "Found 1 row(s) where 'col1' length is not greater than 10.",
+        ),
+        # Long strings success - pyspark
+        ("pyspark", ["a" * 101, "b" * 102, "c" * 103], 100, "success", None, None),
+        # Long strings violation - pyspark
+        (
+            "pyspark",
+            ["a" * 100, "b" * 101, "c" * 102],
+            100,
+            "failure",
+            ["a" * 100],
+            "Found 1 row(s) where 'col1' length is not greater than 100.",
+        ),
+        # Mixed violations - pyspark
+        (
+            "pyspark",
+            ["short", "exactly8", "much longer string"],
+            8,
+            "failure",
+            ["short", "exactly8"],
+            "Found 2 row(s) where 'col1' length is not greater than 8.",
+        ),
+    ],
+    ids=[
+        "pyspark_basic_success",
+        "pyspark_success_length_2",
+        "pyspark_success_length_4",
+        "pyspark_basic_violations",
+        "pyspark_all_violations",
+        "pyspark_mixed_violations",
+        "pyspark_boundary_exact_violation",
+        "pyspark_boundary_success",
+        "pyspark_zero_length_success",
+        "pyspark_zero_length_violation",
+        "pyspark_single_char_success",
+        "pyspark_single_char_violations",
+        "pyspark_empty_string_violations",
+        "pyspark_whitespace_success",
+        "pyspark_whitespace_in_text",
+        "pyspark_whitespace_violations",
+        "pyspark_special_chars_success",
+        "pyspark_special_chars_in_text",
+        "pyspark_special_chars_violations",
+        "pyspark_numbers_success",
+        "pyspark_numbers_versions",
+        "pyspark_numbers_violations",
+        "pyspark_length_10_success",
+        "pyspark_length_20_success",
+        "pyspark_length_10_violation",
+        "pyspark_long_strings_success",
+        "pyspark_long_strings_violation",
+        "pyspark_mixed_short_and_exact",
+    ],
 )
-def test_column_missing_error(df_type, spark):
-    """Test that an error is raised when the specified column is missing in both pandas and PySpark."""
+def test_expectation_basic_scenarios_pyspark(
+    df_type, data, length, expected_result, expected_violations, expected_message, spark
+):
+    """
+    Test the expectation for various scenarios across PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases, violations, boundary conditions (exact length),
+    zero length threshold, single character strings, empty strings,
+    whitespace handling, special characters, numbers in strings, long strings,
+    and mixed violations (both short and exact length).
+    """
+    data_frame = create_pyspark_dataframe(data, "col1", spark)
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationStringLengthGreaterThan",
+        column_name="col1",
+        length=length,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(
+                expectation_name="ExpectationStringLengthGreaterThan"
+            )
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        expected_violations_df = create_pyspark_dataframe(expected_violations, "col1", spark)
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            violations_data_frame=expected_violations_df,
+            message=expected_message,
+            limit_violations=5,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_string_length_greater_than(
+        column_name="col1", length=length
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+def test_column_missing_error_pandas():
+    """Test that an error is raised when the specified column is missing in pandas."""
     expected_message = "Column 'col1' does not exist in the DataFrame."
 
-    if df_type == "pandas":
-        data_frame = pd.DataFrame({"col2": ["foobar", "bazz", "hello"]})
-    else:  # pyspark
-        data_frame = spark.createDataFrame([("foobar",), ("bazz",), ("hello",)], ["col2"])
+    data_frame = pd.DataFrame({"col2": ["foobar", "bazz", "hello"]})
 
     # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -473,7 +528,36 @@ def test_column_missing_error(df_type, spark):
     result = expectation.validate(data_frame=data_frame)
     expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_string_length_greater_than(
+        column_name="col1", length=3
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test that an error is raised when the specified column is missing in PySpark."""
+    expected_message = "Column 'col1' does not exist in the DataFrame."
+
+    data_frame = spark.createDataFrame([("foobar",), ("bazz",), ("hello",)], ["col2"])
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationStringLengthGreaterThan",
+        column_name="col1",
+        length=3,
+    )
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message=expected_message,
     )
     assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"

--- a/tests/expectations/column/string_expectations/test_expect_string_length_less_than.py
+++ b/tests/expectations/column/string_expectations/test_expect_string_length_less_than.py
@@ -7,23 +7,21 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark):
-    """Helper function to create either pandas or PySpark DataFrame."""
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        return spark.createDataFrame([(item,) for item in data], [column_name])
+def create_pyspark_dataframe(data, column_name, spark):
+    """Helper function to create a PySpark DataFrame."""
+    return spark.createDataFrame([(item,) for item in data], [column_name])
 
 
 def test_expectation_name():
+    """Test that the expectation name is correctly returned."""
     expectation = DataFrameExpectationRegistry.get_expectation(
         expectation_name="ExpectationStringLengthLessThan",
         column_name="col1",
@@ -35,208 +33,117 @@ def test_expectation_name():
 
 
 @pytest.mark.parametrize(
-    "df_type,data,length,expected_result,expected_violations",
+    "df_type, data, length, expected_result, expected_violations, expected_message",
     [
         # Basic success - pandas
-        ("pandas", ["foo", "bar", "baz"], 5, "success", None),
-        # Basic success - pyspark
-        ("pyspark", ["foo", "bar", "baz"], 5, "success", None),
+        ("pandas", ["foo", "bar", "baz"], 5, "success", None, None),
         # Success length 2 - pandas
-        ("pandas", ["ab", "cd", "ef"], 3, "success", None),
-        # Success length 2 - pyspark
-        ("pyspark", ["ab", "cd", "ef"], 3, "success", None),
+        ("pandas", ["ab", "cd", "ef"], 3, "success", None, None),
         # Success length 4 - pandas
-        ("pandas", ["abc", "def", "ghi"], 5, "success", None),
-        # Success length 4 - pyspark
-        ("pyspark", ["abc", "def", "ghi"], 5, "success", None),
+        ("pandas", ["abc", "def", "ghi"], 5, "success", None, None),
         # Basic violations - pandas
         (
             "pandas",
             ["foobar", "bar", "bazbaz"],
             5,
-            "violations",
+            "failure",
             ["foobar", "bazbaz"],
-        ),
-        # Basic violations - pyspark
-        (
-            "pyspark",
-            ["foobar", "bar", "bazbaz"],
-            5,
-            "violations",
-            ["foobar", "bazbaz"],
+            "Found 2 row(s) where 'col1' length is not less than 5.",
         ),
         # All violations - pandas
         (
             "pandas",
             ["testing", "longer", "strings"],
             5,
-            "violations",
+            "failure",
             ["testing", "longer", "strings"],
-        ),
-        # All violations - pyspark
-        (
-            "pyspark",
-            ["testing", "longer", "strings"],
-            5,
-            "violations",
-            ["testing", "longer", "strings"],
+            "Found 3 row(s) where 'col1' length is not less than 5.",
         ),
         # Mixed violations - pandas
         (
             "pandas",
             ["ok", "fail", "good"],
             3,
-            "violations",
+            "failure",
             ["fail", "good"],
-        ),
-        # Mixed violations - pyspark
-        (
-            "pyspark",
-            ["ok", "fail", "good"],
-            3,
-            "violations",
-            ["fail", "good"],
+            "Found 2 row(s) where 'col1' length is not less than 3.",
         ),
         # Boundary exact violation - pandas
         (
             "pandas",
             ["test", "exam", "demo"],
             4,
-            "violations",
+            "failure",
             ["test", "exam", "demo"],
-        ),
-        # Boundary exact violation - pyspark
-        (
-            "pyspark",
-            ["test", "exam", "demo"],
-            4,
-            "violations",
-            ["test", "exam", "demo"],
+            "Found 3 row(s) where 'col1' length is not less than 4.",
         ),
         # Boundary success - pandas
-        ("pandas", ["tes", "exa", "dem"], 4, "success", None),
-        # Boundary success - pyspark
-        ("pyspark", ["tes", "exa", "dem"], 4, "success", None),
+        ("pandas", ["tes", "exa", "dem"], 4, "success", None, None),
         # Zero length success - pandas
-        ("pandas", ["", "", ""], 1, "success", None),
-        # Zero length success - pyspark
-        ("pyspark", ["", "", ""], 1, "success", None),
+        ("pandas", ["", "", ""], 1, "success", None, None),
         # Zero length violation - pandas
         (
             "pandas",
             ["a", "b", "c"],
             1,
-            "violations",
+            "failure",
             ["a", "b", "c"],
-        ),
-        # Zero length violation - pyspark
-        (
-            "pyspark",
-            ["a", "b", "c"],
-            1,
-            "violations",
-            ["a", "b", "c"],
+            "Found 3 row(s) where 'col1' length is not less than 1.",
         ),
         # Single char success - pandas
-        ("pandas", ["a", "b", "c"], 2, "success", None),
-        # Single char success - pyspark
-        ("pyspark", ["a", "b", "c"], 2, "success", None),
+        ("pandas", ["a", "b", "c"], 2, "success", None, None),
         # Single char violations - pandas
         (
             "pandas",
             ["a", "b", "c"],
             1,
-            "violations",
+            "failure",
             ["a", "b", "c"],
-        ),
-        # Single char violations - pyspark
-        (
-            "pyspark",
-            ["a", "b", "c"],
-            1,
-            "violations",
-            ["a", "b", "c"],
+            "Found 3 row(s) where 'col1' length is not less than 1.",
         ),
         # Empty strings - pandas
-        ("pandas", ["", "", ""], 5, "success", None),
-        # Empty strings - pyspark
-        ("pyspark", ["", "", ""], 5, "success", None),
+        ("pandas", ["", "", ""], 5, "success", None, None),
         # Whitespace success - pandas
-        ("pandas", ["  ", " ", ""], 3, "success", None),
-        # Whitespace success - pyspark
-        ("pyspark", ["  ", " ", ""], 3, "success", None),
+        ("pandas", ["  ", " ", ""], 3, "success", None, None),
         # Whitespace in text - pandas
-        ("pandas", ["a b", "a", "ab"], 4, "success", None),
-        # Whitespace in text - pyspark
-        ("pyspark", ["a b", "a", "ab"], 4, "success", None),
+        ("pandas", ["a b", "a", "ab"], 4, "success", None, None),
         # Whitespace violations - pandas
         (
             "pandas",
             ["    ", "     ", "      "],
             3,
-            "violations",
+            "failure",
             ["    ", "     ", "      "],
-        ),
-        # Whitespace violations - pyspark
-        (
-            "pyspark",
-            ["    ", "     ", "      "],
-            3,
-            "violations",
-            ["    ", "     ", "      "],
+            "Found 3 row(s) where 'col1' length is not less than 3.",
         ),
         # Special chars success - pandas
-        ("pandas", ["@#$", "!^&", "*()"], 4, "success", None),
-        # Special chars success - pyspark
-        ("pyspark", ["@#$", "!^&", "*()"], 4, "success", None),
+        ("pandas", ["@#$", "!^&", "*()"], 4, "success", None, None),
         # Special chars in text - pandas
-        ("pandas", ["test@", "ex!m", "de#o"], 6, "success", None),
-        # Special chars in text - pyspark
-        ("pyspark", ["test@", "ex!m", "de#o"], 6, "success", None),
+        ("pandas", ["test@", "ex!m", "de#o"], 6, "success", None, None),
         # Special chars violations - pandas
         (
             "pandas",
             ["@#$%^", "&*()_", "+=-[]"],
             4,
-            "violations",
+            "failure",
             ["@#$%^", "&*()_", "+=-[]"],
-        ),
-        # Special chars violations - pyspark
-        (
-            "pyspark",
-            ["@#$%^", "&*()_", "+=-[]"],
-            4,
-            "violations",
-            ["@#$%^", "&*()_", "+=-[]"],
+            "Found 3 row(s) where 'col1' length is not less than 4.",
         ),
         # Numbers success - pandas
-        ("pandas", ["123", "456", "789"], 4, "success", None),
-        # Numbers success - pyspark
-        ("pyspark", ["123", "456", "789"], 4, "success", None),
+        ("pandas", ["123", "456", "789"], 4, "success", None, None),
         # Numbers versions - pandas
-        ("pandas", ["v1.0", "v2.1", "v3.5"], 5, "success", None),
-        # Numbers versions - pyspark
-        ("pyspark", ["v1.0", "v2.1", "v3.5"], 5, "success", None),
+        ("pandas", ["v1.0", "v2.1", "v3.5"], 5, "success", None, None),
         # Numbers violations - pandas
         (
             "pandas",
             ["12345", "67890", "11111"],
             4,
-            "violations",
+            "failure",
             ["12345", "67890", "11111"],
-        ),
-        # Numbers violations - pyspark
-        (
-            "pyspark",
-            ["12345", "67890", "11111"],
-            4,
-            "violations",
-            ["12345", "67890", "11111"],
+            "Found 3 row(s) where 'col1' length is not less than 4.",
         ),
         # Length 10 success - pandas
-        ("pandas", ["a" * 9, "b" * 8, "c" * 7], 11, "success", None),
-        # Length 10 success - pyspark
-        ("pyspark", ["a" * 9, "b" * 8, "c" * 7], 11, "success", None),
+        ("pandas", ["a" * 9, "b" * 8, "c" * 7], 11, "success", None, None),
         # Length 20 success - pandas
         (
             "pandas",
@@ -244,13 +151,6 @@ def test_expectation_name():
             21,
             "success",
             None,
-        ),
-        # Length 20 success - pyspark
-        (
-            "pyspark",
-            ["test " * 3, "demo " * 3, "exam " * 3],
-            21,
-            "success",
             None,
         ),
         # Length 10 violation - pandas
@@ -258,16 +158,9 @@ def test_expectation_name():
             "pandas",
             ["x" * 11, "y" * 12, "z" * 13],
             10,
-            "violations",
+            "failure",
             ["x" * 11, "y" * 12, "z" * 13],
-        ),
-        # Length 10 violation - pyspark
-        (
-            "pyspark",
-            ["x" * 11, "y" * 12, "z" * 13],
-            10,
-            "violations",
-            ["x" * 11, "y" * 12, "z" * 13],
+            "Found 3 row(s) where 'col1' length is not less than 10.",
         ),
         # Long strings success - pandas
         (
@@ -276,6 +169,244 @@ def test_expectation_name():
             101,
             "success",
             None,
+            None,
+        ),
+        # Long strings violation - pandas
+        (
+            "pandas",
+            ["x" * 101, "y" * 102, "z" * 103],
+            100,
+            "failure",
+            ["x" * 101, "y" * 102, "z" * 103],
+            "Found 3 row(s) where 'col1' length is not less than 100.",
+        ),
+        # Mixed violations - pandas
+        (
+            "pandas",
+            ["ab", "abcd", "abc"],
+            4,
+            "failure",
+            ["abcd"],
+            "Found 1 row(s) where 'col1' length is not less than 4.",
+        ),
+    ],
+    ids=[
+        "pandas_basic_success",
+        "pandas_success_length_2",
+        "pandas_success_length_4",
+        "pandas_basic_violations",
+        "pandas_all_violations",
+        "pandas_mixed_violations",
+        "pandas_boundary_exact_violation",
+        "pandas_boundary_success",
+        "pandas_zero_length_success",
+        "pandas_zero_length_violation",
+        "pandas_single_char_success",
+        "pandas_single_char_violations",
+        "pandas_empty_string_success",
+        "pandas_whitespace_success",
+        "pandas_whitespace_in_text",
+        "pandas_whitespace_violations",
+        "pandas_special_chars_success",
+        "pandas_special_chars_in_text",
+        "pandas_special_chars_violations",
+        "pandas_numbers_success",
+        "pandas_numbers_versions",
+        "pandas_numbers_violations",
+        "pandas_length_10_success",
+        "pandas_length_20_success",
+        "pandas_length_10_violation",
+        "pandas_long_strings_success",
+        "pandas_long_strings_violation",
+        "pandas_mixed_short_and_exact",
+    ],
+)
+def test_expectation_basic_scenarios_pandas(
+    df_type, data, length, expected_result, expected_violations, expected_message
+):
+    """
+    Test the expectation for various scenarios across pandas DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases, violations, boundary conditions (exact length),
+    zero length threshold, single character strings, empty strings,
+    whitespace handling, special characters, numbers in strings, long strings,
+    and mixed violations (both short and exact length).
+    """
+    data_frame = pd.DataFrame({"col1": data})
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationStringLengthLessThan",
+        column_name="col1",
+        length=length,
+    )
+
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationStringLengthLessThan")
+        ), f"Expected success message but got: {result}"
+    else:  # failure
+        expected_violations_df = pd.DataFrame({"col1": expected_violations})
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            violations_data_frame=expected_violations_df,
+            message=expected_message,
+            limit_violations=5,
+        )
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
+        )
+
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_string_length_less_than(
+        column_name="col1", length=length
+    )
+
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+@pytest.mark.parametrize(
+    "df_type, data, length, expected_result, expected_violations, expected_message",
+    [
+        # Basic success - pyspark
+        ("pyspark", ["foo", "bar", "baz"], 5, "success", None, None),
+        # Success length 2 - pyspark
+        ("pyspark", ["ab", "cd", "ef"], 3, "success", None, None),
+        # Success length 4 - pyspark
+        ("pyspark", ["abc", "def", "ghi"], 5, "success", None, None),
+        # Basic violations - pyspark
+        (
+            "pyspark",
+            ["foobar", "bar", "bazbaz"],
+            5,
+            "failure",
+            ["foobar", "bazbaz"],
+            "Found 2 row(s) where 'col1' length is not less than 5.",
+        ),
+        # All violations - pyspark
+        (
+            "pyspark",
+            ["testing", "longer", "strings"],
+            5,
+            "failure",
+            ["testing", "longer", "strings"],
+            "Found 3 row(s) where 'col1' length is not less than 5.",
+        ),
+        # Mixed violations - pyspark
+        (
+            "pyspark",
+            ["ok", "fail", "good"],
+            3,
+            "failure",
+            ["fail", "good"],
+            "Found 2 row(s) where 'col1' length is not less than 3.",
+        ),
+        # Boundary exact violation - pyspark
+        (
+            "pyspark",
+            ["test", "exam", "demo"],
+            4,
+            "failure",
+            ["test", "exam", "demo"],
+            "Found 3 row(s) where 'col1' length is not less than 4.",
+        ),
+        # Boundary success - pyspark
+        ("pyspark", ["tes", "exa", "dem"], 4, "success", None, None),
+        # Zero length success - pyspark
+        ("pyspark", ["", "", ""], 1, "success", None, None),
+        # Zero length violation - pyspark
+        (
+            "pyspark",
+            ["a", "b", "c"],
+            1,
+            "failure",
+            ["a", "b", "c"],
+            "Found 3 row(s) where 'col1' length is not less than 1.",
+        ),
+        # Single char success - pyspark
+        ("pyspark", ["a", "b", "c"], 2, "success", None, None),
+        # Single char violations - pyspark
+        (
+            "pyspark",
+            ["a", "b", "c"],
+            1,
+            "failure",
+            ["a", "b", "c"],
+            "Found 3 row(s) where 'col1' length is not less than 1.",
+        ),
+        # Empty strings - pyspark
+        ("pyspark", ["", "", ""], 5, "success", None, None),
+        # Whitespace success - pyspark
+        ("pyspark", ["  ", " ", ""], 3, "success", None, None),
+        # Whitespace in text - pyspark
+        ("pyspark", ["a b", "a", "ab"], 4, "success", None, None),
+        # Whitespace violations - pyspark
+        (
+            "pyspark",
+            ["    ", "     ", "      "],
+            3,
+            "failure",
+            ["    ", "     ", "      "],
+            "Found 3 row(s) where 'col1' length is not less than 3.",
+        ),
+        # Special chars success - pyspark
+        ("pyspark", ["@#$", "!^&", "*()"], 4, "success", None, None),
+        # Special chars in text - pyspark
+        ("pyspark", ["test@", "ex!m", "de#o"], 6, "success", None, None),
+        # Special chars violations - pyspark
+        (
+            "pyspark",
+            ["@#$%^", "&*()_", "+=-[]"],
+            4,
+            "failure",
+            ["@#$%^", "&*()_", "+=-[]"],
+            "Found 3 row(s) where 'col1' length is not less than 4.",
+        ),
+        # Numbers success - pyspark
+        ("pyspark", ["123", "456", "789"], 4, "success", None, None),
+        # Numbers versions - pyspark
+        ("pyspark", ["v1.0", "v2.1", "v3.5"], 5, "success", None, None),
+        # Numbers violations - pyspark
+        (
+            "pyspark",
+            ["12345", "67890", "11111"],
+            4,
+            "failure",
+            ["12345", "67890", "11111"],
+            "Found 3 row(s) where 'col1' length is not less than 4.",
+        ),
+        # Length 10 success - pyspark
+        ("pyspark", ["a" * 9, "b" * 8, "c" * 7], 11, "success", None, None),
+        # Length 20 success - pyspark
+        (
+            "pyspark",
+            ["test " * 3, "demo " * 3, "exam " * 3],
+            21,
+            "success",
+            None,
+            None,
+        ),
+        # Length 10 violation - pyspark
+        (
+            "pyspark",
+            ["x" * 11, "y" * 12, "z" * 13],
+            10,
+            "failure",
+            ["x" * 11, "y" * 12, "z" * 13],
+            "Found 3 row(s) where 'col1' length is not less than 10.",
         ),
         # Long strings success - pyspark
         (
@@ -284,173 +415,164 @@ def test_expectation_name():
             101,
             "success",
             None,
-        ),
-        # Long strings violation - pandas
-        (
-            "pandas",
-            ["x" * 101, "y" * 102, "z" * 103],
-            100,
-            "violations",
-            ["x" * 101, "y" * 102, "z" * 103],
+            None,
         ),
         # Long strings violation - pyspark
         (
             "pyspark",
             ["x" * 101, "y" * 102, "z" * 103],
             100,
-            "violations",
+            "failure",
             ["x" * 101, "y" * 102, "z" * 103],
-        ),
-        # Mixed violations - pandas
-        (
-            "pandas",
-            ["ab", "abcd", "abc"],
-            4,
-            "violations",
-            ["abcd"],
+            "Found 3 row(s) where 'col1' length is not less than 100.",
         ),
         # Mixed violations - pyspark
         (
             "pyspark",
             ["ab", "abcd", "abc"],
             4,
-            "violations",
+            "failure",
             ["abcd"],
+            "Found 1 row(s) where 'col1' length is not less than 4.",
         ),
     ],
     ids=[
-        "pandas_basic_success",
         "pyspark_basic_success",
-        "pandas_success_length_2",
         "pyspark_success_length_2",
-        "pandas_success_length_4",
         "pyspark_success_length_4",
-        "pandas_basic_violations",
         "pyspark_basic_violations",
-        "pandas_all_violations",
         "pyspark_all_violations",
-        "pandas_mixed_violations",
         "pyspark_mixed_violations",
-        "pandas_boundary_exact_violation",
         "pyspark_boundary_exact_violation",
-        "pandas_boundary_success",
         "pyspark_boundary_success",
-        "pandas_zero_length_success",
         "pyspark_zero_length_success",
-        "pandas_zero_length_violation",
         "pyspark_zero_length_violation",
-        "pandas_single_char_success",
         "pyspark_single_char_success",
-        "pandas_single_char_violations",
         "pyspark_single_char_violations",
-        "pandas_empty_string_success",
         "pyspark_empty_string_success",
-        "pandas_whitespace_success",
         "pyspark_whitespace_success",
-        "pandas_whitespace_in_text",
         "pyspark_whitespace_in_text",
-        "pandas_whitespace_violations",
         "pyspark_whitespace_violations",
-        "pandas_special_chars_success",
         "pyspark_special_chars_success",
-        "pandas_special_chars_in_text",
         "pyspark_special_chars_in_text",
-        "pandas_special_chars_violations",
         "pyspark_special_chars_violations",
-        "pandas_numbers_success",
         "pyspark_numbers_success",
-        "pandas_numbers_versions",
         "pyspark_numbers_versions",
-        "pandas_numbers_violations",
         "pyspark_numbers_violations",
-        "pandas_length_10_success",
         "pyspark_length_10_success",
-        "pandas_length_20_success",
         "pyspark_length_20_success",
-        "pandas_length_10_violation",
         "pyspark_length_10_violation",
-        "pandas_long_strings_success",
         "pyspark_long_strings_success",
-        "pandas_long_strings_violation",
         "pyspark_long_strings_violation",
-        "pandas_mixed_short_and_exact",
         "pyspark_mixed_short_and_exact",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, data, length, expected_result, expected_violations, spark
+def test_expectation_basic_scenarios_pyspark(
+    df_type, data, length, expected_result, expected_violations, expected_message, spark
 ):
-    """Test various scenarios for ExpectationStringLengthLessThan expectation."""
+    """
+    Test the expectation for various scenarios across PySpark DataFrames.
+    Tests both direct expectation validation and suite-based validation.
+    Covers: success cases, violations, boundary conditions (exact length),
+    zero length threshold, single character strings, empty strings,
+    whitespace handling, special characters, numbers in strings, long strings,
+    and mixed violations (both short and exact length).
+    """
+    data_frame = create_pyspark_dataframe(data, "col1", spark)
+
+    # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
         expectation_name="ExpectationStringLengthLessThan",
         column_name="col1",
         length=length,
     )
 
-    data_frame = create_dataframe(df_type, data, "col1", spark)
     result = expectation.validate(data_frame=data_frame)
 
     if expected_result == "success":
         assert str(result) == str(
             DataFrameExpectationSuccessMessage(expectation_name="ExpectationStringLengthLessThan")
         ), f"Expected success message but got: {result}"
-
-        # Also test with suite
-        expectations_suite = DataFrameExpectationsSuite().expect_string_length_less_than(
-            column_name="col1", length=length
+    else:  # failure
+        expected_violations_df = create_pyspark_dataframe(expected_violations, "col1", spark)
+        expected_failure_message = DataFrameExpectationFailureMessage(
+            expectation_str=str(expectation),
+            data_frame_type=str(df_type),
+            violations_data_frame=expected_violations_df,
+            message=expected_message,
+            limit_violations=5,
         )
-        suite_result = expectations_suite.build().run(data_frame=data_frame)
-        assert suite_result is not None, "Expected SuiteExecutionResult"
-        assert isinstance(suite_result, SuiteExecutionResult), (
-            "Result should be SuiteExecutionResult"
+        assert str(result) == str(expected_failure_message), (
+            f"Expected failure message but got: {result}"
         )
-        assert suite_result.success, "Expected all expectations to pass"
-        assert suite_result.total_passed == 1, "Expected 1 passed expectation"
-        assert suite_result.total_failed == 0, "Expected 0 failed expectations"
-    else:  # violations
-        violations_df = create_dataframe(df_type, expected_violations, "col1", spark)
-        expected_message = f"Found {len(expected_violations)} row(s) where 'col1' length is not less than {length}."
 
-        assert str(result) == str(
-            DataFrameExpectationFailureMessage(
-                expectation_str=str(expectation),
-                data_frame_type=str(df_type),
-                violations_data_frame=violations_df,
-                message=expected_message,
-                limit_violations=5,
-            )
-        ), f"Expected failure message but got: {result}"
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_string_length_less_than(
+        column_name="col1", length=length
+    )
 
-        # Also test with suite
-        expectations_suite = DataFrameExpectationsSuite().expect_string_length_less_than(
-            column_name="col1", length=length
-        )
+    if expected_result == "success":
+        result = expectations_suite.build().run(data_frame=data_frame)
+        assert result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(result, SuiteExecutionResult), "Result should be SuiteExecutionResult"
+        assert result.success, "Expected all expectations to pass"
+        assert result.total_passed == 1, "Expected 1 passed expectation"
+        assert result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # failure
         with pytest.raises(DataFrameExpectationsSuiteFailure):
             expectations_suite.build().run(data_frame=data_frame)
 
 
-@pytest.mark.parametrize("df_type", ["pandas", "pyspark"])
-def test_column_missing_error(df_type, spark):
-    """Test that missing column raises appropriate error."""
+def test_column_missing_error_pandas():
+    """Test that missing column raises appropriate error in pandas."""
+    expected_message = "Column 'col1' does not exist in the DataFrame."
+
+    data_frame = pd.DataFrame({"col2": ["foo", "bar", "baz"]})
+
+    # Test 1: Direct expectation validation
     expectation = DataFrameExpectationRegistry.get_expectation(
         expectation_name="ExpectationStringLengthLessThan",
         column_name="col1",
         length=5,
     )
-
-    data_frame = create_dataframe(df_type, ["foo", "bar", "baz"], "col2", spark)
     result = expectation.validate(data_frame=data_frame)
-
-    expected_failure_message = DataFrameExpectationFailureMessage(
+    expected_failure = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
-        message="Column 'col1' does not exist in the DataFrame.",
+        data_frame_type="pandas",
+        message=expected_message,
     )
-    assert str(result) == str(expected_failure_message), (
-        f"Expected failure message but got: {result}"
-    )
+    assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
 
-    # Also test with suite
+    # Test 2: Suite-based validation
+    expectations_suite = DataFrameExpectationsSuite().expect_string_length_less_than(
+        column_name="col1", length=5
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test that missing column raises appropriate error in PySpark."""
+    expected_message = "Column 'col1' does not exist in the DataFrame."
+
+    data_frame = spark.createDataFrame([("foo",), ("bar",), ("baz",)], ["col2"])
+
+    # Test 1: Direct expectation validation
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationStringLengthLessThan",
+        column_name="col1",
+        length=5,
+    )
+    result = expectation.validate(data_frame=data_frame)
+    expected_failure = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
+        message=expected_message,
+    )
+    assert str(result) == str(expected_failure), f"Expected failure message but got: {result}"
+
+    # Test 2: Suite-based validation
     expectations_suite = DataFrameExpectationsSuite().expect_string_length_less_than(
         column_name="col1", length=5
     )

--- a/tests/expectations/column/string_expectations/test_expect_string_not_contains.py
+++ b/tests/expectations/column/string_expectations/test_expect_string_not_contains.py
@@ -7,20 +7,17 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark):
-    """Helper function to create either pandas or PySpark DataFrame."""
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        return spark.createDataFrame([(item,) for item in data], [column_name])
+def create_pyspark_dataframe(data, column_name, spark):
+    """Helper function to create a PySpark DataFrame."""
+    return spark.createDataFrame([(item,) for item in data], [column_name])
 
 
 def test_expectation_name():
@@ -39,44 +36,12 @@ def test_expectation_name():
     [
         # Basic success - pandas
         ("pandas", ["bar", "baz", "qux"], "foo", "success", None),
-        # Basic success - pyspark
-        ("pyspark", ["bar", "baz", "qux"], "foo", "success", None),
         # Success no match - pandas
         ("pandas", ["test", "demo", "exam"], "xyz", "success", None),
-        # Success no match - pyspark
-        ("pyspark", ["test", "demo", "exam"], "xyz", "success", None),
         # Success different substring - pandas
-        (
-            "pandas",
-            ["hello", "world", "python"],
-            "java",
-            "success",
-            None,
-        ),
-        # Success different substring - pyspark
-        (
-            "pyspark",
-            ["hello", "world", "python"],
-            "java",
-            "success",
-            None,
-        ),
+        ("pandas", ["hello", "world", "python"], "java", "success", None),
         # Basic violations - pandas
-        (
-            "pandas",
-            ["foobar", "bar", "foo"],
-            "foo",
-            "violations",
-            ["foobar", "foo"],
-        ),
-        # Basic violations - pyspark
-        (
-            "pyspark",
-            ["foobar", "bar", "foo"],
-            "foo",
-            "violations",
-            ["foobar", "foo"],
-        ),
+        ("pandas", ["foobar", "bar", "foo"], "foo", "violations", ["foobar", "foo"]),
         # All violations - pandas
         (
             "pandas",
@@ -85,30 +50,8 @@ def test_expectation_name():
             "violations",
             ["testing", "test", "attest"],
         ),
-        # All violations - pyspark
-        (
-            "pyspark",
-            ["testing", "test", "attest"],
-            "test",
-            "violations",
-            ["testing", "test", "attest"],
-        ),
         # Mixed violations - pandas
-        (
-            "pandas",
-            ["good", "bad", "badge"],
-            "bad",
-            "violations",
-            ["bad", "badge"],
-        ),
-        # Mixed violations - pyspark
-        (
-            "pyspark",
-            ["good", "bad", "badge"],
-            "bad",
-            "violations",
-            ["bad", "badge"],
-        ),
+        ("pandas", ["good", "bad", "badge"], "bad", "violations", ["bad", "badge"]),
         # Substring at beginning - pandas
         (
             "pandas",
@@ -117,30 +60,8 @@ def test_expectation_name():
             "violations",
             ["prefix_test", "prefix_demo"],
         ),
-        # Substring at beginning - pyspark
-        (
-            "pyspark",
-            ["prefix_test", "prefix_demo", "other"],
-            "prefix",
-            "violations",
-            ["prefix_test", "prefix_demo"],
-        ),
         # No substring at beginning - pandas
-        (
-            "pandas",
-            ["no_match", "also_no", "nope"],
-            "prefix",
-            "success",
-            None,
-        ),
-        # No substring at beginning - pyspark
-        (
-            "pyspark",
-            ["no_match", "also_no", "nope"],
-            "prefix",
-            "success",
-            None,
-        ),
+        ("pandas", ["no_match", "also_no", "nope"], "prefix", "success", None),
         # Substring at end - pandas
         (
             "pandas",
@@ -149,30 +70,8 @@ def test_expectation_name():
             "violations",
             ["test_suffix", "demo_suffix"],
         ),
-        # Substring at end - pyspark
-        (
-            "pyspark",
-            ["test_suffix", "demo_suffix", "other"],
-            "suffix",
-            "violations",
-            ["test_suffix", "demo_suffix"],
-        ),
         # No substring at end - pandas
-        (
-            "pandas",
-            ["no_match", "also_no", "nope"],
-            "suffix",
-            "success",
-            None,
-        ),
-        # No substring at end - pyspark
-        (
-            "pyspark",
-            ["no_match", "also_no", "nope"],
-            "suffix",
-            "success",
-            None,
-        ),
+        ("pandas", ["no_match", "also_no", "nope"], "suffix", "success", None),
         # Substring in middle - pandas
         (
             "pandas",
@@ -181,91 +80,21 @@ def test_expectation_name():
             "violations",
             ["pre_mid_post", "another_mid_test"],
         ),
-        # Substring in middle - pyspark
-        (
-            "pyspark",
-            ["pre_mid_post", "another_mid_test", "nomatch"],
-            "mid",
-            "violations",
-            ["pre_mid_post", "another_mid_test"],
-        ),
         # No substring in middle - pandas
-        (
-            "pandas",
-            ["no_match", "also_no", "nope"],
-            "mid",
-            "success",
-            None,
-        ),
-        # No substring in middle - pyspark
-        (
-            "pyspark",
-            ["no_match", "also_no", "nope"],
-            "mid",
-            "success",
-            None,
-        ),
+        ("pandas", ["no_match", "also_no", "nope"], "mid", "success", None),
         # Case sensitive success - pandas
         ("pandas", ["FOO", "Foo", "fOo"], "foo", "success", None),
-        # Case sensitive success - pyspark
-        (
-            "pyspark",
-            ["FOO", "Foo", "fOo"],
-            "foo",
-            "success",
-            None,
-        ),
         # Case sensitive violations - pandas
-        (
-            "pandas",
-            ["foo", "FOO", "test"],
-            "FOO",
-            "violations",
-            ["FOO"],
-        ),
-        # Case sensitive violations - pyspark
-        (
-            "pyspark",
-            ["foo", "FOO", "test"],
-            "FOO",
-            "violations",
-            ["FOO"],
-        ),
+        ("pandas", ["foo", "FOO", "test"], "FOO", "violations", ["FOO"]),
         # Empty string success - pandas
         ("pandas", ["", "", ""], "foo", "success", None),
-        # Empty string success - pyspark
-        ("pyspark", ["", "", ""], "foo", "success", None),
         # Empty string with violation - pandas
-        (
-            "pandas",
-            ["", "foo", ""],
-            "foo",
-            "violations",
-            ["foo"],
-        ),
-        # Empty string with violation - pyspark
-        (
-            "pyspark",
-            ["", "foo", ""],
-            "foo",
-            "violations",
-            ["foo"],
-        ),
+        ("pandas", ["", "foo", ""], "foo", "violations", ["foo"]),
         # Whitespace only success - pandas
         ("pandas", ["   ", "  ", " "], "test", "success", None),
-        # Whitespace only success - pyspark
-        ("pyspark", ["   ", "  ", " "], "test", "success", None),
         # Whitespace in text violations - pandas
         (
             "pandas",
-            ["test with spaces", "test", "no match"],
-            "test",
-            "violations",
-            ["test with spaces", "test"],
-        ),
-        # Whitespace in text violations - pyspark
-        (
-            "pyspark",
             ["test with spaces", "test", "no match"],
             "test",
             "violations",
@@ -279,14 +108,6 @@ def test_expectation_name():
             "violations",
             ["   test   ", "test"],
         ),
-        # Whitespace around violations - pyspark
-        (
-            "pyspark",
-            ["   test   ", "test", "clean"],
-            "test",
-            "violations",
-            ["   test   ", "test"],
-        ),
         # Special char at violations - pandas
         (
             "pandas",
@@ -295,41 +116,11 @@ def test_expectation_name():
             "violations",
             ["test@email", "user@domain"],
         ),
-        # Special char at violations - pyspark
-        (
-            "pyspark",
-            ["test@email", "user@domain", "plain"],
-            "@",
-            "violations",
-            ["test@email", "user@domain"],
-        ),
         # Special char at success - pandas
-        (
-            "pandas",
-            ["no-match", "also-no", "nope"],
-            "@",
-            "success",
-            None,
-        ),
-        # Special char at success - pyspark
-        (
-            "pyspark",
-            ["no-match", "also-no", "nope"],
-            "@",
-            "success",
-            None,
-        ),
+        ("pandas", ["no-match", "also-no", "nope"], "@", "success", None),
         # Special char hash violations - pandas
         (
             "pandas",
-            ["test#tag", "demo#hash", "plain"],
-            "#",
-            "violations",
-            ["test#tag", "demo#hash"],
-        ),
-        # Special char hash violations - pyspark
-        (
-            "pyspark",
             ["test#tag", "demo#hash", "plain"],
             "#",
             "violations",
@@ -343,58 +134,16 @@ def test_expectation_name():
             "violations",
             ["version123"],
         ),
-        # Numbers violations - pyspark
-        (
-            "pyspark",
-            ["version123", "test456", "plain"],
-            "123",
-            "violations",
-            ["version123"],
-        ),
         # Numbers no match - pandas
         ("pandas", ["v1.0", "v2.1", "v3.5"], "123", "success", None),
-        # Numbers no match - pyspark
-        ("pyspark", ["v1.0", "v2.1", "v3.5"], "123", "success", None),
         # Numbers exact match - pandas
-        (
-            "pandas",
-            ["test", "demo", "123"],
-            "123",
-            "violations",
-            ["123"],
-        ),
-        # Numbers exact match - pyspark
-        (
-            "pyspark",
-            ["test", "demo", "123"],
-            "123",
-            "violations",
-            ["123"],
-        ),
+        ("pandas", ["test", "demo", "123"], "123", "violations", ["123"]),
         # Single char success - pandas
         ("pandas", ["a", "b", "c"], "x", "success", None),
-        # Single char success - pyspark
-        ("pyspark", ["a", "b", "c"], "x", "success", None),
         # Single char violation - pandas
         ("pandas", ["a", "b", "c"], "a", "violations", ["a"]),
-        # Single char violation - pyspark
-        ("pyspark", ["a", "b", "c"], "a", "violations", ["a"]),
         # Long string success - pandas
-        (
-            "pandas",
-            ["a" * 100, "b" * 100, "c" * 100],
-            "x",
-            "success",
-            None,
-        ),
-        # Long string success - pyspark
-        (
-            "pyspark",
-            ["a" * 100, "b" * 100, "c" * 100],
-            "x",
-            "success",
-            None,
-        ),
+        ("pandas", ["a" * 100, "b" * 100, "c" * 100], "x", "success", None),
         # Long string with substring - pandas
         (
             "pandas",
@@ -403,96 +152,47 @@ def test_expectation_name():
             "violations",
             ["a" * 50 + "test" + "b" * 50],
         ),
-        # Long string with substring - pyspark
-        (
-            "pyspark",
-            ["a" * 50 + "test" + "b" * 50, "clean" * 20, "other"],
-            "test",
-            "violations",
-            ["a" * 50 + "test" + "b" * 50],
-        ),
         # Exact match - pandas
         ("pandas", ["test", "demo", "exam"], "test", "violations", ["test"]),
-        # Exact match - pyspark
-        (
-            "pyspark",
-            ["test", "demo", "exam"],
-            "test",
-            "violations",
-            ["test"],
-        ),
         # No exact match - pandas
         ("pandas", ["test", "demo", "exam"], "testing", "success", None),
-        # No exact match - pyspark
-        ("pyspark", ["test", "demo", "exam"], "testing", "success", None),
     ],
     ids=[
         "pandas_basic_success",
-        "pyspark_basic_success",
         "pandas_success_no_match",
-        "pyspark_success_no_match",
         "pandas_success_different_substring",
-        "pyspark_success_different_substring",
         "pandas_basic_violations",
-        "pyspark_basic_violations",
         "pandas_all_violations",
-        "pyspark_all_violations",
         "pandas_mixed_violations",
-        "pyspark_mixed_violations",
         "pandas_substring_at_beginning",
-        "pyspark_substring_at_beginning",
         "pandas_no_substring_at_beginning",
-        "pyspark_no_substring_at_beginning",
         "pandas_substring_at_end",
-        "pyspark_substring_at_end",
         "pandas_no_substring_at_end",
-        "pyspark_no_substring_at_end",
         "pandas_substring_in_middle",
-        "pyspark_substring_in_middle",
         "pandas_no_substring_in_middle",
-        "pyspark_no_substring_in_middle",
         "pandas_case_sensitive_success",
-        "pyspark_case_sensitive_success",
         "pandas_case_sensitive_violations",
-        "pyspark_case_sensitive_violations",
         "pandas_empty_string_success",
-        "pyspark_empty_string_success",
         "pandas_empty_string_with_violation",
-        "pyspark_empty_string_with_violation",
         "pandas_whitespace_only_success",
-        "pyspark_whitespace_only_success",
         "pandas_whitespace_in_text_violations",
-        "pyspark_whitespace_in_text_violations",
         "pandas_whitespace_around_violations",
-        "pyspark_whitespace_around_violations",
         "pandas_special_char_at_violations",
-        "pyspark_special_char_at_violations",
         "pandas_special_char_at_success",
-        "pyspark_special_char_at_success",
         "pandas_special_char_hash_violations",
-        "pyspark_special_char_hash_violations",
         "pandas_numbers_violations",
-        "pyspark_numbers_violations",
         "pandas_numbers_no_match",
-        "pyspark_numbers_no_match",
         "pandas_numbers_exact_match",
-        "pyspark_numbers_exact_match",
         "pandas_single_char_success",
-        "pyspark_single_char_success",
         "pandas_single_char_violation",
-        "pyspark_single_char_violation",
         "pandas_long_string_success",
-        "pyspark_long_string_success",
         "pandas_long_string_with_substring",
-        "pyspark_long_string_with_substring",
         "pandas_exact_match",
-        "pyspark_exact_match",
         "pandas_no_exact_match",
-        "pyspark_no_exact_match",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, data, substring, expected_result, expected_violations, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, data, substring, expected_result, expected_violations
 ):
     """Test various scenarios for ExpectationStringNotContains expectation."""
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -501,7 +201,7 @@ def test_expectation_basic_scenarios(
         substring=substring,
     )
 
-    data_frame = create_dataframe(df_type, data, "col1", spark)
+    data_frame = pd.DataFrame({"col1": data})
     result = expectation.validate(data_frame=data_frame)
 
     if expected_result == "success":
@@ -522,7 +222,7 @@ def test_expectation_basic_scenarios(
         assert suite_result.total_passed == 1, "Expected 1 passed expectation"
         assert suite_result.total_failed == 0, "Expected 0 failed expectations"
     else:  # violations
-        violations_df = create_dataframe(df_type, expected_violations, "col1", spark)
+        violations_df = pd.DataFrame({"col1": expected_violations})
         expected_message = (
             f"Found {len(expected_violations)} row(s) where 'col1' contains '{substring}'."
         )
@@ -545,21 +245,264 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
-@pytest.mark.parametrize("df_type", ["pandas", "pyspark"])
-def test_column_missing_error(df_type, spark):
-    """Test that missing column raises appropriate error."""
+@pytest.mark.pyspark
+@pytest.mark.parametrize(
+    "df_type, data, substring, expected_result, expected_violations",
+    [
+        # Basic success - pyspark
+        ("pyspark", ["bar", "baz", "qux"], "foo", "success", None),
+        # Success no match - pyspark
+        ("pyspark", ["test", "demo", "exam"], "xyz", "success", None),
+        # Success different substring - pyspark
+        ("pyspark", ["hello", "world", "python"], "java", "success", None),
+        # Basic violations - pyspark
+        ("pyspark", ["foobar", "bar", "foo"], "foo", "violations", ["foobar", "foo"]),
+        # All violations - pyspark
+        (
+            "pyspark",
+            ["testing", "test", "attest"],
+            "test",
+            "violations",
+            ["testing", "test", "attest"],
+        ),
+        # Mixed violations - pyspark
+        ("pyspark", ["good", "bad", "badge"], "bad", "violations", ["bad", "badge"]),
+        # Substring at beginning - pyspark
+        (
+            "pyspark",
+            ["prefix_test", "prefix_demo", "other"],
+            "prefix",
+            "violations",
+            ["prefix_test", "prefix_demo"],
+        ),
+        # No substring at beginning - pyspark
+        ("pyspark", ["no_match", "also_no", "nope"], "prefix", "success", None),
+        # Substring at end - pyspark
+        (
+            "pyspark",
+            ["test_suffix", "demo_suffix", "other"],
+            "suffix",
+            "violations",
+            ["test_suffix", "demo_suffix"],
+        ),
+        # No substring at end - pyspark
+        ("pyspark", ["no_match", "also_no", "nope"], "suffix", "success", None),
+        # Substring in middle - pyspark
+        (
+            "pyspark",
+            ["pre_mid_post", "another_mid_test", "nomatch"],
+            "mid",
+            "violations",
+            ["pre_mid_post", "another_mid_test"],
+        ),
+        # No substring in middle - pyspark
+        ("pyspark", ["no_match", "also_no", "nope"], "mid", "success", None),
+        # Case sensitive success - pyspark
+        ("pyspark", ["FOO", "Foo", "fOo"], "foo", "success", None),
+        # Case sensitive violations - pyspark
+        ("pyspark", ["foo", "FOO", "test"], "FOO", "violations", ["FOO"]),
+        # Empty string success - pyspark
+        ("pyspark", ["", "", ""], "foo", "success", None),
+        # Empty string with violation - pyspark
+        ("pyspark", ["", "foo", ""], "foo", "violations", ["foo"]),
+        # Whitespace only success - pyspark
+        ("pyspark", ["   ", "  ", " "], "test", "success", None),
+        # Whitespace in text violations - pyspark
+        (
+            "pyspark",
+            ["test with spaces", "test", "no match"],
+            "test",
+            "violations",
+            ["test with spaces", "test"],
+        ),
+        # Whitespace around violations - pyspark
+        (
+            "pyspark",
+            ["   test   ", "test", "clean"],
+            "test",
+            "violations",
+            ["   test   ", "test"],
+        ),
+        # Special char at violations - pyspark
+        (
+            "pyspark",
+            ["test@email", "user@domain", "plain"],
+            "@",
+            "violations",
+            ["test@email", "user@domain"],
+        ),
+        # Special char at success - pyspark
+        ("pyspark", ["no-match", "also-no", "nope"], "@", "success", None),
+        # Special char hash violations - pyspark
+        (
+            "pyspark",
+            ["test#tag", "demo#hash", "plain"],
+            "#",
+            "violations",
+            ["test#tag", "demo#hash"],
+        ),
+        # Numbers violations - pyspark
+        (
+            "pyspark",
+            ["version123", "test456", "plain"],
+            "123",
+            "violations",
+            ["version123"],
+        ),
+        # Numbers no match - pyspark
+        ("pyspark", ["v1.0", "v2.1", "v3.5"], "123", "success", None),
+        # Numbers exact match - pyspark
+        ("pyspark", ["test", "demo", "123"], "123", "violations", ["123"]),
+        # Single char success - pyspark
+        ("pyspark", ["a", "b", "c"], "x", "success", None),
+        # Single char violation - pyspark
+        ("pyspark", ["a", "b", "c"], "a", "violations", ["a"]),
+        # Long string success - pyspark
+        ("pyspark", ["a" * 100, "b" * 100, "c" * 100], "x", "success", None),
+        # Long string with substring - pyspark
+        (
+            "pyspark",
+            ["a" * 50 + "test" + "b" * 50, "clean" * 20, "other"],
+            "test",
+            "violations",
+            ["a" * 50 + "test" + "b" * 50],
+        ),
+        # Exact match - pyspark
+        ("pyspark", ["test", "demo", "exam"], "test", "violations", ["test"]),
+        # No exact match - pyspark
+        ("pyspark", ["test", "demo", "exam"], "testing", "success", None),
+    ],
+    ids=[
+        "pyspark_basic_success",
+        "pyspark_success_no_match",
+        "pyspark_success_different_substring",
+        "pyspark_basic_violations",
+        "pyspark_all_violations",
+        "pyspark_mixed_violations",
+        "pyspark_substring_at_beginning",
+        "pyspark_no_substring_at_beginning",
+        "pyspark_substring_at_end",
+        "pyspark_no_substring_at_end",
+        "pyspark_substring_in_middle",
+        "pyspark_no_substring_in_middle",
+        "pyspark_case_sensitive_success",
+        "pyspark_case_sensitive_violations",
+        "pyspark_empty_string_success",
+        "pyspark_empty_string_with_violation",
+        "pyspark_whitespace_only_success",
+        "pyspark_whitespace_in_text_violations",
+        "pyspark_whitespace_around_violations",
+        "pyspark_special_char_at_violations",
+        "pyspark_special_char_at_success",
+        "pyspark_special_char_hash_violations",
+        "pyspark_numbers_violations",
+        "pyspark_numbers_no_match",
+        "pyspark_numbers_exact_match",
+        "pyspark_single_char_success",
+        "pyspark_single_char_violation",
+        "pyspark_long_string_success",
+        "pyspark_long_string_with_substring",
+        "pyspark_exact_match",
+        "pyspark_no_exact_match",
+    ],
+)
+def test_expectation_basic_scenarios_pyspark(
+    df_type, data, substring, expected_result, expected_violations, spark
+):
+    """Test various scenarios for ExpectationStringNotContains expectation."""
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationStringNotContains",
+        column_name="col1",
+        substring=substring,
+    )
+
+    data_frame = create_pyspark_dataframe(data, "col1", spark)
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationStringNotContains")
+        ), f"Expected success message but got: {result}"
+
+        # Also test with suite
+        expectations_suite = DataFrameExpectationsSuite().expect_string_not_contains(
+            column_name="col1", substring=substring
+        )
+        suite_result = expectations_suite.build().run(data_frame=data_frame)
+        assert suite_result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(suite_result, SuiteExecutionResult), (
+            "Result should be SuiteExecutionResult"
+        )
+        assert suite_result.success, "Expected all expectations to pass"
+        assert suite_result.total_passed == 1, "Expected 1 passed expectation"
+        assert suite_result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # violations
+        violations_df = create_pyspark_dataframe(expected_violations, "col1", spark)
+        expected_message = (
+            f"Found {len(expected_violations)} row(s) where 'col1' contains '{substring}'."
+        )
+
+        assert str(result) == str(
+            DataFrameExpectationFailureMessage(
+                expectation_str=str(expectation),
+                data_frame_type=str(df_type),
+                violations_data_frame=violations_df,
+                message=expected_message,
+                limit_violations=5,
+            )
+        ), f"Expected failure message but got: {result}"
+
+        # Also test with suite
+        expectations_suite = DataFrameExpectationsSuite().expect_string_not_contains(
+            column_name="col1", substring=substring
+        )
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+def test_column_missing_error_pandas():
+    """Test that missing column raises appropriate error for pandas."""
     expectation = DataFrameExpectationRegistry.get_expectation(
         expectation_name="ExpectationStringNotContains",
         column_name="col1",
         substring="foo",
     )
 
-    data_frame = create_dataframe(df_type, ["bar", "baz", "qux"], "col2", spark)
+    data_frame = pd.DataFrame({"col2": ["bar", "baz", "qux"]})
     result = expectation.validate(data_frame=data_frame)
 
     expected_failure_message = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message="Column 'col1' does not exist in the DataFrame.",
+    )
+    assert str(result) == str(expected_failure_message), (
+        f"Expected failure message but got: {result}"
+    )
+
+    # Also test with suite
+    expectations_suite = DataFrameExpectationsSuite().expect_string_not_contains(
+        column_name="col1", substring="foo"
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test that missing column raises appropriate error for pyspark."""
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationStringNotContains",
+        column_name="col1",
+        substring="foo",
+    )
+
+    data_frame = create_pyspark_dataframe(["bar", "baz", "qux"], "col2", spark)
+    result = expectation.validate(data_frame=data_frame)
+
+    expected_failure_message = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message="Column 'col1' does not exist in the DataFrame.",
     )
     assert str(result) == str(expected_failure_message), (

--- a/tests/expectations/column/string_expectations/test_expect_string_starts_with.py
+++ b/tests/expectations/column/string_expectations/test_expect_string_starts_with.py
@@ -7,20 +7,17 @@ from dataframe_expectations.registry import (
 from dataframe_expectations.suite import (
     DataFrameExpectationsSuite,
     DataFrameExpectationsSuiteFailure,
-    SuiteExecutionResult,
 )
+from dataframe_expectations.core.suite_result import SuiteExecutionResult
 from dataframe_expectations.result_message import (
     DataFrameExpectationFailureMessage,
     DataFrameExpectationSuccessMessage,
 )
 
 
-def create_dataframe(df_type, data, column_name, spark):
-    """Helper function to create either pandas or PySpark DataFrame."""
-    if df_type == "pandas":
-        return pd.DataFrame({column_name: data})
-    else:  # pyspark
-        return spark.createDataFrame([(item,) for item in data], [column_name])
+def create_pyspark_dataframe(data, column_name, spark):
+    """Helper function to create a PySpark DataFrame."""
+    return spark.createDataFrame([(item,) for item in data], [column_name])
 
 
 def test_expectation_name():
@@ -39,14 +36,6 @@ def test_expectation_name():
     [
         # Basic success - pandas
         ("pandas", ["foobar", "foo123", "foobaz"], "foo", "success", None),
-        # Basic success - pyspark
-        (
-            "pyspark",
-            ["foobar", "foo123", "foobaz"],
-            "foo",
-            "success",
-            None,
-        ),
         # Basic violations - pandas
         (
             "pandas",
@@ -55,29 +44,11 @@ def test_expectation_name():
             "violations",
             ["bar", "baz", "qux"],
         ),
-        # Basic violations - pyspark
-        (
-            "pyspark",
-            ["bar", "baz", "qux"],
-            "foo",
-            "violations",
-            ["bar", "baz", "qux"],
-        ),
         # Exact match success - pandas
         ("pandas", ["foo", "foo", "foo"], "foo", "success", None),
-        # Exact match success - pyspark
-        ("pyspark", ["foo", "foo", "foo"], "foo", "success", None),
         # Exact match mixed - pandas
         (
             "pandas",
-            ["foo", "bar", "baz"],
-            "foo",
-            "violations",
-            ["bar", "baz"],
-        ),
-        # Exact match mixed - pyspark
-        (
-            "pyspark",
             ["foo", "bar", "baz"],
             "foo",
             "violations",
@@ -91,25 +62,9 @@ def test_expectation_name():
             "violations",
             ["", "", ""],
         ),
-        # Empty strings - pyspark
-        (
-            "pyspark",
-            ["", "", ""],
-            "foo",
-            "violations",
-            ["", "", ""],
-        ),
         # Whitespace only violations - pandas
         (
             "pandas",
-            ["   ", "  ", " "],
-            "foo",
-            "violations",
-            ["   ", "  ", " "],
-        ),
-        # Whitespace only violations - pyspark
-        (
-            "pyspark",
             ["   ", "  ", " "],
             "foo",
             "violations",
@@ -123,25 +78,9 @@ def test_expectation_name():
             "success",
             None,
         ),
-        # Whitespace in text success - pyspark
-        (
-            "pyspark",
-            ["foo bar", "foo baz", "foo qux"],
-            "foo",
-            "success",
-            None,
-        ),
         # Whitespace at end violations - pandas
         (
             "pandas",
-            ["bar foo", "baz foo", "qux foo"],
-            "foo",
-            "violations",
-            ["bar foo", "baz foo", "qux foo"],
-        ),
-        # Whitespace at end violations - pyspark
-        (
-            "pyspark",
             ["bar foo", "baz foo", "qux foo"],
             "foo",
             "violations",
@@ -155,14 +94,6 @@ def test_expectation_name():
             "violations",
             ["#foo", "$foo"],
         ),
-        # Special char at violations - pyspark
-        (
-            "pyspark",
-            ["@foo", "#foo", "$foo"],
-            "@",
-            "violations",
-            ["#foo", "$foo"],
-        ),
         # Special char in prefix violations - pandas
         (
             "pandas",
@@ -171,29 +102,11 @@ def test_expectation_name():
             "violations",
             ["foo#baz", "foo$qux"],
         ),
-        # Special char in prefix violations - pyspark
-        (
-            "pyspark",
-            ["foo@bar", "foo#baz", "foo$qux"],
-            "foo@",
-            "violations",
-            ["foo#baz", "foo$qux"],
-        ),
         # Numbers success - pandas
         ("pandas", ["foo1", "foo2", "foo3"], "foo", "success", None),
-        # Numbers success - pyspark
-        ("pyspark", ["foo1", "foo2", "foo3"], "foo", "success", None),
         # Numbers at start violations - pandas
         (
             "pandas",
-            ["1foo", "2foo", "3foo"],
-            "foo",
-            "violations",
-            ["1foo", "2foo", "3foo"],
-        ),
-        # Numbers at start violations - pyspark
-        (
-            "pyspark",
             ["1foo", "2foo", "3foo"],
             "foo",
             "violations",
@@ -207,25 +120,9 @@ def test_expectation_name():
             "success",
             None,
         ),
-        # Long string success - pyspark
-        (
-            "pyspark",
-            ["foo" + "a" * 97, "foo" + "b" * 97, "foo" + "c" * 97],
-            "foo",
-            "success",
-            None,
-        ),
         # Long string violations - pandas
         (
             "pandas",
-            ["a" * 100, "b" * 100, "c" * 100],
-            "foo",
-            "violations",
-            ["a" * 100, "b" * 100, "c" * 100],
-        ),
-        # Long string violations - pyspark
-        (
-            "pyspark",
             ["a" * 100, "b" * 100, "c" * 100],
             "foo",
             "violations",
@@ -239,50 +136,27 @@ def test_expectation_name():
             "violations",
             ["bar"],
         ),
-        # Mixed violations - pyspark
-        (
-            "pyspark",
-            ["foobar", "bar", "foo123"],
-            "foo",
-            "violations",
-            ["bar"],
-        ),
     ],
     ids=[
         "pandas_basic_success",
-        "pyspark_basic_success",
         "pandas_basic_violations",
-        "pyspark_basic_violations",
         "pandas_exact_match_success",
-        "pyspark_exact_match_success",
         "pandas_exact_match_mixed",
-        "pyspark_exact_match_mixed",
         "pandas_empty_string_violations",
-        "pyspark_empty_string_violations",
         "pandas_whitespace_only_violations",
-        "pyspark_whitespace_only_violations",
         "pandas_whitespace_in_text_success",
-        "pyspark_whitespace_in_text_success",
         "pandas_whitespace_at_end_violations",
-        "pyspark_whitespace_at_end_violations",
         "pandas_special_char_at_violations",
-        "pyspark_special_char_at_violations",
         "pandas_special_char_in_prefix_violations",
-        "pyspark_special_char_in_prefix_violations",
         "pandas_numbers_success",
-        "pyspark_numbers_success",
         "pandas_numbers_at_start_violations",
-        "pyspark_numbers_at_start_violations",
         "pandas_long_string_success",
-        "pyspark_long_string_success",
         "pandas_long_string_violations",
-        "pyspark_long_string_violations",
         "pandas_mixed_violations",
-        "pyspark_mixed_violations",
     ],
 )
-def test_expectation_basic_scenarios(
-    df_type, data, prefix, expected_result, expected_violations, spark
+def test_expectation_basic_scenarios_pandas(
+    df_type, data, prefix, expected_result, expected_violations
 ):
     """Test various scenarios for ExpectationStringStartsWith expectation."""
     expectation = DataFrameExpectationRegistry.get_expectation(
@@ -291,7 +165,7 @@ def test_expectation_basic_scenarios(
         prefix=prefix,
     )
 
-    data_frame = create_dataframe(df_type, data, "col1", spark)
+    data_frame = pd.DataFrame({"col1": data})
     result = expectation.validate(data_frame=data_frame)
 
     if expected_result == "success":
@@ -312,7 +186,7 @@ def test_expectation_basic_scenarios(
         assert suite_result.total_passed == 1, "Expected 1 passed expectation"
         assert suite_result.total_failed == 0, "Expected 0 failed expectations"
     else:  # violations
-        violations_df = create_dataframe(df_type, expected_violations, "col1", spark)
+        violations_df = pd.DataFrame({"col1": expected_violations})
         expected_message = (
             f"Found {len(expected_violations)} row(s) where 'col1' does not start with '{prefix}'."
         )
@@ -335,21 +209,228 @@ def test_expectation_basic_scenarios(
             expectations_suite.build().run(data_frame=data_frame)
 
 
-@pytest.mark.parametrize("df_type", ["pandas", "pyspark"])
-def test_column_missing_error(df_type, spark):
-    """Test that missing column raises appropriate error."""
+@pytest.mark.pyspark
+@pytest.mark.parametrize(
+    "df_type,data,prefix,expected_result,expected_violations",
+    [
+        # Basic success - pyspark
+        ("pyspark", ["foobar", "foo123", "foobaz"], "foo", "success", None),
+        # Basic violations - pyspark
+        (
+            "pyspark",
+            ["bar", "baz", "qux"],
+            "foo",
+            "violations",
+            ["bar", "baz", "qux"],
+        ),
+        # Exact match success - pyspark
+        ("pyspark", ["foo", "foo", "foo"], "foo", "success", None),
+        # Exact match mixed - pyspark
+        (
+            "pyspark",
+            ["foo", "bar", "baz"],
+            "foo",
+            "violations",
+            ["bar", "baz"],
+        ),
+        # Empty strings - pyspark
+        (
+            "pyspark",
+            ["", "", ""],
+            "foo",
+            "violations",
+            ["", "", ""],
+        ),
+        # Whitespace only violations - pyspark
+        (
+            "pyspark",
+            ["   ", "  ", " "],
+            "foo",
+            "violations",
+            ["   ", "  ", " "],
+        ),
+        # Whitespace in text success - pyspark
+        (
+            "pyspark",
+            ["foo bar", "foo baz", "foo qux"],
+            "foo",
+            "success",
+            None,
+        ),
+        # Whitespace at end violations - pyspark
+        (
+            "pyspark",
+            ["bar foo", "baz foo", "qux foo"],
+            "foo",
+            "violations",
+            ["bar foo", "baz foo", "qux foo"],
+        ),
+        # Special char at violations - pyspark
+        (
+            "pyspark",
+            ["@foo", "#foo", "$foo"],
+            "@",
+            "violations",
+            ["#foo", "$foo"],
+        ),
+        # Special char in prefix violations - pyspark
+        (
+            "pyspark",
+            ["foo@bar", "foo#baz", "foo$qux"],
+            "foo@",
+            "violations",
+            ["foo#baz", "foo$qux"],
+        ),
+        # Numbers success - pyspark
+        ("pyspark", ["foo1", "foo2", "foo3"], "foo", "success", None),
+        # Numbers at start violations - pyspark
+        (
+            "pyspark",
+            ["1foo", "2foo", "3foo"],
+            "foo",
+            "violations",
+            ["1foo", "2foo", "3foo"],
+        ),
+        # Long string success - pyspark
+        (
+            "pyspark",
+            ["foo" + "a" * 97, "foo" + "b" * 97, "foo" + "c" * 97],
+            "foo",
+            "success",
+            None,
+        ),
+        # Long string violations - pyspark
+        (
+            "pyspark",
+            ["a" * 100, "b" * 100, "c" * 100],
+            "foo",
+            "violations",
+            ["a" * 100, "b" * 100, "c" * 100],
+        ),
+        # Mixed violations - pyspark
+        (
+            "pyspark",
+            ["foobar", "bar", "foo123"],
+            "foo",
+            "violations",
+            ["bar"],
+        ),
+    ],
+    ids=[
+        "pyspark_basic_success",
+        "pyspark_basic_violations",
+        "pyspark_exact_match_success",
+        "pyspark_exact_match_mixed",
+        "pyspark_empty_string_violations",
+        "pyspark_whitespace_only_violations",
+        "pyspark_whitespace_in_text_success",
+        "pyspark_whitespace_at_end_violations",
+        "pyspark_special_char_at_violations",
+        "pyspark_special_char_in_prefix_violations",
+        "pyspark_numbers_success",
+        "pyspark_numbers_at_start_violations",
+        "pyspark_long_string_success",
+        "pyspark_long_string_violations",
+        "pyspark_mixed_violations",
+    ],
+)
+def test_expectation_basic_scenarios_pyspark(
+    df_type, data, prefix, expected_result, expected_violations, spark
+):
+    """Test various scenarios for ExpectationStringStartsWith expectation."""
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationStringStartsWith",
+        column_name="col1",
+        prefix=prefix,
+    )
+
+    data_frame = create_pyspark_dataframe(data, "col1", spark)
+    result = expectation.validate(data_frame=data_frame)
+
+    if expected_result == "success":
+        assert str(result) == str(
+            DataFrameExpectationSuccessMessage(expectation_name="ExpectationStringStartsWith")
+        ), f"Expected success message but got: {result}"
+
+        # Also test with suite
+        expectations_suite = DataFrameExpectationsSuite().expect_string_starts_with(
+            column_name="col1", prefix=prefix
+        )
+        suite_result = expectations_suite.build().run(data_frame=data_frame)
+        assert suite_result is not None, "Expected SuiteExecutionResult"
+        assert isinstance(suite_result, SuiteExecutionResult), (
+            "Result should be SuiteExecutionResult"
+        )
+        assert suite_result.success, "Expected all expectations to pass"
+        assert suite_result.total_passed == 1, "Expected 1 passed expectation"
+        assert suite_result.total_failed == 0, "Expected 0 failed expectations"
+    else:  # violations
+        violations_df = create_pyspark_dataframe(expected_violations, "col1", spark)
+        expected_message = (
+            f"Found {len(expected_violations)} row(s) where 'col1' does not start with '{prefix}'."
+        )
+
+        assert str(result) == str(
+            DataFrameExpectationFailureMessage(
+                expectation_str=str(expectation),
+                data_frame_type=str(df_type),
+                violations_data_frame=violations_df,
+                message=expected_message,
+                limit_violations=5,
+            )
+        ), f"Expected failure message but got: {result}"
+
+        # Also test with suite
+        expectations_suite = DataFrameExpectationsSuite().expect_string_starts_with(
+            column_name="col1", prefix=prefix
+        )
+        with pytest.raises(DataFrameExpectationsSuiteFailure):
+            expectations_suite.build().run(data_frame=data_frame)
+
+
+def test_column_missing_error_pandas():
+    """Test that missing column raises appropriate error for pandas."""
     expectation = DataFrameExpectationRegistry.get_expectation(
         expectation_name="ExpectationStringStartsWith",
         column_name="col1",
         prefix="foo",
     )
 
-    data_frame = create_dataframe(df_type, ["foobar", "foo123", "foobaz"], "col2", spark)
+    data_frame = pd.DataFrame({"col2": ["foobar", "foo123", "foobaz"]})
     result = expectation.validate(data_frame=data_frame)
 
     expected_failure_message = DataFrameExpectationFailureMessage(
         expectation_str=str(expectation),
-        data_frame_type=str(df_type),
+        data_frame_type="pandas",
+        message="Column 'col1' does not exist in the DataFrame.",
+    )
+    assert str(result) == str(expected_failure_message), (
+        f"Expected failure message but got: {result}"
+    )
+
+    # Also test with suite
+    expectations_suite = DataFrameExpectationsSuite().expect_string_starts_with(
+        column_name="col1", prefix="foo"
+    )
+    with pytest.raises(DataFrameExpectationsSuiteFailure):
+        expectations_suite.build().run(data_frame=data_frame)
+
+
+@pytest.mark.pyspark
+def test_column_missing_error_pyspark(spark):
+    """Test that missing column raises appropriate error for pyspark."""
+    expectation = DataFrameExpectationRegistry.get_expectation(
+        expectation_name="ExpectationStringStartsWith",
+        column_name="col1",
+        prefix="foo",
+    )
+
+    data_frame = create_pyspark_dataframe(["foobar", "foo123", "foobaz"], "col2", spark)
+    result = expectation.validate(data_frame=data_frame)
+
+    expected_failure_message = DataFrameExpectationFailureMessage(
+        expectation_str=str(expectation),
+        data_frame_type="pyspark",
         message="Column 'col1' does not exist in the DataFrame.",
     )
     assert str(result) == str(expected_failure_message), (

--- a/uv.lock
+++ b/uv.lock
@@ -308,13 +308,17 @@ toml = [
 
 [[package]]
 name = "dataframe-expectations"
-version = "0.5.1"
+version = "0.5.2"
 source = { virtual = "." }
 dependencies = [
     { name = "pandas" },
     { name = "pydantic" },
-    { name = "pyspark" },
     { name = "tabulate" },
+]
+
+[package.optional-dependencies]
+pyspark = [
+    { name = "pyspark" },
 ]
 
 [package.dev-dependencies]
@@ -340,9 +344,10 @@ docs = [
 requires-dist = [
     { name = "pandas", specifier = ">=1.5.0" },
     { name = "pydantic", specifier = ">=2.12.4" },
-    { name = "pyspark", specifier = ">=3.3.0" },
+    { name = "pyspark", marker = "extra == 'pyspark'", specifier = ">=3.3.0" },
     { name = "tabulate", specifier = ">=0.8.9" },
 ]
+provides-extras = ["pyspark"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Make PySpark an optional dependency

Closes #54

Users running PySpark in managed environments (Databricks, EMR, etc.) typically have PySpark
pre-installed and cannot or do not want the library to reinstall it. Previously, `pyspark` was
a hard dependency, making `dataframe-expectations` incompatible with those environments.

This PR makes PySpark fully optional while preserving all existing behaviour for users who do
have it installed.

---

### What changed

**1. PySpark moved to an optional extra (`pyproject.toml`)**

```
pip install dataframe-expectations           # pandas only
pip install dataframe-expectations[pyspark]  # includes pyspark
```

`pandas`, `pydantic`, and `tabulate` remain hard dependencies. `pyspark` is now under
`[project.optional-dependencies]`.

**2. Lazy PySpark loading in production code (`pyspark_utils.py`)**

All PySpark imports are deferred behind `@lru_cache` helpers:
- `get_pyspark_functions()` — returns real `pyspark.sql.functions` when PySpark is available,
  or a `_MissingPySparkFunctions` proxy that raises a clear `ImportError` only when a PySpark
  code path is actually executed.
- `_get_pyspark_dataframe_types()` / `is_pyspark_dataframe()` — runtime type detection with
  graceful fallback when PySpark is absent.
- The one remaining module-level reference (`PySparkConnectDataFrame` in `expectation.py`) is
  guarded with `try/except ImportError` and is kept for backward compatibility and test patching.

This means importing `dataframe_expectations` never touches PySpark at all when it isn't installed.

**3. Tests split by marker**

All PySpark test cases are decorated with `@pytest.mark.pyspark` and separated into their own
parametrize blocks. `--strict-markers` is enforced in `pyproject.toml` so unregistered markers
cause an immediate failure rather than being silently ignored. Tests can now be run without
PySpark present:

```
pytest -m "not pyspark"   # no PySpark required
pytest -m pyspark          # requires PySpark
```

**4. CI updated to cover three install scenarios**

| Job | How PySpark is present | Tests run |
|---|---|---|
| `tests-without-pyspark` | Not installed | `-m "not pyspark"` |
| `tests-with-pyspark-extra` | `pip install .[pyspark]` | All |
| `tests-with-external-pyspark` | Pre-installed externally | All |

The external-pyspark job specifically validates the case from issue #54 — that the library works
correctly when PySpark is already present in the environment and was not installed by this package.

**5. Docs updated**

Installation instructions updated to document both install paths and explain when each is appropriate.

## Checklist
<!--
  Please consider the following when submitting code changes.

  Note: You can check the boxes once you submit, or put an x in the [ ] like [x]
-->

-   [x] Tests have been added in the prescribed format
-   [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
-   [x] Pre-commit hooks pass locally
